### PR TITLE
Download rooms keys from backups if they exist

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -21,6 +21,7 @@ use url::Url;
 use matrix_sdk::{
     config::{RequestConfig, SyncSettings},
     encryption::verification::{SasVerification, Verification},
+    encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_handler::Ctx,
     matrix_auth::MatrixSession,
     reqwest,
@@ -99,6 +100,12 @@ use crate::{
     },
     message::MessageFetchResult,
     ApplicationSettings,
+};
+
+const DEFAULT_ENCRYPTION_SETTINGS: EncryptionSettings = EncryptionSettings {
+    auto_enable_cross_signing: true,
+    auto_enable_backups: true,
+    backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
 };
 
 const IAMB_DEVICE_NAME: &str = "iamb";
@@ -664,7 +671,8 @@ async fn create_client_inner(
     let builder = Client::builder()
         .http_client(http)
         .sqlite_store(settings.sqlite_dir.as_path(), None)
-        .request_config(req_config);
+        .request_config(req_config)
+        .with_encryption_settings(DEFAULT_ENCRYPTION_SETTINGS.clone());
 
     let builder = if let Some(url) = homeserver {
         // Use the explicitly specified homeserver.


### PR DESCRIPTION
From what I can tell, it looks like the SDK defaults to `BackupDownloadStrategy::Manual`. I think that `BackupDownloadStrategy::AfterDecryptionFailure` is probably what most users expect, so I'm going to switch to that, and to creating backups by default when one doesn't already exist.