### PR TITLE
Fix odd Windows-only compile error

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1311,7 +1311,7 @@ impl ClientWorker {
 
     async fn logout(&mut self, user_id: String) -> IambResult<EditInfo> {
         // Verify that the user is logging out of the correct profile.
-        let curr = self.settings.profile.user_id.as_ref();
+        let curr = self.settings.profile.user_id.as_str();
 
         if user_id != curr {
             let msg = format!("Incorrect user ID (currently logged in as {curr})");


### PR DESCRIPTION
The CI failed for Windows in #192 due to not being able to infer the type parameter for an `.as_ref()` call. I can reproduce it with that PR checked out on Windows, but not on other platforms (or without that PR checked out). I'm not sure what the issue is, but it's easy enough to fix so that the the PR can compile in CI.