### PR TITLE
Add support for logging in with SSO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,14 +1978,17 @@ dependencies = [
  "matrix-sdk-indexeddb",
  "matrix-sdk-sled",
  "mime",
+ "rand 0.8.5",
  "reqwest",
  "ruma",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
+ "warp",
  "wasm-timer",
  "zeroize",
 ]
@@ -3181,6 +3209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3286,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3695,6 +3740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,6 +3803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4005,6 +4062,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project",
+ "rustls-pemfile",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ version = "0.0.16"
 [dependencies.matrix-sdk]
 version = "^0.6.2"
 default-features = false
-features = ["e2e-encryption", "sled", "rustls-tls"]
+features = ["e2e-encryption", "sled", "rustls-tls", "sso-login"]
 
 [dependencies.tokio]
 version = "1.24.1"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ two other TUI clients and Element Web:
 | Message editing                         | ✔️           | ✔️        | ❌               | ✔️                   |
 | Room upgrades                           | ❌ ([#41])  | ✔️        | ❌               | ✔️                   |
 | Localisations                           | ❌          | 1        | ❌               | 44                  |
-| SSO Support                             | ❌          | ✔️        | ✔️                | ✔️                   |
+| SSO Support                             | ✔️          | ✔️        | ✔️                | ✔️                   |
                                                                                        
 ## License
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ two other TUI clients and Element Web:
 | Message editing                         | ✔️           | ✔️        | ❌               | ✔️                   |
 | Room upgrades                           | ❌ ([#41])  | ✔️        | ❌               | ✔️                   |
 | Localisations                           | ❌          | 1        | ❌               | 44                  |
-| SSO Support                             | ✔️          | ✔️        | ✔️                | ✔️                   |
+| SSO Support                             | ✔️           | ✔️        | ✔️                | ✔️                   |
                                                                                        
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -648,21 +648,17 @@ async fn login(worker: Requester, settings: &ApplicationSettings) -> IambResult<
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();
 
-        let login_style = 
-        match input.chars().nth(0).map(|x| char::to_ascii_lowercase(&x)) {
+        let login_style = match input.chars().nth(0).map(|x| char::to_ascii_lowercase(&x)) {
             None | Some('p') => {
                 let password = rpassword::prompt_password("Password: ")?;
                 LoginStyle::Password(password)
             },
-            Some('s') => {
-                LoginStyle::SingleSignOn
-            }
+            Some('s') => LoginStyle::SingleSignOn,
             Some(_) => {
                 println!("Failed to login. Please enter 'p' or 's'");
                 break;
             },
         };
-
 
         match worker.login(login_style) {
             Ok(info) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,9 +642,29 @@ async fn login(worker: Requester, settings: &ApplicationSettings) -> IambResult<
     }
 
     loop {
-        let password = rpassword::prompt_password("Password: ")?;
+        println!("Please select login type");
+        println!("[P]assword / [s]ingle sign on");
 
-        match worker.login(LoginStyle::Password(password)) {
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).unwrap();
+
+        let login_style = 
+        match input.chars().nth(0).map(|x| char::to_ascii_lowercase(&x)) {
+            None | Some('p') => {
+                let password = rpassword::prompt_password("Password: ")?;
+                LoginStyle::Password(password)
+            },
+            Some('s') => {
+                LoginStyle::SingleSignOn
+            }
+            Some(_) => {
+                println!("Failed to login. Please enter 'p' or 's'");
+                break;
+            },
+        };
+
+
+        match worker.login(login_style) {
             Ok(info) => {
                 if let Some(msg) = info {
                     println!("{msg}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,13 +642,12 @@ async fn login(worker: Requester, settings: &ApplicationSettings) -> IambResult<
     }
 
     loop {
-        println!("Please select login type");
-        println!("[P]assword / [s]ingle sign on");
+        println!("Please select login type: [p]assword / [s]ingle sign on");
 
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();
 
-        let login_style = match input.chars().nth(0).map(|x| char::to_ascii_lowercase(&x)) {
+        let login_style = match input.chars().next().map(|c| c.to_ascii_lowercase()) {
             None | Some('p') => {
                 let password = rpassword::prompt_password("Password: ")?;
                 LoginStyle::Password(password)
@@ -656,7 +655,7 @@ async fn login(worker: Requester, settings: &ApplicationSettings) -> IambResult<
             Some('s') => LoginStyle::SingleSignOn,
             Some(_) => {
                 println!("Failed to login. Please enter 'p' or 's'");
-                break;
+                continue;
             },
         };
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1020,9 +1020,11 @@ impl ClientWorker {
             },
             LoginStyle::SingleSignOn => {
                 let resp = client
-                    .login_sso(|url| async move {
-                        println!("Open {} in a browser", url);
-                        Ok(())
+                    .login_sso(|url| {
+                        async move {
+                            println!("Open {} in a browser", url);
+                            Ok(())
+                        }
                     })
                     .initial_device_display_name(initial_devname().as_str())
                     .send()

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -384,6 +384,7 @@ async fn refresh_receipts_forever(client: &Client, store: &AsyncProgramStore) {
 pub enum LoginStyle {
     SessionRestore(Session),
     Password(String),
+    SingleSignOn,
 }
 
 pub struct ClientResponse<T>(Receiver<T>);
@@ -1012,6 +1013,22 @@ impl ClientWorker {
                     .send()
                     .await
                     .map_err(IambError::from)?;
+                let file = File::create(self.settings.session_json.as_path())?;
+                let writer = BufWriter::new(file);
+                let session = Session::from(resp);
+                serde_json::to_writer(writer, &session).map_err(IambError::from)?;
+            },
+            LoginStyle::SingleSignOn => {
+                let resp = client
+                    .login_sso(|url| async move {
+                        println!("Open {} in a browser", url);
+                        Ok(())
+                    })
+                    .initial_device_display_name(initial_devname().as_str())
+                    .send()
+                    .await
+                    .map_err(IambError::from)?;
+
                 let file = File::create(self.settings.session_json.as_path())?;
                 let writer = BufWriter::new(file);
                 let session = Session::from(resp);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1021,8 +1021,13 @@ impl ClientWorker {
             LoginStyle::SingleSignOn => {
                 let resp = client
                     .login_sso(|url| {
+                        let opened = format!(
+                            "The following URL should have been opened in your browser:\n    {url}"
+                        );
+
                         async move {
-                            println!("Open {} in a browser", url);
+                            tokio::task::spawn_blocking(move || open::that(url));
+                            println!("\n{opened}\n");
                             Ok(())
                         }
                     })


### PR DESCRIPTION
Use `matrix-sdk`'s `sso-login` feature to provide SSO login.

Gives an interactive option at launch time for users to pick between SSO and password authentication.

In common with [the `matrix-sdk` project](https://github.com/matrix-org/matrix-rust-sdk/pull/176#issuecomment-800318936), I couldn't figure out any way to test this feature because it relies on a browser. If there's anything that I should do, please say! :)

First PR in Rust, so please feel free to criticize!!