### PR TITLE
Move LTO into its own "release-lto" profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,10 @@ features = ["macros", "net", "rt-multi-thread", "sync", "time"]
 lazy_static = "1.4.0"
 pretty_assertions = "1.4.0"
 
-[profile.release]
-lto = true
+[profile.release-lto]
+inherits = "release"
 incremental = false
+lto = true
 
 [features]
 default = ["sixel"]


### PR DESCRIPTION
The AUR `iamb-git` package seems to be broken right now due to some kind of weirdness with the LTO. A user reported in `#iamb-users:0x.badd.cafe` that they get the following:

```
          /usr/bin/ld: /home/rek2/.cache/paru/clone/iamb-git/src/iamb/target/release/deps/iamb-dee5b80dcda0a0a7: hidden symbol `GFp_ia32cap_P' isn't defined
          /usr/bin/ld: final link failed: bad value
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

error: could not compile `iamb` (bin "iamb") due to 1 previous error
==> ERROR: A failure occurred in build().
    Aborting...
error: failed to build 'iamb-git-0.1.e98d58a-1': 
error: packages failed to build: iamb-git-0.1.e98d58a-1
``` 

This seems to be the same issue seen in briansmith/ring#1444. It sounds like certain environments result in a mix of GCC and Clang/LLVM being used while building resulting, causing the issue. I'm going to move LTO into its own non-default profile so that people won't hit this. For folks who want smaller binaries (LTO shaves off ~10mb, so I plan to continue using it for the binaries on the releases page), you can build with:

```
cargo build --profile release-lto
```