### PR TITLE
Support configuring which program `:open` runs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -237,6 +237,7 @@ pub struct TunableValues {
     pub typing_notice_display: bool,
     pub users: UserOverrides,
     pub default_room: Option<String>,
+    pub open_command: Option<Vec<String>>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -251,6 +252,7 @@ pub struct Tunables {
     pub typing_notice_display: Option<bool>,
     pub users: Option<UserOverrides>,
     pub default_room: Option<String>,
+    pub open_command: Option<Vec<String>>,
 }
 
 impl Tunables {
@@ -268,6 +270,7 @@ impl Tunables {
             typing_notice_display: self.typing_notice_display.or(other.typing_notice_display),
             users: merge_users(self.users, other.users),
             default_room: self.default_room.or(other.default_room),
+            open_command: self.open_command.or(other.open_command),
         }
     }
 
@@ -283,6 +286,7 @@ impl Tunables {
             typing_notice_display: self.typing_notice_display.unwrap_or(true),
             users: self.users.unwrap_or_default(),
             default_room: self.default_room,
+            open_command: self.open_command,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -188,6 +188,7 @@ pub fn mock_tunables() -> TunableValues {
         })]
         .into_iter()
         .collect::<HashMap<_, _>>(),
+        open_command: None,
     }
 }
 


### PR DESCRIPTION
Allow setting "open_command" to array of [program, args...] as alternative to using `open::that`.
The `open-rs` crate now has [`open::with_command`](https://docs.rs/open/4.1.0/open/fn.with_command.html), but that only allows adding args _after_ the path arg. In my case I need `firefox --new-window path` and that seems like the most common case.

@ulyssa the two fns in chat.rs feel a bit randomly placed, but I didn't want to decide on anything about files/modules in this PR. Feel free to suggest some better organization.