### PR TITLE
fix: attachment download flags + exists check

### DIFF
--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -215,17 +215,7 @@ impl ChatState {
                         },
                     };
 
-                    if filename.exists() {
-                        if !flags.contains(DownloadFlags::FORCE) {
-                            let msg = format!(
-                                "The file {} already exists; add ! to end of command to overwrite it.",
-                                filename.display()
-                            );
-                            let err = UIError::Failure(msg);
-
-                            return Err(err);
-                        }
-
+                    if !filename.exists() || flags.contains(DownloadFlags::FORCE) {
                         let req = MediaRequest { source, format: MediaFormat::File };
 
                         let bytes =
@@ -234,6 +224,14 @@ impl ChatState {
                         fs::write(filename.as_path(), bytes.as_slice())?;
 
                         msg.downloaded = true;
+                    } else if !flags.contains(DownloadFlags::OPEN) {
+                        let msg = format!(
+                            "The file {} already exists; add ! to end of command to overwrite it.",
+                            filename.display()
+                        );
+                        let err = UIError::Failure(msg);
+
+                        return Err(err);
                     }
 
                     let info = if flags.contains(DownloadFlags::OPEN) {


### PR DESCRIPTION
Fix file never downloading (unless it has been downloaded in the past and using `!` force flag).

The logic should be:

* If file does not exist, or `!` force flag used, then download it
* Else if neither `!` or `:open` flag used, then error out

and then return downloaded-message or open-and-message.

I.e. `:open` should still open the file if it has already been downloaded. Otherwise the only way to open it is to use `!` and re-download it.