### PR TITLE
Ignore key releases on platforms that support it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ use modalkit::crossterm::{
         EnableBracketedPaste,
         EnableFocusChange,
         Event,
+        KeyEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
@@ -341,7 +342,13 @@ impl Application {
             }
 
             match read()? {
-                Event::Key(ke) => return Ok(ke.into()),
+                Event::Key(ke) => {
+                    if ke.kind == KeyEventKind::Release {
+                        continue;
+                    }
+
+                    return Ok(ke.into());
+                },
                 Event::Mouse(_) => {
                     // Do nothing for now.
                 },


### PR DESCRIPTION
Keys currently get typed twice on platforms where `crossterm` can detect key releases (like Windows) . I imagine that this would also apply if I ever turned on the kitty keyboard protocol for terminals that support it. When iamb sees a key release, it should just skip it.