### PR TITLE
Update modalkit dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arboard"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac57f2b058a76363e357c056e4f74f1945bf734d37b8b3ef49066c4787dde0fc"
+checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
 dependencies = [
  "clipboard-win",
  "core-graphics",
@@ -319,9 +319,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "blake3"
@@ -707,7 +707,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
 dependencies = [
  "libc",
  "winapi",
@@ -1595,7 +1595,7 @@ name = "iamb"
 version = "0.0.9-alpha.1"
 dependencies = [
  "arboard",
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "chrono",
  "clap",
  "comrak",
@@ -1615,8 +1615,10 @@ dependencies = [
  "mime",
  "mime_guess",
  "modalkit",
+ "modalkit-ratatui",
  "open",
  "pretty_assertions",
+ "ratatui",
  "ratatui-image",
  "regex",
  "rpassword",
@@ -1855,6 +1857,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "keybindings"
+version = "0.0.1"
+source = "git+https://github.com/ulyssa/modalkit?rev=5ebcaf1#5ebcaf18289526216a4e852a6c2c9ee03709e717"
+dependencies = [
+ "textwrap",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2180,9 +2192,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -2242,26 +2254,37 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.16"
-source = "git+https://github.com/ulyssa/modalkit?rev=f9f0517ed6a6152c1eab36d2e71b11f38831d5e6#f9f0517ed6a6152c1eab36d2e71b11f38831d5e6"
+version = "0.0.17"
+source = "git+https://github.com/ulyssa/modalkit?rev=5ebcaf1#5ebcaf18289526216a4e852a6c2c9ee03709e717"
 dependencies = [
  "anymap2",
  "arboard",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "crossterm 0.27.0",
  "derive_more",
  "intervaltree",
- "libc",
+ "keybindings",
  "nom",
  "radix_trie",
- "ratatui",
  "regex",
  "ropey",
- "serde",
- "textwrap",
  "thiserror",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "modalkit-ratatui"
+version = "0.0.17"
+source = "git+https://github.com/ulyssa/modalkit?rev=5ebcaf1#5ebcaf18289526216a4e852a6c2c9ee03709e717"
+dependencies = [
+ "crossterm 0.27.0",
+ "intervaltree",
+ "libc",
+ "modalkit",
+ "ratatui",
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -2281,14 +2304,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -2869,7 +2892,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "cassowary",
  "crossterm 0.27.0",
  "indoc",
@@ -3195,7 +3218,7 @@ version = "0.38.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys 0.4.8",
@@ -4516,11 +4539,11 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
+checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
 dependencies = [
- "gethostname 0.2.3",
+ "gethostname 0.3.0",
  "nix",
  "winapi",
  "winapi-wsapoll",
@@ -4529,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
 dependencies = [
  "nix",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-features = false
 features = ["build", "git", "gitcl",]
 
 [dependencies]
-arboard = "3.2.0"
+arboard = "3.3.0"
 bitflags = "^2.3"
 chrono = "0.4"
 clap = {version = "~4.3", features = ["derive"]}
@@ -40,6 +40,7 @@ markup5ever_rcdom = "0.2.0"
 mime = "^0.3.16"
 mime_guess = "^2.0.4"
 open = "3.2.0"
+ratatui = "0.23"
 ratatui-image = { version = "0.4.3", features = ["serde"] }
 regex = "^1.5"
 rpassword = "^7.2"
@@ -55,9 +56,14 @@ url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
 
 [dependencies.modalkit]
-# version = "0.0.16"
+version = "0.0.17"
 git = "https://github.com/ulyssa/modalkit"
-rev = "f9f0517ed6a6152c1eab36d2e71b11f38831d5e6"
+rev = "5ebcaf1"
+
+[dependencies.modalkit-ratatui]
+version = "0.0.17"
+git = "https://github.com/ulyssa/modalkit"
+rev = "5ebcaf1"
 
 [dependencies.matrix-sdk]
 version = "^0.6.2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,10 +7,9 @@ use std::convert::TryFrom;
 use matrix_sdk::ruma::{events::tag::TagName, OwnedUserId};
 
 use modalkit::{
-    editing::base::OpenTarget,
+    commands::{CommandError, CommandResult, CommandStep},
     env::vim::command::{CommandContext, CommandDescription, OptionType},
-    input::commands::{CommandError, CommandResult, CommandStep},
-    input::InputContext,
+    prelude::OpenTarget,
 };
 
 use crate::base::{
@@ -23,14 +22,13 @@ use crate::base::{
     MessageAction,
     ProgramCommand,
     ProgramCommands,
-    ProgramContext,
     RoomAction,
     RoomField,
     SendAction,
     VerifyAction,
 };
 
-type ProgContext = CommandContext<ProgramContext>;
+type ProgContext = CommandContext;
 type ProgResult = CommandResult<ProgramCommand>;
 
 /// Convert strings the user types into a tag name.
@@ -99,7 +97,7 @@ fn iamb_invite(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     };
 
     let iact = IambAction::from(ract);
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -110,7 +108,7 @@ fn iamb_verify(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     match args.len() {
         0 => {
             let open = ctx.switch(OpenTarget::Application(IambId::VerifyList));
-            let step = CommandStep::Continue(open, ctx.context.take());
+            let step = CommandStep::Continue(open, ctx.context.clone());
 
             return Ok(step);
         },
@@ -125,7 +123,7 @@ fn iamb_verify(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
                 "mismatch" => VerifyAction::Mismatch,
                 "request" => {
                     let iact = IambAction::VerifyRequest(args.remove(1));
-                    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+                    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
                     return Ok(step);
                 },
@@ -133,7 +131,7 @@ fn iamb_verify(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
             };
 
             let vact = IambAction::Verify(act, args.remove(1));
-            let step = CommandStep::Continue(vact.into(), ctx.context.take());
+            let step = CommandStep::Continue(vact.into(), ctx.context.clone());
 
             return Ok(step);
         },
@@ -149,7 +147,7 @@ fn iamb_dms(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(OpenTarget::Application(IambId::DirectList));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -160,7 +158,7 @@ fn iamb_members(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = IambAction::Room(RoomAction::Members(ctx.clone().into()));
-    let step = CommandStep::Continue(open.into(), ctx.context.take());
+    let step = CommandStep::Continue(open.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -171,7 +169,7 @@ fn iamb_leave(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let leave = IambAction::Room(RoomAction::Leave(desc.bang));
-    let step = CommandStep::Continue(leave.into(), ctx.context.take());
+    let step = CommandStep::Continue(leave.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -182,7 +180,7 @@ fn iamb_cancel(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let mact = IambAction::from(MessageAction::Cancel(desc.bang));
-    let step = CommandStep::Continue(mact.into(), ctx.context.take());
+    let step = CommandStep::Continue(mact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -193,7 +191,7 @@ fn iamb_edit(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let mact = IambAction::from(MessageAction::Edit);
-    let step = CommandStep::Continue(mact.into(), ctx.context.take());
+    let step = CommandStep::Continue(mact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -209,7 +207,7 @@ fn iamb_react(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     if let Some(emoji) = emojis::get(k).or_else(|| emojis::get_by_shortcode(k)) {
         let mact = IambAction::from(MessageAction::React(emoji.to_string()));
-        let step = CommandStep::Continue(mact.into(), ctx.context.take());
+        let step = CommandStep::Continue(mact.into(), ctx.context.clone());
 
         return Ok(step);
     } else {
@@ -240,7 +238,7 @@ fn iamb_unreact(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         IambAction::from(MessageAction::Unreact(None))
     };
 
-    let step = CommandStep::Continue(mact.into(), ctx.context.take());
+    let step = CommandStep::Continue(mact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -254,7 +252,7 @@ fn iamb_redact(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let reason = args.into_iter().next();
     let ract = IambAction::from(MessageAction::Redact(reason, desc.bang));
-    let step = CommandStep::Continue(ract.into(), ctx.context.take());
+    let step = CommandStep::Continue(ract.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -265,7 +263,7 @@ fn iamb_reply(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let ract = IambAction::from(MessageAction::Reply);
-    let step = CommandStep::Continue(ract.into(), ctx.context.take());
+    let step = CommandStep::Continue(ract.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -276,7 +274,7 @@ fn iamb_editor(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let sact = IambAction::from(SendAction::SubmitFromEditor);
-    let step = CommandStep::Continue(sact.into(), ctx.context.take());
+    let step = CommandStep::Continue(sact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -287,7 +285,7 @@ fn iamb_rooms(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(OpenTarget::Application(IambId::RoomList));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -298,7 +296,7 @@ fn iamb_chats(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(OpenTarget::Application(IambId::ChatList));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -309,7 +307,7 @@ fn iamb_spaces(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(OpenTarget::Application(IambId::SpaceList));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -320,7 +318,7 @@ fn iamb_welcome(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(OpenTarget::Application(IambId::Welcome));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -333,7 +331,7 @@ fn iamb_join(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let open = ctx.switch(args.remove(0));
-    let step = CommandStep::Continue(open, ctx.context.take());
+    let step = CommandStep::Continue(open, ctx.context.clone());
 
     return Ok(step);
 }
@@ -380,7 +378,7 @@ fn iamb_create(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let hact = HomeserverAction::CreateRoom(alias, ct, flags);
     let iact = IambAction::from(hact);
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -427,7 +425,7 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         _ => return Result::Err(CommandError::InvalidArgument),
     };
 
-    let step = CommandStep::Continue(act.into(), ctx.context.take());
+    let step = CommandStep::Continue(act.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -441,7 +439,7 @@ fn iamb_upload(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let sact = SendAction::Upload(args.remove(0));
     let iact = IambAction::from(sact);
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -459,7 +457,7 @@ fn iamb_download(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult 
     };
     let mact = MessageAction::Download(args.pop(), flags);
     let iact = IambAction::from(mact);
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -477,7 +475,7 @@ fn iamb_open(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     };
     let mact = MessageAction::Download(args.pop(), flags);
     let iact = IambAction::from(mact);
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -490,7 +488,7 @@ fn iamb_logout(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     }
 
     let iact = IambAction::from(HomeserverAction::Logout(args[0].clone(), desc.bang));
-    let step = CommandStep::Continue(iact.into(), ctx.context.take());
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -607,11 +605,12 @@ mod tests {
     use super::*;
     use matrix_sdk::ruma::user_id;
     use modalkit::editing::action::WindowAction;
+    use modalkit::editing::context::EditContext;
 
     #[test]
     fn test_cmd_verify() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd(":verify", ctx.clone()).unwrap();
         let act = WindowAction::Switch(OpenTarget::Application(IambId::VerifyList));
@@ -658,7 +657,7 @@ mod tests {
     #[test]
     fn test_cmd_join() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("join #foobar:example.com", ctx.clone()).unwrap();
         let act = WindowAction::Switch(OpenTarget::Name("#foobar:example.com".into()));
@@ -678,7 +677,7 @@ mod tests {
     #[test]
     fn test_cmd_room_invalid() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room", ctx.clone());
         assert_eq!(res, Err(CommandError::InvalidArgument));
@@ -693,7 +692,7 @@ mod tests {
     #[test]
     fn test_cmd_room_topic_set() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds
             .input_cmd("room topic set \"Lots of fun discussion!\"", ctx.clone())
@@ -724,7 +723,7 @@ mod tests {
     #[test]
     fn test_cmd_room_name_invalid() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room name", ctx.clone());
         assert_eq!(res, Err(CommandError::InvalidArgument));
@@ -736,7 +735,7 @@ mod tests {
     #[test]
     fn test_cmd_room_name_set() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room name set Development", ctx.clone()).unwrap();
         let act = RoomAction::Set(RoomField::Name, "Development".into());
@@ -755,7 +754,7 @@ mod tests {
     #[test]
     fn test_cmd_room_name_unset() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room name unset", ctx.clone()).unwrap();
         let act = RoomAction::Unset(RoomField::Name);
@@ -768,7 +767,7 @@ mod tests {
     #[test]
     fn test_cmd_room_tag_set() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room tag set favourite", ctx.clone()).unwrap();
         let act = RoomAction::Set(RoomField::Tag(TagName::Favorite), "".into());
@@ -837,7 +836,7 @@ mod tests {
     #[test]
     fn test_cmd_room_tag_unset() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room tag unset favourite", ctx.clone()).unwrap();
         let act = RoomAction::Unset(RoomField::Tag(TagName::Favorite));
@@ -902,7 +901,7 @@ mod tests {
     #[test]
     fn test_cmd_invite() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("invite accept", ctx.clone()).unwrap();
         let act = IambAction::Room(RoomAction::InviteAccept);
@@ -939,7 +938,7 @@ mod tests {
     #[test]
     fn test_cmd_redact() {
         let mut cmds = setup_commands();
-        let ctx = ProgramContext::default();
+        let ctx = EditContext::default();
 
         let res = cmds.input_cmd("redact", ctx.clone()).unwrap();
         let act = IambAction::Message(MessageAction::Redact(None, false));

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,15 +11,12 @@ use std::process;
 
 use clap::Parser;
 use matrix_sdk::ruma::{OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
+use ratatui::style::{Color, Modifier as StyleModifier, Style};
+use ratatui::text::Span;
 use ratatui_image::picker::ProtocolType;
 use serde::{de::Error as SerdeError, de::Visitor, Deserialize, Deserializer};
 use tracing::Level;
 use url::Url;
-
-use modalkit::tui::{
-    style::{Color, Modifier as StyleModifier, Style},
-    text::Span,
-};
 
 use super::base::{IambId, RoomInfo, SortColumn, SortFieldRoom, SortFieldUser, SortOrder};
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -6,8 +6,8 @@ use modalkit::{
     editing::action::WindowAction,
     env::vim::keybindings::{InputStep, VimBindings},
     env::vim::VimMode,
-    input::bindings::{EdgeEvent, EdgeRepeat, InputBindings},
-    input::key::TerminalKey,
+    key::TerminalKey,
+    keybindings::{EdgeEvent, EdgeRepeat, InputBindings},
 };
 
 use crate::base::{IambAction, IambInfo, Keybindings, MATRIX_ID_WORD};

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ use modalkit::crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
 };
 
-use modalkit::tui::{
+use ratatui::{
     backend::CrosstermBackend,
     layout::Rect,
     style::{Color, Style},
@@ -116,20 +116,26 @@ use modalkit::{
             WindowAction,
             WindowContainer,
         },
-        base::{CloseFlags, MoveDir1D, OpenTarget, RepeatType, TabTarget},
         context::Resolve,
         key::KeyManager,
         store::Store,
     },
-    input::{bindings::BindingMachine, dialog::Pager, dialog::PromptYesNo, key::TerminalKey},
-    widgets::{
-        cmdbar::CommandBarState,
-        screen::{FocusList, Screen, ScreenState, TabLayoutDescription},
-        windows::WindowLayoutDescription,
-        TerminalCursor,
-        TerminalExtOps,
-        Window,
+    key::TerminalKey,
+    keybindings::{
+        dialog::{Pager, PromptYesNo},
+        BindingMachine,
     },
+    prelude::*,
+    ui::FocusList,
+};
+
+use modalkit_ratatui::{
+    cmdbar::CommandBarState,
+    screen::{Screen, ScreenState, TabLayoutDescription},
+    windows::WindowLayoutDescription,
+    TerminalCursor,
+    TerminalExtOps,
+    Window,
 };
 
 fn config_tab_to_desc(
@@ -229,7 +235,7 @@ struct Application {
     worker: Requester,
 
     /// Mapped keybindings.
-    bindings: KeyManager<TerminalKey, ProgramAction, RepeatType, ProgramContext>,
+    bindings: KeyManager<TerminalKey, ProgramAction, RepeatType>,
 
     /// Pending actions to run.
     actstack: VecDeque<(ProgramAction, ProgramContext)>,

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -26,7 +26,7 @@ use html5ever::{
     tendril::{StrTendril, TendrilSink},
 };
 
-use modalkit::tui::{
+use ratatui::{
     layout::Alignment,
     style::{Color, Modifier as StyleModifier, Style},
     symbols::line,

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -44,13 +44,14 @@ use matrix_sdk::ruma::{
     UInt,
 };
 
-use modalkit::tui::{
+use ratatui::{
     style::{Modifier as StyleModifier, Style},
     symbols::line::THICK_VERTICAL,
     text::{Line, Span, Text},
 };
 
-use modalkit::editing::{base::ViewportContext, cursor::Cursor};
+use modalkit::editing::cursor::Cursor;
+use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -5,9 +5,9 @@
 //! contents).
 use std::borrow::Cow;
 
-use modalkit::tui::layout::Alignment;
-use modalkit::tui::style::Style;
-use modalkit::tui::text::{Line, Span, Text};
+use ratatui::layout::Alignment;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span, Text};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -19,7 +19,7 @@ use matrix_sdk::{
     },
     Media,
 };
-use modalkit::tui::layout::Rect;
+use ratatui::layout::Rect;
 use ratatui_image::Resize;
 
 use crate::{

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ use matrix_sdk::ruma::{
 };
 
 use lazy_static::lazy_static;
-use modalkit::tui::style::{Color, Style};
+use ratatui::style::{Color, Style};
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::Level;
 use url::Url;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use modalkit::tui::style::Style;
-use modalkit::tui::text::{Line, Span, Text};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span, Text};
 
 pub fn split_cow(cow: Cow<'_, str>, idx: usize) -> (Cow<'_, str>, Cow<'_, str>) {
     match cow {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -24,7 +24,7 @@ use matrix_sdk::{
     },
 };
 
-use modalkit::tui::{
+use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
     style::{Modifier as StyleModifier, Style},
@@ -48,25 +48,17 @@ use modalkit::{
             UIError,
             WindowAction,
         },
-        base::{
-            CloseFlags,
-            MoveDir1D,
-            OpenTarget,
-            PositionList,
-            ScrollStyle,
-            ViewportContext,
-            WordStyle,
-            WriteFlags,
-        },
         completion::CompletionList,
     },
-    widgets::{
-        list::{List, ListCursor, ListItem, ListState},
-        TermOffset,
-        TerminalCursor,
-        Window,
-        WindowOps,
-    },
+    prelude::*,
+};
+
+use modalkit_ratatui::{
+    list::{List, ListCursor, ListItem, ListState},
+    TermOffset,
+    TerminalCursor,
+    Window,
+    WindowOps,
 };
 
 use crate::base::{
@@ -281,7 +273,6 @@ fn room_prompt(
 
             Err(err)
         },
-        _ => Err(EditError::Unimplemented("unknown prompt action".to_string())),
     }
 }
 
@@ -1332,7 +1323,6 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for VerifyItem {
 
                 Err(err)
             },
-            _ => Err(EditError::Unimplemented("unknown prompt action".to_string())),
         }
     }
 }
@@ -1428,7 +1418,6 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for MemberItem {
 
                 Err(err)
             },
-            _ => Err(EditError::Unimplemented("unknown prompt action".to_string())),
         }
     }
 }

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -31,17 +31,20 @@ use matrix_sdk::{
     },
 };
 
-use modalkit::{
-    input::dialog::{MultiChoice, MultiChoiceItem, PromptYesNo},
-    tui::{
-        buffer::Buffer,
-        layout::Rect,
-        text::{Line, Span},
-        widgets::{Paragraph, StatefulWidget, Widget},
-    },
-    widgets::textbox::{TextBox, TextBoxState},
-    widgets::TerminalCursor,
-    widgets::{PromptActions, WindowOps},
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Paragraph, StatefulWidget, Widget},
+};
+
+use modalkit::keybindings::dialog::{MultiChoice, MultiChoiceItem, PromptYesNo};
+
+use modalkit_ratatui::{
+    textbox::{TextBox, TextBoxState},
+    PromptActions,
+    TerminalCursor,
+    WindowOps,
 };
 
 use modalkit::editing::{
@@ -59,12 +62,12 @@ use modalkit::editing::{
         Scrollable,
         UIError,
     },
-    base::{CloseFlags, Count, MoveDir1D, PositionList, ScrollStyle, WordStyle, WriteFlags},
     completion::CompletionList,
     context::Resolve,
     history::{self, HistoryList},
     rope::EditRope,
 };
+use modalkit::prelude::*;
 
 use crate::base::{
     DownloadFlags,
@@ -811,7 +814,6 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ChatState {
             PromptAction::Recall(dir, count, prefixed) => {
                 self.recall(dir, count, *prefixed, ctx, store)
             },
-            _ => Err(EditError::Unimplemented("unknown prompt action".to_string())),
         }
     }
 }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -11,7 +11,7 @@ use matrix_sdk::{
     DisplayName,
 };
 
-use modalkit::tui::{
+use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
     style::{Modifier as StyleModifier, Style},
@@ -19,6 +19,7 @@ use modalkit::tui::{
     widgets::{Paragraph, StatefulWidget, Widget},
 };
 
+use modalkit::prelude::*;
 use modalkit::{
     editing::action::{
         Action,
@@ -32,22 +33,10 @@ use modalkit::{
         Scrollable,
         UIError,
     },
-    editing::base::{
-        Axis,
-        CloseFlags,
-        Count,
-        MoveDir1D,
-        OpenTarget,
-        PositionList,
-        ScrollStyle,
-        WordStyle,
-        WriteFlags,
-    },
     editing::completion::CompletionList,
-    input::dialog::PromptYesNo,
-    input::InputContext,
-    widgets::{TermOffset, TerminalCursor, WindowOps},
+    keybindings::dialog::PromptYesNo,
 };
+use modalkit_ratatui::{TermOffset, TerminalCursor, WindowOps};
 
 use crate::base::{
     IambAction,
@@ -253,7 +242,7 @@ impl RoomState {
                         width.into(),
                     );
 
-                Ok(vec![(act, cmd.context.take())])
+                Ok(vec![(act, cmd.context.clone())])
             },
             RoomAction::Set(field, value) => {
                 let room = store

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
     ruma::{OwnedRoomId, RoomId},
 };
 
-use modalkit::tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Style},
@@ -15,9 +15,11 @@ use modalkit::tui::{
     widgets::StatefulWidget,
 };
 
-use modalkit::{
-    widgets::list::{List, ListState},
-    widgets::{TermOffset, TerminalCursor, WindowOps},
+use modalkit_ratatui::{
+    list::{List, ListState},
+    TermOffset,
+    TerminalCursor,
+    WindowOps,
 };
 
 use crate::base::{IambBufferId, IambInfo, ProgramStore, RoomFocus};

--- a/src/windows/welcome.rs
+++ b/src/windows/welcome.rs
@@ -1,17 +1,13 @@
 //! Welcome Window
 use std::ops::{Deref, DerefMut};
 
-use modalkit::tui::{buffer::Buffer, layout::Rect};
+use ratatui::{buffer::Buffer, layout::Rect};
 
-use modalkit::{
-    widgets::textbox::TextBoxState,
-    widgets::WindowOps,
-    widgets::{TermOffset, TerminalCursor},
-};
+use modalkit_ratatui::{textbox::TextBoxState, TermOffset, TerminalCursor, WindowOps};
 
 use modalkit::editing::action::EditInfo;
-use modalkit::editing::base::{CloseFlags, WordStyle, WriteFlags};
 use modalkit::editing::completion::CompletionList;
+use modalkit::prelude::*;
 
 use crate::base::{IambBufferId, IambInfo, IambResult, ProgramStore};
 


### PR DESCRIPTION
I split the `modalkit` dependency up into several crates, and moved some things around to hopefully make it easier for people to understand how things piece together. This PR reorganizes the impacted imports, and also takes care of updating for the `EditContext` trait to struct change.