### PR TITLE
fix example config

### DIFF
--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -30,3 +30,4 @@
 		"logs":      "~/.local/share/iamb/logs/",
 		"downloads": "~/Downloads/"
 	}
+}

--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -26,8 +26,8 @@
 		"default_room": "#iamb-users:0x.badd.cafe"
 	},
 	"dirs": {
-		"cache":     "~/.cache/iamb/",
-		"logs":      "~/.local/share/iamb/logs/",
-		"downloads": "~/Downloads/"
+		"cache":     "/home/user/.cache/iamb/",
+		"logs":      "/home/user/.local/share/iamb/logs/",
+		"downloads": "/home/user/Downloads/"
 	}
 }


### PR DESCRIPTION
- docs: add missing brace to example config
- docs: fix paths in example config
