### PR TITLE
Fix error message for undefined download directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -324,7 +324,7 @@ impl Directories {
         let downloads = self
             .downloads
             .or_else(dirs::download_dir)
-            .expect("no dirs.download value configured!");
+            .expect("no dirs.downloads value configured!");
 
         DirectoryValues { cache, logs, downloads }
     }


### PR DESCRIPTION
The current error message is
	thread 'main' panicked at 'no dirs.download value configured!', src/config.rs:327:14
	note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

which is not only unelegant, but also wrong. The key iamb expects is `dirs.downloads`, which is now also reflected in the error message.