### PR TITLE
Add support for threads

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -885,7 +885,7 @@ impl RoomInfo {
         let key = (msg.origin_server_ts().into(), event_id.clone());
 
         let loc = EventLocation::Message(None, key.clone());
-        self.keys.insert(event_id.clone(), loc);
+        self.keys.insert(event_id, loc);
         self.messages.insert_message(key, msg);
     }
 
@@ -895,7 +895,7 @@ impl RoomInfo {
 
         let replies = self.threads.entry(thread_root.clone()).or_default();
         let loc = EventLocation::Message(Some(thread_root), key.clone());
-        self.keys.insert(event_id.clone(), loc);
+        self.keys.insert(event_id, loc);
         replies.insert_message(key, msg);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,14 +141,14 @@ fn config_tab_to_desc(
                     let name = user_id.to_string();
                     let room_id = worker.join_room(name.clone())?;
                     names.insert(name, room_id.clone());
-                    IambId::Room(room_id)
+                    IambId::Room(room_id, None)
                 },
-                config::WindowPath::RoomId(room_id) => IambId::Room(room_id),
+                config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
                     let name = alias.to_string();
                     let room_id = worker.join_room(name.clone())?;
                     names.insert(name, room_id.clone());
-                    IambId::Room(room_id)
+                    IambId::Room(room_id, None)
                 },
                 config::WindowPath::Window(id) => id,
             };
@@ -563,7 +563,7 @@ impl Application {
             HomeserverAction::CreateRoom(alias, vis, flags) => {
                 let client = &store.application.worker.client;
                 let room_id = create_room(client, alias, vis, flags).await?;
-                let room = IambId::Room(room_id);
+                let room = IambId::Room(room_id, None);
                 let target = OpenTarget::Application(room);
                 let action = WindowAction::Switch(target);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use matrix_sdk::ruma::{
@@ -125,17 +125,17 @@ pub fn mock_message5() -> Message {
 pub fn mock_keys() -> HashMap<OwnedEventId, EventLocation> {
     let mut keys = HashMap::new();
 
-    keys.insert(MSG1_EVID.clone(), EventLocation::Message(MSG1_KEY.clone()));
-    keys.insert(MSG2_EVID.clone(), EventLocation::Message(MSG2_KEY.clone()));
-    keys.insert(MSG3_EVID.clone(), EventLocation::Message(MSG3_KEY.clone()));
-    keys.insert(MSG4_EVID.clone(), EventLocation::Message(MSG4_KEY.clone()));
-    keys.insert(MSG5_EVID.clone(), EventLocation::Message(MSG5_KEY.clone()));
+    keys.insert(MSG1_EVID.clone(), EventLocation::Message(None, MSG1_KEY.clone()));
+    keys.insert(MSG2_EVID.clone(), EventLocation::Message(None, MSG2_KEY.clone()));
+    keys.insert(MSG3_EVID.clone(), EventLocation::Message(None, MSG3_KEY.clone()));
+    keys.insert(MSG4_EVID.clone(), EventLocation::Message(None, MSG4_KEY.clone()));
+    keys.insert(MSG5_EVID.clone(), EventLocation::Message(None, MSG5_KEY.clone()));
 
     keys
 }
 
 pub fn mock_messages() -> Messages {
-    let mut messages = BTreeMap::new();
+    let mut messages = Messages::default();
 
     messages.insert(MSG1_KEY.clone(), mock_message1());
     messages.insert(MSG2_KEY.clone(), mock_message2());
@@ -153,6 +153,7 @@ pub fn mock_room() -> RoomInfo {
 
         keys: mock_keys(),
         messages: mock_messages(),
+        threads: HashMap::default(),
 
         event_receipts: HashMap::new(),
         user_receipts: HashMap::new(),

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -39,7 +39,7 @@ pub struct SpaceState {
 impl SpaceState {
     pub fn new(room: MatrixRoom) -> Self {
         let room_id = room.room_id().to_owned();
-        let content = IambBufferId::Room(room_id.clone(), RoomFocus::Scrollback);
+        let content = IambBufferId::Room(room_id.clone(), None, RoomFocus::Scrollback);
         let list = ListState::new(content, vec![]);
         let last_fetch = None;
 


### PR DESCRIPTION
This adds initial support for entering messages threads. A thread can be entered by pressing `<Enter>` on the thread  root message. Messages entered into the message bar are then sent to the thread. You can navigate back to the main view using `^O`, just as with navigating back to other previous views.

I'm planning to add a `:threads` command to show the threads in the room, but this will require implementing loading non-continous ranges of messages in order to work well. 