### PR TITLE
Fix Nix flake build on Darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/result
 /TODO
 /docs/iamb.[15]

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,9 @@
           version = "0.0.7";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
-          nativeBuildInputs = [ pkgs.openssl pkgs.pkgconfig ];
-          buildInputs = [ pkgs.openssl ];
+          nativeBuildInputs = [ pkgs.pkgconfig ];
+          buildInputs = [ pkgs.openssl ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
+            (with pkgs.darwin.apple_sdk.frameworks; [ AppKit Security ]);
         };
         devShell = mkShell {
           buildInputs = [


### PR DESCRIPTION
Hi there,

building iamb on darwin requires the `AppKit` and `Security` frameworks which must be explicitly specified as dependencies when using nix.

Additionally I've removed `openssl` from the `nativeBuildInputs` as it's only required in `buildInputs` and added the `result` output directory used by nix to the gitignore file. 