### PR TITLE
Support custom sorting for room and user lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iamb
 
-[![Build Status](https://github.com/ulyssa/iamb/workflows/CI/badge.svg)](https://github.com/ulyssa/iamb/actions?query=workflow%3ACI+)
+[![Build Status](https://github.com/ulyssa/iamb/actions/workflows/ci.yml/badge.svg)](https://github.com/ulyssa/iamb/actions?query=workflow%3ACI+)
 [![License: Apache 2.0](https://img.shields.io/crates/l/iamb.svg?logo=apache)](https://crates.io/crates/iamb)
 [![#iamb:0x.badd.cafe](https://img.shields.io/badge/matrix-%23iamb:0x.badd.cafe-blue)](https://matrix.to/#/#iamb:0x.badd.cafe)
 [![Latest Version](https://img.shields.io/crates/v/iamb.svg?logo=rust)](https://crates.io/crates/iamb)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,6 +28,7 @@ use crate::{
         ApplicationSettings,
         DirectoryValues,
         ProfileConfig,
+        SortOverrides,
         TunableValues,
         UserColor,
         UserDisplayStyle,
@@ -183,6 +184,7 @@ pub fn mock_tunables() -> TunableValues {
         read_receipt_send: true,
         read_receipt_display: true,
         request_timeout: 120,
+        sort: SortOverrides::default().values(),
         typing_notice_send: true,
         typing_notice_display: true,
         users: vec![(TEST_USER5.clone(), UserDisplayTunables {

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -22,7 +22,7 @@ use modalkit::{
 
 use crate::base::{IambBufferId, IambInfo, ProgramStore, RoomFocus};
 
-use crate::windows::RoomItem;
+use crate::windows::{room_fields_cmp, RoomItem};
 
 const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 
@@ -120,7 +120,7 @@ impl<'a> StatefulWidget for Space<'a> {
 
             match res {
                 Ok(members) => {
-                    let items = members
+                    let mut items = members
                         .into_iter()
                         .filter_map(|id| {
                             let (room, _, tags) =
@@ -133,7 +133,9 @@ impl<'a> StatefulWidget for Space<'a> {
                                 None
                             }
                         })
-                        .collect();
+                        .collect::<Vec<_>>();
+                    let fields = &self.store.application.settings.tunables.sort.rooms;
+                    items.sort_by(|a, b| room_fields_cmp(a, b, fields));
 
                     state.list.set(items);
                     state.last_fetch = Some(Instant::now());

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -330,34 +330,30 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
 
     for room in client.invited_rooms().into_iter() {
         let name = room.display_name().await.unwrap_or(DisplayName::Empty).to_string();
+        let tags = room.tags().await.unwrap_or_default();
+
         names.push((room.room_id().to_owned(), name));
 
         if room.is_direct() {
-            let tags = room.tags().await.unwrap_or_default();
-
             dms.push(Arc::new((room.into(), tags)));
         } else if room.is_space() {
-            spaces.push(room.into());
+            spaces.push(Arc::new((room.into(), tags)));
         } else {
-            let tags = room.tags().await.unwrap_or_default();
-
             rooms.push(Arc::new((room.into(), tags)));
         }
     }
 
     for room in client.joined_rooms().into_iter() {
         let name = room.display_name().await.unwrap_or(DisplayName::Empty).to_string();
+        let tags = room.tags().await.unwrap_or_default();
+
         names.push((room.room_id().to_owned(), name));
 
         if room.is_direct() {
-            let tags = room.tags().await.unwrap_or_default();
-
             dms.push(Arc::new((room.into(), tags)));
         } else if room.is_space() {
-            spaces.push(room.into());
+            spaces.push(Arc::new((room.into(), tags)));
         } else {
-            let tags = room.tags().await.unwrap_or_default();
-
             rooms.push(Arc::new((room.into(), tags)));
         }
     }


### PR DESCRIPTION
This adds a new `"sort"` field to the `"settings"` object that allows configuring how the lists of rooms and users in `:rooms`, `:dms`, `:spaces`, `:members` are sorted.