### PR TITLE
Fix truncation/padding for non-ASCII sender names

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -58,7 +58,7 @@ use crate::{
     base::{IambResult, RoomInfo},
     config::ApplicationSettings,
     message::html::{parse_matrix_html, StyleTree},
-    util::{space_span, wrapped_text},
+    util::{space, space_span, take_width, wrapped_text},
 };
 
 mod html;
@@ -898,13 +898,13 @@ impl Message {
         }
 
         let Span { content, style } = self.sender_span(info, settings);
-        let stop = content.len().min(28);
-        let s = &content[..stop];
+        let ((truncated, width), _) = take_width(content, 28);
+        let padding = 28 - width;
 
         let sender = if align_right {
-            format!("{: >width$}  ", s, width = 28)
+            space(padding) + &truncated + "  "
         } else {
-            format!("{: <width$}  ", s, width = 28)
+            truncated.into_owned() + &space(padding) + "  "
         };
 
         Span::styled(sender, style).into()

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,19 +26,19 @@ pub fn split_cow(cow: Cow<'_, str>, idx: usize) -> (Cow<'_, str>, Cow<'_, str>) 
 
 pub fn take_width(s: Cow<'_, str>, width: usize) -> ((Cow<'_, str>, usize), Cow<'_, str>) {
     // Find where to split the line.
-    let mut idx = 0;
     let mut w = 0;
 
-    for (i, g) in UnicodeSegmentation::grapheme_indices(s.as_ref(), true) {
-        let gw = UnicodeWidthStr::width(g);
-        idx = i;
-
-        if w + gw > width {
-            break;
-        }
-
-        w += gw;
-    }
+    let idx = UnicodeSegmentation::grapheme_indices(s.as_ref(), true)
+        .find_map(|(i, g)| {
+            let gw = UnicodeWidthStr::width(g);
+            if w + gw > width {
+                Some(i)
+            } else {
+                w += gw;
+                None
+            }
+        })
+        .unwrap_or(s.len());
 
     let (s0, s1) = split_cow(s, idx);
 


### PR DESCRIPTION
Found out about this one when somebody with the displayname "qxofficial🍥🏳️‍⚧️" joined the rust room. This string is 30 bytes long in utf8, so iamb decided to truncate it at byte 28. This happens to be in the middle of the VS16 codepoint, which caused a panic.

`take_width` calculates the width of a grapheme cluster by adding the width of all it's code points under UAX#11. This overcounts many emoji sequences, like 🏳️‍⚧️, which consists of "🏳<ZWJ>⚧". Calculating the width of a name wrong currently causes the entire messages window UI to be misaligned, which is why this PR is marked as a draft.

The tricky bit is that the number of terminal cells that 🏳️‍⚧️ takes up varies depending on your font and terminal emulator. In some contexts, it will display as 🏳️‍⚧️ (one cell), while in others it will display as "🏳⚧" (two cells). As far as I can tell, there is no way to accurately predict the width of a given string without actually printing it to the terminal and querying the current cursor position with ANSI escapes.

The best thing I've come up with so far is:

 - pessimistically assume that the terminal/font doesn't support ZWJ sequences/country flags/skin tone modifiers/etc, and keep the current width calculation for determining truncation and _minimum_ padding.
 - emit ANSI escapes to set the cursor position after printing the displaynames, to fix the alignment issues.