### PR TITLE
Enable direnv for Nix flakes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /result
 /TODO
 /docs/iamb.[15]
+.direnv


### PR DESCRIPTION
Allot of nix users use [direnv](https://direnv.net) for automatically entering the devshell.

Here is an example on how it looks on a direnv enabled nix machine:

https://github.com/ulyssa/iamb/assets/19208988/be4dc63a-3b87-46b6-9c2d-3c3936d5b8e0


With this change, nix users do not even have to think about devshells. It enters and exits the devshell automatically.
This will make contributing even easier :)
