### PR TITLE
Add support for previewing images in room scrollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         reporter: 'github-check'
     - name: Run tests
-      run: cargo test
+      run: cargo test ${{ matrix.platform == 'windows-latest' && '--no-default-features' || '' }}
     - name: Build artifacts
-      run: cargo build --release
+      run: cargo build --release ${{ matrix.platform == 'windows-latest' && '--no-default-features' || '' }}
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,22 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
@@ -939,6 +955,12 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ed25519"
@@ -1595,6 +1617,7 @@ dependencies = [
  "modalkit",
  "open",
  "pretty_assertions",
+ "ratatui-image",
  "regex",
  "rpassword",
  "serde",
@@ -1911,6 +1934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "make-cmd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,7 +2248,7 @@ dependencies = [
  "anymap2",
  "arboard",
  "bitflags 1.3.2",
- "crossterm",
+ "crossterm 0.27.0",
  "derive_more",
  "intervaltree",
  "libc",
@@ -2842,13 +2871,30 @@ checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",
- "crossterm",
+ "crossterm 0.27.0",
  "indoc",
  "itertools 0.11.0",
  "paste",
  "strum",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a43ba44f10847b9f76f54e528832b0d63029ce48be7663fb8ddded27ac1457"
+dependencies = [
+ "base64 0.21.4",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "image",
+ "rand 0.8.5",
+ "ratatui",
+ "rustix 0.38.17",
+ "serde",
+ "sixel-bytes",
 ]
 
 [[package]]
@@ -3391,6 +3437,25 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sixel-bytes"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cad296a72571e80953823496e9a55caf893e264de9a7c5cfd29427fca720fc"
+dependencies = [
+ "sixel-sys-static",
+]
+
+[[package]]
+name = "sixel-sys-static"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2988846c5099382a880a7dd385d38b203a60430710a9c22e538d500e6908f4f9"
+dependencies = [
+ "make-cmd",
+ "pkg-config",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ markup5ever_rcdom = "0.2.0"
 mime = "^0.3.16"
 mime_guess = "^2.0.4"
 open = "3.2.0"
+ratatui-image = { version = "0.4.1", features = ["serde"] }
 regex = "^1.5"
 rpassword = "^7.2"
 serde = "^1.0"
@@ -74,3 +75,7 @@ pretty_assertions = "1.4.0"
 [profile.release]
 lto = true
 incremental = false
+
+[features]
+default = ["sixel"]
+sixel = ["ratatui-image/sixel"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ two other TUI clients and Element Web:
 | Room upgrades                           | ❌ ([#41])  | ✔️        | ❌               | ✔️                   |
 | Localisations                           | ❌          | 1        | ❌               | 44                  |
 | SSO Support                             | ✔️           | ✔️        | ✔️                | ✔️                   |
+| Image preview                           | ✔️           | ❌       | ❌               | ✔️                   |
                                                                                        
 ## License
 

--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -23,7 +23,16 @@
 				"color": "magenta"
 			}
 		},
-		"default_room": "#iamb-users:0x.badd.cafe"
+		"default_room": "#iamb-users:0x.badd.cafe",
+		"image_preview": {
+			"protocol": {
+				"type": "sixel"
+			},
+			"size": {
+				"width": 66,
+				"height": 10
+			}
+		}
 	},
 	"dirs": {
 		"cache":     "/home/user/.cache/iamb/",

--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -86,7 +86,7 @@ overridden as described in *PROFILES*.
 > Enable image previews and configure it. An empty object will enable the
 > feature with default settings, omitting it will disable the feature.
 > *size* is an optional object with *width* and *height* numbers, which are
-> used te set the preview size in characters. Defaults to 66 and 10.
+> used to set the preview size in characters. Defaults to 66 and 10.
 > *protocol* is an optional object to override settings that should normally
 > be guessed automatically.
 > *protocol.type* is an optional string with one of the protocol types:

--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -82,6 +82,18 @@ overridden as described in *PROFILES*.
 **default_room** (type: string)
 > The room to show by default instead of a welcome-screen.
 
+**image_preview** (type: image_preview object)
+> Enable image previews and configure it. An empty object will enable the
+> feature with default settings, omitting it will disable the feature.
+> *size* is an optional object with *width* and *height* numbers, which are
+> used te set the preview size in characters. Defaults to 66 and 10.
+> *protocol* is an optional object to override settings that should normally
+> be guessed automatically.
+> *protocol.type* is an optional string with one of the protocol types:
+> _sixel_, _kitty_, _halfblocks_.
+> *protocol.font_size* is an optional list of two numbers representing font
+> width and height in pixels.
+
 ## USER OVERRIDES
 
 Overrides are mapped onto matrix User IDs such as _@user:matrix.org_ and are
@@ -126,6 +138,9 @@ Specifies the directories to save data in. Configured as a map under the key
 
 **downloads** (type: string)
 > Specifies where to store downloaded files.
+
+**image_previews** (type: string)
+> Specifies where to store automatically downloaded image previews.
 
 # SEE ALSO
 

--- a/flake.nix
+++ b/flake.nix
@@ -22,18 +22,25 @@
           pname = "iamb";
           version = "0.0.7";
           src = ./.;
-          cargoLock.lockFile = ./Cargo.lock;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            # Remove this once modalkit gets pinned by version again.
+            outputHashes = {
+              "modalkit-0.0.16" = "sha256-mjAD1v0r2+SzPdoB2wZ/5iJ1NZK+3OSvCYcUZ5Ef38Y=";
+            };
+          };
           nativeBuildInputs = [ pkgs.pkgconfig ];
           buildInputs = [ pkgs.openssl ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
             (with pkgs.darwin.apple_sdk.frameworks; [ AppKit Security ]);
         };
         devShell = mkShell {
           buildInputs = [
-            (rustNightly.override { extensions = [ "rust-src" ]; })
+            (rustNightly.override {
+              extensions = [ "rust-src" "rust-analyzer-preview" "rustfmt" "clippy" ]; 
+            })
             pkg-config
             cargo-tarpaulin
-            rust-analyzer
-            rustfmt
+            cargo-watch
           ];
         };
       });

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,11 +272,13 @@ pub struct ImagePreviewValues {
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
+
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
+
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
@@ -291,11 +293,13 @@ pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
 }
+
 impl Default for ImagePreviewSize {
     fn default() -> Self {
         ImagePreviewSize { width: 66, height: 10 }
     }
 }
+
 #[derive(Clone, Deserialize)]
 pub struct ImagePreviewProtocolValues {
     pub r#type: Option<ProtocolType>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
+use config::ImagePreviewProtocolValues;
+use ratatui_image::picker::Picker;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing_subscriber::FmtSubscriber;
 
@@ -68,6 +70,7 @@ mod commands;
 mod config;
 mod keybindings;
 mod message;
+mod preview;
 mod util;
 mod windows;
 mod worker;
@@ -264,9 +267,44 @@ impl Application {
         let bindings = KeyManager::new(bindings);
 
         let mut locked = store.lock().await;
+
+        if let Some(image_preview) = settings.tunables.image_preview.as_ref() {
+            let picker_from_settings = match image_preview.protocol.as_ref() {
+                // User forced type and font_size: use that.
+                Some(&ImagePreviewProtocolValues {
+                    r#type: Some(protocol_type),
+                    font_size: Some(font_size),
+                }) => {
+                    let mut picker = Picker::new(font_size);
+                    picker.protocol_type = protocol_type;
+                    Ok(picker)
+                },
+                // Guess, but use type if forced.
+                #[cfg(unix)]
+                image_preview_protocol => {
+                    Picker::from_termios().map(|mut picker| {
+                        if let Some(&ImagePreviewProtocolValues { r#type: Some(protocol_type), .. }) = image_preview_protocol {
+                            picker.protocol_type = protocol_type;
+                        } else {
+                            picker.guess_protocol();
+                        }
+                        picker
+                    })
+                },
+                // Windows: always needs type and font_size.
+                #[cfg(windows)]
+                _ => Err(Into::<Box<dyn std::error::Error>>::into("\"image_preview\" requires \"protocol\" with \"type\" and \"font_size\" options for windows.")),
+            };
+            match picker_from_settings {
+                Ok(picker) => locked.application.picker = Some(picker),
+                Err(err) => tracing::error!("{}", err),
+            }
+        }
+
         let screen = setup_screen(settings, locked.deref_mut())?;
 
         let worker = locked.application.worker.clone();
+
         drop(locked);
 
         let actstack = VecDeque::new();

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -51,7 +51,9 @@ use modalkit::tui::{
 };
 
 use modalkit::editing::{base::ViewportContext, cursor::Cursor};
+use ratatui_image::protocol::Protocol;
 
+use crate::config::ImagePreviewSize;
 use crate::{
     base::{IambResult, RoomInfo},
     config::ApplicationSettings,
@@ -585,12 +587,20 @@ impl<'a> MessageFormatter<'a> {
     }
 }
 
+pub enum ImageStatus {
+    None,
+    Downloading(ImagePreviewSize),
+    Loaded(Box<dyn Protocol>),
+    Error(String),
+}
+
 pub struct Message {
     pub event: MessageEvent,
     pub sender: OwnedUserId,
     pub timestamp: MessageTimeStamp,
     pub downloaded: bool,
     pub html: Option<StyleTree>,
+    pub image_preview: ImageStatus,
 }
 
 impl Message {
@@ -598,7 +608,14 @@ impl Message {
         let html = event.html();
         let downloaded = false;
 
-        Message { event, sender, timestamp, downloaded, html }
+        Message {
+            event,
+            sender,
+            timestamp,
+            downloaded,
+            html,
+            image_preview: ImageStatus::None,
+        }
     }
 
     pub fn reply_to(&self) -> Option<OwnedEventId> {
@@ -679,6 +696,36 @@ impl Message {
 
             MessageFormatter { settings, cols, orig, fill, user, date, time, read }
         }
+    }
+
+    /// Get the image preview Protocol and x,y offset, based on get_render_format.
+    pub fn line_preview<'a>(
+        &'a self,
+        prev: Option<&Message>,
+        vwctx: &ViewportContext<MessageCursor>,
+        info: &'a RoomInfo,
+    ) -> Option<(&dyn Protocol, u16, u16)> {
+        let width = vwctx.get_width();
+        // The x position where get_render_format would render the text.
+        let x = (if USER_GUTTER + MIN_MSG_LEN <= width {
+            USER_GUTTER
+        } else {
+            0
+        } + 1) as u16;
+        // See get_render_format; account for possible "date" line.
+        let date_y = match &prev {
+            Some(prev) if !prev.timestamp.same_day(&self.timestamp) => 1,
+            _ => 0,
+        };
+        if let ImageStatus::Loaded(backend) = &self.image_preview {
+            return Some((backend.as_ref(), x, date_y));
+        } else if let Some(reply) = self.reply_to().and_then(|e| info.get_event(&e)) {
+            if let ImageStatus::Loaded(backend) = &reply.image_preview {
+                // The reply should be offset a bit:
+                return Some((backend.as_ref(), x + 2, date_y + 1));
+            }
+        }
+        None
     }
 
     pub fn show<'a>(
@@ -791,6 +838,19 @@ impl Message {
                 msg.to_mut().push_str(" \u{2705}");
             }
 
+            if let Some(placeholder) = match &self.image_preview {
+                ImageStatus::None => None,
+                ImageStatus::Downloading(image_preview_size) => {
+                    Some(Message::placeholder_frame(Some("Downloading..."), image_preview_size))
+                },
+                ImageStatus::Loaded(backend) => {
+                    Some(Message::placeholder_frame(None, &backend.rect().into()))
+                },
+                ImageStatus::Error(err) => Some(format!("[Image error: {err}]")),
+            } {
+                msg.to_mut().insert_str(0, &placeholder);
+            }
+
             wrapped_text(msg, width, style)
         }
     }
@@ -801,6 +861,24 @@ impl Message {
         settings: &'a ApplicationSettings,
     ) -> Span<'a> {
         settings.get_user_span(self.sender.as_ref(), info)
+    }
+
+    /// Before the image is loaded, already display a placeholder frame of the image size.
+    fn placeholder_frame(text: Option<&str>, image_preview_size: &ImagePreviewSize) -> String {
+        let ImagePreviewSize { width, height } = image_preview_size;
+        let mut placeholder = "\u{230c}".to_string();
+        placeholder.push_str(&" ".repeat(width - 2));
+        placeholder.push_str("\u{230d}\n");
+        placeholder.push(' ');
+        if let Some(text) = text {
+            placeholder.push_str(text);
+        }
+
+        placeholder.push_str(&"\n".repeat(height - 2));
+        placeholder.push('\u{230e}');
+        placeholder.push_str(&" ".repeat(width - 2));
+        placeholder.push_str("\u{230f}\n");
+        placeholder
     }
 
     fn show_sender<'a>(

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -846,7 +846,7 @@ impl Message {
                 ImageStatus::Loaded(backend) => {
                     Some(Message::placeholder_frame(None, &backend.rect().into()))
                 },
-                ImageStatus::Error(err) => Some(format!("[Image error: {err}]")),
+                ImageStatus::Error(err) => Some(format!("[Image error: {err}]\n")),
             } {
                 msg.to_mut().insert_str(0, &placeholder);
             }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,0 +1,172 @@
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+use matrix_sdk::{
+    media::{MediaFormat, MediaRequest},
+    ruma::{
+        events::{
+            room::{
+                message::{MessageType, RoomMessageEventContent},
+                MediaSource,
+            },
+            MessageLikeEvent,
+        },
+        OwnedEventId,
+        OwnedRoomId,
+    },
+    Media,
+};
+use modalkit::tui::layout::Rect;
+use ratatui_image::Resize;
+
+use crate::{
+    base::{AsyncProgramStore, ChatStore, IambError},
+    config::ImagePreviewSize,
+    message::ImageStatus,
+};
+
+pub fn source_from_event(
+    ev: &MessageLikeEvent<RoomMessageEventContent>,
+) -> Option<(OwnedEventId, MediaSource)> {
+    if let MessageLikeEvent::Original(ev) = &ev {
+        if let MessageType::Image(c) = &ev.content.msgtype {
+            return Some((ev.event_id.clone(), c.source.clone()));
+        }
+    }
+    None
+}
+
+impl From<ImagePreviewSize> for Rect {
+    fn from(value: ImagePreviewSize) -> Self {
+        Rect::new(0, 0, value.width as _, value.height as _)
+    }
+}
+impl From<Rect> for ImagePreviewSize {
+    fn from(rect: Rect) -> Self {
+        ImagePreviewSize { width: rect.width as _, height: rect.height as _ }
+    }
+}
+
+/// Download and prepare the preview, and then lock the store to insert it.
+pub fn spawn_insert_preview(
+    store: AsyncProgramStore,
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+    source: MediaSource,
+    media: Media,
+    cache_dir: PathBuf,
+) {
+    tokio::spawn(async move {
+        let img = download_or_load(event_id.to_owned(), source, media, cache_dir)
+            .await
+            .map(std::io::Cursor::new)
+            .map(image::io::Reader::new)
+            .map_err(IambError::Matrix)
+            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError))
+            .and_then(|reader| reader.decode().map_err(IambError::Image));
+
+        match img {
+            Err(err) => {
+                try_set_msg_preview_error(
+                    &mut store.lock().await.application,
+                    room_id,
+                    event_id,
+                    err,
+                );
+            },
+            Ok(img) => {
+                let mut locked = store.lock().await;
+                let ChatStore { rooms, picker, settings, .. } = &mut locked.application;
+
+                match picker
+                    .as_mut()
+                    .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
+                    .and_then(|picker| {
+                        Ok((
+                            picker,
+                            rooms
+                                .get_or_default(room_id.clone())
+                                .get_event_mut(&event_id)
+                                .ok_or_else(|| {
+                                    IambError::Preview("Message not found".to_string())
+                                })?,
+                            settings.tunables.image_preview.clone().ok_or_else(|| {
+                                IambError::Preview("image_preview settings not found".to_string())
+                            })?,
+                        ))
+                    })
+                    .and_then(|(picker, msg, image_preview)| {
+                        picker
+                            .new_protocol(img, image_preview.size.into(), Resize::Fit)
+                            .map_err(|err| IambError::Preview(format!("{err:?}")))
+                            .map(|backend| (backend, msg))
+                    }) {
+                    Err(err) => {
+                        try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
+                    },
+                    Ok((backend, msg)) => {
+                        msg.image_preview = ImageStatus::Loaded(backend);
+                    },
+                }
+            },
+        }
+    });
+}
+
+fn try_set_msg_preview_error(
+    application: &mut ChatStore,
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+    err: IambError,
+) {
+    let rooms = &mut application.rooms;
+
+    match rooms
+        .get_or_default(room_id.clone())
+        .get_event_mut(&event_id)
+        .ok_or_else(|| IambError::Preview("Message not found".to_string()))
+    {
+        Ok(msg) => msg.image_preview = ImageStatus::Error(format!("{err:?}")),
+        Err(err) => {
+            tracing::error!(
+                "Failed to set error on msg.image_backend for event {}, room {}: {}",
+                event_id,
+                room_id,
+                err
+            )
+        },
+    }
+}
+
+async fn download_or_load(
+    event_id: OwnedEventId,
+    source: MediaSource,
+    media: Media,
+    mut cache_path: PathBuf,
+) -> Result<Vec<u8>, matrix_sdk::Error> {
+    cache_path.push(Path::new(event_id.localpart()));
+
+    match File::open(&cache_path) {
+        Ok(mut f) => {
+            let mut buffer = Vec::new();
+            f.read_to_end(&mut buffer)?;
+            Ok(buffer)
+        },
+        Err(_) => {
+            media
+                .get_media_content(&MediaRequest { source, format: MediaFormat::File }, true)
+                .await
+                .and_then(|buffer| {
+                    if let Err(err) =
+                        File::create(&cache_path).and_then(|mut f| f.write_all(&buffer))
+                    {
+                        return Err(err.into());
+                    }
+                    Ok(buffer)
+                })
+        },
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -172,6 +172,7 @@ pub fn mock_dirs() -> DirectoryValues {
         cache: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
+        image_previews: PathBuf::new(),
     }
 }
 
@@ -195,6 +196,7 @@ pub fn mock_tunables() -> TunableValues {
         .collect::<HashMap<_, _>>(),
         open_command: None,
         username_display: UserDisplayStyle::Username,
+        image_preview: None,
     }
 }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1359,7 +1359,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
         for ((_, _), _, txt, line_preview) in lines.into_iter() {
             let _ = buf.set_line(x, y, &txt, area.width);
             if let Some((backend, msg_x, _)) = line_preview {
-                image_previews.push((msg_x, y, backend));
+                image_previews.push((x + msg_x, y, backend));
             }
 
             y += 1;

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,6 +1,7 @@
 //! Message scrollback
 use std::collections::HashSet;
 
+use ratatui_image::FixedImage;
 use regex::Regex;
 
 use matrix_sdk::ruma::OwnedRoomId;
@@ -1264,6 +1265,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let info = self.store.application.rooms.get_or_default(state.room_id.clone());
         let settings = &self.store.application.settings;
+        let picker = &self.store.application.picker;
         let area = if state.cursor.timestamp.is_some() {
             render_jump_to_recent(area, buf, self.focused)
         } else {
@@ -1307,7 +1309,11 @@ impl<'a> StatefulWidget for Scrollback<'a> {
             let sel = key == cursor_key;
             let txt = item.show(prev, foc && sel, &state.viewctx, info, settings);
 
-            prev = Some(item);
+            let mut msg_preview = if picker.is_some() {
+                item.line_preview(prev, &state.viewctx, info)
+            } else {
+                None
+            };
 
             let incomplete_ok = !full || !sel;
 
@@ -1323,9 +1329,17 @@ impl<'a> StatefulWidget for Scrollback<'a> {
                     continue;
                 }
 
-                lines.push((key, row, line));
+                let line_preview = match msg_preview {
+                    // Only take the preview into the matching row number.
+                    Some((_, _, y)) if y as usize == row => msg_preview.take(),
+                    _ => None,
+                };
+
+                lines.push((key, row, line, line_preview));
                 sawit |= sel;
             }
+
+            prev = Some(item);
         }
 
         if lines.len() > height {
@@ -1333,7 +1347,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
             let _ = lines.drain(..n);
         }
 
-        if let Some(((ts, event_id), row, _)) = lines.first() {
+        if let Some(((ts, event_id), row, _, _)) = lines.first() {
             state.viewctx.corner.timestamp = Some((*ts, event_id.clone()));
             state.viewctx.corner.text_row = *row;
         }
@@ -1341,10 +1355,26 @@ impl<'a> StatefulWidget for Scrollback<'a> {
         let mut y = area.top();
         let x = area.left();
 
-        for (_, _, txt) in lines.into_iter() {
+        let mut image_previews = vec![];
+        for ((_, _), _, txt, line_preview) in lines.into_iter() {
             let _ = buf.set_line(x, y, &txt, area.width);
+            if let Some((backend, msg_x, _)) = line_preview {
+                image_previews.push((msg_x, y, backend));
+            }
 
             y += 1;
+        }
+        // Render image previews after all text lines have been drawn, as the render might draw below the current
+        // line.
+        for (x, y, backend) in image_previews {
+            let image_widget = FixedImage::new(backend);
+            let mut rect = backend.rect();
+            rect.x = x;
+            rect.y = y;
+            // Don't render outside of scrollback area
+            if rect.bottom() <= area.bottom() && rect.right() <= area.right() {
+                image_widget.render(rect, buf);
+            }
         }
 
         if self.room_focused &&


### PR DESCRIPTION
An image says more than a thousand words:
![image](https://github.com/ulyssa/iamb/assets/310215/2d2b352c-429d-44b7-9983-86da932b0741)

There has been some work to get some small change into ratatui that allows for "skipping" of rendering some cells (characters). This in turn allowed to make a crate [ratatui-image](https://github.com/benjajaja/ratatui-image) that provides a image widgets for ratatui, taking care of the terminal's graphics protocol automatically. Currently the supported "protocols" are sixels, kitty, and unicode-halfblocks. iTerm2's protocol should be easy to add, I just don't have access to a mac.

This PR uses ratatui-image widget's `render()` method to render images in the `ScrollBack` widget, in the chat lines. This seems hacky, but this kind of usage was actually intended and recommended for these kind of use cases in the discussion on the ratatui PR.

Currently, the download and image processing happens in one spawned tokio task per attachment. I also have a branch where only one "worker" is created, but I don't actually know if that is an actual improvement.  I mainly made that branch/version to learn a bit more about tokio/tasks/threads in rust.