### PR TITLE
Indicate and sort on rooms with unread messages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,9 +32,10 @@ const DEFAULT_MEMBERS_SORT: [SortColumn<SortFieldUser>; 2] = [
     SortColumn(SortFieldUser::UserId, SortOrder::Ascending),
 ];
 
-const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 3] = [
+const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 4] = [
     SortColumn(SortFieldRoom::Favorite, SortOrder::Ascending),
     SortColumn(SortFieldRoom::LowPriority, SortOrder::Ascending),
+    SortColumn(SortFieldRoom::Unread, SortOrder::Ascending),
     SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
 ];
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,7 +156,6 @@ pub fn mock_room() -> RoomInfo {
 
         event_receipts: HashMap::new(),
         user_receipts: HashMap::new(),
-        read_till: None,
         reactions: HashMap::new(),
 
         fetching: false,

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -126,11 +126,7 @@ fn selected_text(s: &str, selected: bool) -> Text {
     Text::from(selected_span(s, selected))
 }
 
-fn name_and_labels(
-    name: &str,
-    unread: bool,
-    style: Style,
-) -> (Span<'_>, Vec<Vec<Span<'_>>>) {
+fn name_and_labels(name: &str, unread: bool, style: Style) -> (Span<'_>, Vec<Vec<Span<'_>>>) {
     let name_style = if unread {
         style.add_modifier(StyleModifier::BOLD)
     } else {

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1342,7 +1342,9 @@ impl<'a> StatefulWidget for Scrollback<'a> {
             state.cursor.timestamp.is_none()
         {
             // If the cursor is at the last message, then update the read marker.
-            info.read_till = info.messages.last_key_value().map(|(k, _)| k.1.clone());
+            if let Some((k, _)) = info.messages.last_key_value() {
+                info.set_receipt(settings.profile.user_id.clone(), k.1.clone());
+            }
         }
 
         // Check whether we should load older messages for this room.


### PR DESCRIPTION
This fixes #83 by adding two new fields to sort on, `unread` and `recent`. I've updated the sort order for `"rooms"` (and therefore by default all of the other room-like lists) to now be `["favorite", "lowpriority", "unread", "name"]`, so that favorites will still be at the top, and low-priority items at the bottom of the list, with unreads at the top inside those groups, and finally sorted by names.

The `"recent"` sort field can be used by folks who also want rooms to move within the list based on how recently someone has messaged there. This could potentially be annoying for users in multiple rooms with frequent activity that keep swapping positions in the list, so  I haven't put it in the default sort.