### PR TITLE
Add desktop file for GUI environment launchers

### DIFF
--- a/iamb.desktop
+++ b/iamb.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Categories=Network;InstantMessaging;Chat;
+Comment=A Matrix client for Vim addicts
+Exec=iamb
+GenericName=Matrix Client
+Keywords=Matrix;matrix.org;chat;communications;talk;
+Name=iamb
+StartupNotify=false
+Terminal=true
+TryExec=iamb
+Type=Application


### PR DESCRIPTION
Howdie!

I'm not sure if this is something you'd like to keep, but I put together a desktop file per https://specifications.freedesktop.org/desktop-entry-spec/latest/

I've manually tested this by copying it into ~/.local/share/applications/ and then restarting my desktop environment (GNOME in this case)

There's no custom Icon=... field defined here, but otherwise it works quite well (for me, at least)