### PR TITLE
Add support for custom key macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,8 @@ dependencies = [
 [[package]]
 name = "keybindings"
 version = "0.0.1"
-source = "git+https://github.com/ulyssa/modalkit?rev=cb8c8aeb9a499b9b16615ce144f9014d78036e01#cb8c8aeb9a499b9b16615ce144f9014d78036e01"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680e4699c91c0622dd70da32c274881aadb1ac86252d738c3641266e90e4ca15"
 dependencies = [
  "textwrap",
  "unicode-segmentation",
@@ -2507,8 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.17"
-source = "git+https://github.com/ulyssa/modalkit?rev=cb8c8aeb9a499b9b16615ce144f9014d78036e01#cb8c8aeb9a499b9b16615ce144f9014d78036e01"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d68711785c96d06bede5bd38fee2e2ac856cfccce7ea0b3e302bc4c5688010"
 dependencies = [
  "anymap2",
  "arboard",
@@ -2528,8 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "modalkit-ratatui"
-version = "0.0.17"
-source = "git+https://github.com/ulyssa/modalkit?rev=cb8c8aeb9a499b9b16615ce144f9014d78036e01#cb8c8aeb9a499b9b16615ce144f9014d78036e01"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747e3dc36bfc4b62a152a37b6631f471797269afa094f6ba0d7aea768be31e2b"
 dependencies = [
  "crossterm",
  "intervaltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
 
 [dependencies.modalkit]
-version = "0.0.17"
-git = "https://github.com/ulyssa/modalkit"
-rev = "cb8c8aeb9a499b9b16615ce144f9014d78036e01"
+version = "0.0.18"
+#git = "https://github.com/ulyssa/modalkit"
+#rev = "cb8c8aeb9a499b9b16615ce144f9014d78036e01"
 
 [dependencies.modalkit-ratatui]
-version = "0.0.17"
-git = "https://github.com/ulyssa/modalkit"
-rev = "cb8c8aeb9a499b9b16615ce144f9014d78036e01"
+version = "0.0.18"
+#git = "https://github.com/ulyssa/modalkit"
+#rev = "cb8c8aeb9a499b9b16615ce144f9014d78036e01"
 
 [dependencies.matrix-sdk]
 version = "0.7.1"

--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -2,7 +2,7 @@
 	"default_profile": "default",
 	"profiles": {
 		"default": {
-			"user_id":  "",
+			"user_id":  "@user:matrix.org",
 			"url":      "https://matrix.org",
 			"settings": {},
 			"dirs":     {}
@@ -32,6 +32,14 @@
 				"width": 66,
 				"height": 10
 			}
+		}
+	},
+	"layout": {
+		"style": "restore"
+	},
+	"macros": {
+		"i": {
+			"jj": "<Esc>"
 		}
 	},
 	"dirs": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,6 @@
           src = ./.;
           cargoLock = {
             lockFile = ./Cargo.lock;
-            outputHashes = {
-              "keybindings-0.0.1" = "sha256-6gGviJF4/gzoPxgh0XJXXrhQoWxOTqyI9fwiOE+TY7s=";
-            };
           };
           nativeBuildInputs = [ pkg-config ];
           buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 use clap::Parser;
 use matrix_sdk::crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::OwnedUserId;
+use modalkit::keybindings::InputBindings;
 use rand::{distributions::Alphanumeric, Rng};
 use temp_dir::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
@@ -257,7 +258,8 @@ impl Application {
         let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend)?;
 
-        let bindings = crate::keybindings::setup_keybindings();
+        let mut bindings = crate::keybindings::setup_keybindings();
+        settings.setup(&mut bindings);
         let bindings = KeyManager::new(bindings);
 
         let mut locked = store.lock().await;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -217,10 +217,12 @@ pub fn mock_settings() -> ApplicationSettings {
             settings: None,
             dirs: None,
             layout: None,
+            macros: None,
         },
         tunables: mock_tunables(),
         dirs: mock_dirs(),
         layout: Default::default(),
+        macros: HashMap::default(),
     }
 }
 


### PR DESCRIPTION
This adds a `"macros"` field to `config.json` which allows specifying custom mappings from one set of keys to another. This allows writing something like the following to map `jj` to `<Esc>` in Insert mode:

```json
{
    ...,
    "macros": {
        "i": { "jj": "<Esc>" }
    }
}
```

The following names can be used to refer to the different modes:

- `normal`/`n` for Normal mode
- `insert`/`i` for Insert mode
- `visual`/`v` for Visual mode
- `command`/`c` for Command mode
- `select` for Select mode
-  `operator-pending` for Operator Pending mode

Multiple modes can be specified together using `|` to put a mapping in all of them. For example, `"insert|command"` or `"i|c"` could be used in the above example to map `jj` in both Insert and Command mode.

I've called this `"macros"` since they'll behave like macros: a `{count}` argument will repeat the mapping (`<Esc>` in the above example), and not provide an argument to it. I have plans for a separate way to specify keybindings in the future using expressions that generate an `Action` that should help anyone who needs to specify something that takes an optional count or register argument. 