### PR TITLE
Support linking against system OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ categories = ["command-line-utilities"]
 rust-version = "1.70"
 build = "build.rs"
 
+[features]
+default = ["bundled"]
+bundled = ["matrix-sdk/bundled-sqlite", "rustls-tls"]
+native-tls = ["matrix-sdk/native-tls"]
+rustls-tls = ["matrix-sdk/rustls-tls"]
+
 [build-dependencies]
 mandown = "0.1.3"
 
@@ -71,7 +77,7 @@ version = "0.0.18"
 [dependencies.matrix-sdk]
 version = "0.7.1"
 default-features = false
-features = ["e2e-encryption", "rustls-tls", "bundled-sqlite", "sso-login"]
+features = ["e2e-encryption", "sqlite", "sso-login"]
 
 [dependencies.tokio]
 version = "1.24.1"

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,27 @@
+# Notes For Package Maintainers
+
+## Linking Against System Packages
+
+The default Cargo features for __iamb__ will bundle SQLite and use [rustls] for
+TLS. Package maintainers may want to link against the system's native SQLite
+and TLS libraries instead. To do so, you'll want to build without the default
+features and specify that it should build with `native-tls`:
+
+```
+% cargo build --release --no-default-features --features=native-tls
+```
+
+## Enabling LTO
+
+Enabling LTO can result in smaller binaries. There is a separate profile to
+enable it when building:
+
+```
+% cargo build --profile release-lto
+```
+
+Note that this [can fail][ring-lto] in some build environments if both Clang
+and GCC are present.
+
+[ring-lto]: https://github.com/briansmith/ring/issues/1444
+[rustls]: https://crates.io/crates/rustls


### PR DESCRIPTION
This fixes #84 by adding a way to build that links against the system `libssl`/`libcrypto` libraries. I've also made it possible to link against the system SQLite, and added a `PACKAGING.md` that package maintainers can reference for useful building tips.