### PR TITLE
Fix image preview offset

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -711,7 +711,7 @@ impl Message {
             USER_GUTTER
         } else {
             0
-        } + 1) as u16;
+        }) as u16;
         // See get_render_format; account for possible "date" line.
         let date_y = match &prev {
             Some(prev) if !prev.timestamp.same_day(&self.timestamp) => 1,


### PR DESCRIPTION
There was a hardcoded offset of `1` for the borders. With @ulyssa's fix for vertical splits, that can be removed now, as it displaces all previews one character too much to the right.

There some other offset bugs related to the layout-by-width in `get_render_format` not being replicated by `line_preview`, which should probably by unified some way.