### PR TITLE
Fix not showing display names in already synced rooms

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -2,6 +2,7 @@
 //!
 //! The types defined here get used throughout iamb.
 use std::borrow::Cow;
+use std::collections::hash_map::IntoIter;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt::{self, Display};
@@ -1042,6 +1043,43 @@ pub struct SyncInfo {
     pub dms: Vec<Arc<(MatrixRoom, Option<Tags>)>>,
 }
 
+bitflags::bitflags! {
+    /// Load-needs
+    #[derive(Debug, PartialEq)]
+    pub struct Need: u32 {
+        const MESSAGES = 0b00000001;
+        const MEMBERS =  0b00000010;
+    }
+}
+
+/// Things that need loading for different rooms.
+#[derive(Default)]
+pub struct RoomNeeds {
+    needs: HashMap<OwnedRoomId, Need>,
+}
+
+impl RoomNeeds {
+    /// Mark a room for needing something to be loaded.
+    pub fn insert(&mut self, room_id: OwnedRoomId, need: Need) {
+        let new_need = if let Some(mut existing_need) = self.needs.remove(&room_id) {
+            existing_need.insert(need);
+            existing_need
+        } else {
+            need
+        };
+        self.needs.insert(room_id, new_need);
+    }
+}
+
+impl IntoIterator for RoomNeeds {
+    type Item = (OwnedRoomId, Need);
+    type IntoIter = IntoIter<OwnedRoomId, Need>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.needs.into_iter()
+    }
+}
+
 /// The main application state.
 pub struct ChatStore {
     /// `:`-commands
@@ -1066,7 +1104,7 @@ pub struct ChatStore {
     pub settings: ApplicationSettings,
 
     /// Set of rooms that need more messages loaded in their scrollback.
-    pub need_load: HashSet<OwnedRoomId>,
+    pub need_load: RoomNeeds,
 
     /// [CompletionMap] of Emoji shortcodes.
     pub emojis: CompletionMap<String, &'static Emoji>,
@@ -1111,11 +1149,6 @@ impl ChatStore {
             .and_then(|i| i.name.as_ref())
             .map(String::from)
             .unwrap_or_else(|| "Untitled Matrix Room".to_string())
-    }
-
-    /// Mark a room for loading more scrollback.
-    pub fn mark_for_load(&mut self, room_id: OwnedRoomId) {
-        self.need_load.insert(room_id);
     }
 
     /// Get the [RoomInfo] for a given room identifier.
@@ -1657,6 +1690,21 @@ pub mod tests {
                 Span::from(" is typing...")
             ])
         );
+    }
+
+    #[test]
+    fn test_need_load() {
+        let room_id = TEST_ROOM1_ID.clone();
+
+        let mut need_load = RoomNeeds::default();
+
+        need_load.insert(room_id.clone(), Need::MESSAGES);
+        need_load.insert(room_id.clone(), Need::MEMBERS);
+
+        assert_eq!(need_load.into_iter().collect::<Vec<(OwnedRoomId, Need)>>(), vec![(
+            room_id,
+            Need::MESSAGES | Need::MEMBERS,
+        )],);
     }
 
     #[tokio::test]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1045,8 +1045,9 @@ pub struct SyncInfo {
 
 bitflags::bitflags! {
     /// Load-needs
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Default, PartialEq)]
     pub struct Need: u32 {
+        const EMPTY = 0b00000000;
         const MESSAGES = 0b00000001;
         const MEMBERS =  0b00000010;
     }
@@ -1061,13 +1062,7 @@ pub struct RoomNeeds {
 impl RoomNeeds {
     /// Mark a room for needing something to be loaded.
     pub fn insert(&mut self, room_id: OwnedRoomId, need: Need) {
-        let new_need = if let Some(mut existing_need) = self.needs.remove(&room_id) {
-            existing_need.insert(need);
-            existing_need
-        } else {
-            need
-        };
-        self.needs.insert(room_id, new_need);
+        self.needs.entry(room_id).or_default().insert(need);
     }
 }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -77,6 +77,7 @@ use crate::base::{
     IambInfo,
     IambResult,
     MessageAction,
+    Need,
     ProgramAction,
     ProgramContext,
     ProgramStore,
@@ -659,6 +660,7 @@ impl Window<IambInfo> for IambWindow {
                 let (room, name, tags) = store.application.worker.get_room(room_id)?;
                 let room = RoomState::new(room, name, tags, store);
 
+                store.application.need_load.insert(room.id().to_owned(), Need::MEMBERS);
                 return Ok(room.into());
             },
             IambId::DirectList => {
@@ -710,6 +712,7 @@ impl Window<IambInfo> for IambWindow {
             let (room, name, tags) = store.application.worker.get_room(room_id)?;
             let room = RoomState::new(room, name, tags, store);
 
+            store.application.need_load.insert(room.id().to_owned(), Need::MEMBERS);
             Ok(room.into())
         }
     }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -1,4 +1,5 @@
 //! # Windows for Matrix rooms and spaces
+
 use matrix_sdk::{
     room::{Invited, Room as MatrixRoom},
     ruma::{
@@ -109,8 +110,8 @@ impl RoomState {
         tags: Option<Tags>,
         store: &mut ProgramStore,
     ) -> Self {
-        let room_id = room.room_id().to_owned();
-        let info = store.application.get_room_info(room_id);
+        let room_id = room.room_id();
+        let info = store.application.get_room_info(room_id.to_owned());
         info.name = name.to_string().into();
         info.tags = tags;
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -1,5 +1,4 @@
 //! # Windows for Matrix rooms and spaces
-
 use matrix_sdk::{
     room::{Invited, Room as MatrixRoom},
     ruma::{
@@ -110,8 +109,8 @@ impl RoomState {
         tags: Option<Tags>,
         store: &mut ProgramStore,
     ) -> Self {
-        let room_id = room.room_id();
-        let info = store.application.get_room_info(room_id.to_owned());
+        let room_id = room.room_id().to_owned();
+        let info = store.application.get_room_info(room_id);
         info.name = name.to_string().into();
         info.tags = tags;
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -193,6 +193,7 @@ enum Plan {
     Messages(OwnedRoomId, Option<String>),
     Members(OwnedRoomId),
 }
+
 async fn load_plans(store: &AsyncProgramStore) -> Vec<Plan> {
     let mut locked = store.lock().await;
     let ChatStore { need_load, rooms, .. } = &mut locked.application;


### PR DESCRIPTION
Fixes #149

The display_names only got populated from the
OriginalSyncRoomMemberEvent. When opening an already synced room, display_names is not populated.

ClientWorker::get_room extends the returned FetchedRoom to include RoomMembers from Room::members_no_sync. This allows RoomState::new to populate the RoomInfo's display_names.

Thanks to @Benjamin-L for finding the source of the bug in that issue. It was mentioned that it might be problematic to iterate over all members of large rooms. The largest room I had available to test this was only about 200 members, but it seemed fine.