### PR TITLE
Load receipts for room before acquiring lock

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1119,6 +1119,10 @@ impl RoomNeeds {
     pub fn insert(&mut self, room_id: OwnedRoomId, need: Need) {
         self.needs.entry(room_id).or_default().insert(need);
     }
+
+    pub fn rooms(&self) -> usize {
+        self.needs.len()
+    }
 }
 
 impl IntoIterator for RoomNeeds {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -33,7 +33,6 @@ use matrix_sdk::ruma::{
             },
             redaction::SyncRoomRedactionEvent,
         },
-        AnyMessageLikeEvent,
         RedactContent,
         RedactedUnsigned,
     },
@@ -57,7 +56,7 @@ use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
 use crate::{
-    base::{IambResult, RoomInfo},
+    base::RoomInfo,
     config::ApplicationSettings,
     message::html::{parse_matrix_html, StyleTree},
     util::{space, space_span, take_width, wrapped_text},
@@ -66,7 +65,6 @@ use crate::{
 mod html;
 mod printer;
 
-pub type MessageFetchResult = IambResult<(Option<String>, Vec<AnyMessageLikeEvent>)>;
 pub type MessageKey = (MessageTimeStamp, OwnedEventId);
 pub type Messages = BTreeMap<MessageKey, Message>;
 


### PR DESCRIPTION
In #205 I added a `Need::MESSAGES` for every room at startup, which locks up the UI for the first several seconds when there are enough joined rooms. This adds an upper limit on how many load plans we execute in parallel at a time, and moves the receipt loading for a room to be outside of the `load_insert` function. This reduces the demand on the lock enough that the UI remains responsive.