### PR TITLE
Support following the .well-known entries for a username's domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ You can create a basic configuration in `$CONFIG_DIR/iamb/config.json` that look
 {
     "profiles": {
         "example.com": {
+            "user_id": "@user:example.com"
+        }
+    }
+}
+```
+
+If you homeserver is located on a different domain than the server part of the
+`user_id` and you don't have a [`/.well-known`][well_known_entry] entry, then
+you can explicitly specify the homeserver URL to use:
+
+```json
+{
+    "profiles": {
+        "example.com": {
             "url": "https://example.com",
             "user_id": "@user:example.com"
         }
@@ -122,6 +136,7 @@ iamb is released under the [Apache License, Version 2.0].
 [iamb.chat]: https://iamb.chat
 [gomuks]: https://github.com/tulir/gomuks
 [weechat-matrix]: https://github.com/poljar/weechat-matrix
+[well_known_entry]: https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixclient
 [#8]: https://github.com/ulyssa/iamb/issues/8
 [#14]: https://github.com/ulyssa/iamb/issues/14
 [#16]: https://github.com/ulyssa/iamb/issues/16

--- a/src/config.rs
+++ b/src/config.rs
@@ -505,7 +505,7 @@ pub enum Layout {
 #[derive(Clone, Deserialize)]
 pub struct ProfileConfig {
     pub user_id: OwnedUserId,
-    pub url: Url,
+    pub url: Option<Url>,
     pub settings: Option<Tunables>,
     pub dirs: Option<Directories>,
     pub layout: Option<Layout>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -209,7 +209,7 @@ pub fn mock_settings() -> ApplicationSettings {
         profile_name: "test".into(),
         profile: ProfileConfig {
             user_id: user_id!("@user:example.com").to_owned(),
-            url: Url::parse("https://example.com").unwrap(),
+            url: None,
             settings: None,
             dirs: None,
             layout: None,


### PR DESCRIPTION
This fixes #158, and should help people avoid accidentally using the wrong homeserver during setup when the `/.well-known/matrix/client` points at a different domain.