### PR TITLE
Replace GitHub actions using deprecated features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,6 @@ on:
 name: CI
 
 jobs:
-  clippy_check:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          components: clippy
-          override: true
-    - name: Check Clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        toolchain: stable
-        args:
   test:
     strategy:
       matrix:
@@ -38,12 +19,12 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
+    - name: Install Rust (1.66 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.66
       with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+          components: clippy
+    - name: Install Rust (nightly w/ rustfmt)
+      run: rustup toolchain install nightly --component rustfmt
     - name: Cache cargo registry
       uses: actions/cache@v3
       with:
@@ -55,19 +36,17 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
     - name: Check formatting
-      uses: actions-rs/cargo@v1
+      run: cargo +nightly fmt --all -- --check
+    - name: Check Clippy
+      if: matrix.platform == 'ubuntu-latest'
+      uses: giraffate/clippy-action@v1
       with:
-          command: fmt
-          args: --all -- --check
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        reporter: 'github-check'
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-          command: test
+      run: cargo test
     - name: Build artifacts
-      uses: actions-rs/cargo@v1
-      with:
-          command: build
-          args: '--release'
+      run: cargo build --release
     - name: Upload artifacts
       uses: actions/upload-artifact@master
       with:

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -489,7 +489,7 @@ impl ChatState {
                         .map_err(IambError::from)?;
                 let mime = mime::IMAGE_PNG;
 
-                let name = Cow::from(format!("Clipboard.png"));
+                let name = "Clipboard.png";
                 let config = AttachmentConfig::new();
 
                 let resp = room


### PR DESCRIPTION
GitHub is deprecated node.js v12 runners and the `set-output` command, both of which are currently used within the `ci.yml` action. They were initially slated to stop working at the [end of this month](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), but it looks like that's been pushed back to some TBD date.

Since they're unmaintained, and don't seem likely at this point to be updated by the time that GitHub turns off the deprecated functionality, I'm going to replace [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain/) with [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and [`actions-rs/clippy-check`](https://github.com/actions-rs/clippy-check) with [`giraffate/clippy-action`](https://github.com/giraffate/clippy-action).