### PR TITLE
Support displaying shortcodes instead of emojis in messages

### DIFF
--- a/docs/example_config.json
+++ b/docs/example_config.json
@@ -10,6 +10,7 @@
 	},
 	"settings": {
 		"log_level":                  "warn",
+		"message_shortcode_display":  false,
 		"reaction_display":           true,
 		"reaction_shortcode_display": false,
 		"read_receipt_send":          true,

--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -53,6 +53,10 @@ overridden as described in *PROFILES*.
 > Specifies the lowest log level that should be shown. Possible values
 > are: _trace_, _debug_, _info_, _warn_, and _error_.
 
+**message_shortcode_display** (type: boolean)
+> Defines whether or not emoji characters in messages should be replaced by
+> their respective shortcodes.
+
 **reaction_display** (type: boolean)
 > Defines whether or not reactions should be shown.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -469,6 +469,7 @@ impl SortOverrides {
 #[derive(Clone)]
 pub struct TunableValues {
     pub log_level: Level,
+    pub message_shortcode_display: bool,
     pub reaction_display: bool,
     pub reaction_shortcode_display: bool,
     pub read_receipt_send: bool,
@@ -489,6 +490,7 @@ pub struct TunableValues {
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
     pub log_level: Option<LogLevel>,
+    pub message_shortcode_display: Option<bool>,
     pub reaction_display: Option<bool>,
     pub reaction_shortcode_display: Option<bool>,
     pub read_receipt_send: Option<bool>,
@@ -511,6 +513,9 @@ impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
             log_level: self.log_level.or(other.log_level),
+            message_shortcode_display: self
+                .message_shortcode_display
+                .or(other.message_shortcode_display),
             reaction_display: self.reaction_display.or(other.reaction_display),
             reaction_shortcode_display: self
                 .reaction_shortcode_display
@@ -534,6 +539,7 @@ impl Tunables {
     fn values(self) -> TunableValues {
         TunableValues {
             log_level: self.log_level.map(Level::from).unwrap_or(Level::INFO),
+            message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             reaction_display: self.reaction_display.unwrap_or(true),
             reaction_shortcode_display: self.reaction_shortcode_display.unwrap_or(false),
             read_receipt_send: self.read_receipt_send.unwrap_or(true),

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -166,7 +166,8 @@ impl Table {
 
         if let Some(caption) = &self.caption {
             let subw = width.saturating_sub(6);
-            let mut printer = TextPrinter::new(subw, style, true, emoji_shortcodes).align(Alignment::Center);
+            let mut printer =
+                TextPrinter::new(subw, style, true, emoji_shortcodes).align(Alignment::Center);
             caption.print(&mut printer, style);
 
             for mut line in printer.finish().lines {
@@ -464,7 +465,13 @@ impl StyleTree {
         return links;
     }
 
-    pub fn to_text(&self, width: usize, style: Style, hide_reply: bool, emoji_shortcodes: bool) -> Text<'_> {
+    pub fn to_text(
+        &self,
+        width: usize,
+        style: Style,
+        hide_reply: bool,
+        emoji_shortcodes: bool,
+    ) -> Text<'_> {
         let mut printer = TextPrinter::new(width, style, hide_reply, emoji_shortcodes);
 
         for child in self.children.iter() {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -834,7 +834,8 @@ impl Message {
 
         if let Some(r) = &reply {
             let w = width.saturating_sub(2);
-            let mut replied = r.show_msg(w, style, true, settings.tunables.message_shortcode_display);
+            let mut replied =
+                r.show_msg(w, style, true, settings.tunables.message_shortcode_display);
             let mut sender = r.sender_span(info, settings);
             let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
             let trailing = w.saturating_sub(sender_width + 1);
@@ -862,7 +863,12 @@ impl Message {
         }
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let msg = self.show_msg(width, style, reply.is_some(), settings.tunables.message_shortcode_display);
+        let msg = self.show_msg(
+            width,
+            style,
+            reply.is_some(),
+            settings.tunables.message_shortcode_display,
+        );
         fmt.push_text(msg, style, &mut text);
 
         if text.lines.is_empty() {
@@ -920,7 +926,8 @@ impl Message {
             if len > 0 {
                 let style = Style::default();
                 let emoji_shortcodes = settings.tunables.message_shortcode_display;
-                let mut threaded = printer::TextPrinter::new(width, style, false, emoji_shortcodes).literal(true);
+                let mut threaded =
+                    printer::TextPrinter::new(width, style, false, emoji_shortcodes).literal(true);
                 let len = Span::styled(len.to_string(), style.add_modifier(StyleModifier::BOLD));
                 threaded.push_str(" \u{2937} ", style);
                 threaded.push_span_nobreak(len);
@@ -932,7 +939,13 @@ impl Message {
         text
     }
 
-    pub fn show_msg(&self, width: usize, style: Style, hide_reply: bool, emoji_shortcodes: bool) -> Text {
+    pub fn show_msg(
+        &self,
+        width: usize,
+        style: Style,
+        hide_reply: bool,
+        emoji_shortcodes: bool,
+    ) -> Text {
         if let Some(html) = &self.html {
             html.to_text(width, style, hide_reply, emoji_shortcodes)
         } else {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -61,7 +61,7 @@ use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
     message::html::{parse_matrix_html, StyleTree},
-    util::{space, space_span, take_width, wrapped_text},
+    util::{replace_emojis_in_str, space, space_span, take_width, wrapped_text},
 };
 
 mod html;
@@ -834,7 +834,7 @@ impl Message {
 
         if let Some(r) = &reply {
             let w = width.saturating_sub(2);
-            let mut replied = r.show_msg(w, style, true);
+            let mut replied = r.show_msg(w, style, true, settings.tunables.message_shortcode_display);
             let mut sender = r.sender_span(info, settings);
             let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
             let trailing = w.saturating_sub(sender_width + 1);
@@ -862,7 +862,7 @@ impl Message {
         }
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let msg = self.show_msg(width, style, reply.is_some());
+        let msg = self.show_msg(width, style, reply.is_some(), settings.tunables.message_shortcode_display);
         fmt.push_text(msg, style, &mut text);
 
         if text.lines.is_empty() {
@@ -871,7 +871,9 @@ impl Message {
         }
 
         if settings.tunables.reaction_display {
-            let mut emojis = printer::TextPrinter::new(width, style, false);
+            // Pass false for emoji_shortcodes parameter because we handle shortcodes ourselves
+            // before pushing to the printer.
+            let mut emojis = printer::TextPrinter::new(width, style, false, false);
             let mut reactions = 0;
 
             for (key, count) in info.get_reactions(self.event.event_id()).into_iter() {
@@ -917,7 +919,8 @@ impl Message {
 
             if len > 0 {
                 let style = Style::default();
-                let mut threaded = printer::TextPrinter::new(width, style, false).literal(true);
+                let emoji_shortcodes = settings.tunables.message_shortcode_display;
+                let mut threaded = printer::TextPrinter::new(width, style, false, emoji_shortcodes).literal(true);
                 let len = Span::styled(len.to_string(), style.add_modifier(StyleModifier::BOLD));
                 threaded.push_str(" \u{2937} ", style);
                 threaded.push_span_nobreak(len);
@@ -929,11 +932,14 @@ impl Message {
         text
     }
 
-    pub fn show_msg(&self, width: usize, style: Style, hide_reply: bool) -> Text {
+    pub fn show_msg(&self, width: usize, style: Style, hide_reply: bool, emoji_shortcodes: bool) -> Text {
         if let Some(html) = &self.html {
-            html.to_text(width, style, hide_reply)
+            html.to_text(width, style, hide_reply, emoji_shortcodes)
         } else {
             let mut msg = self.event.body();
+            if emoji_shortcodes {
+                msg = Cow::Owned(replace_emojis_in_str(msg.as_ref()));
+            }
 
             if self.downloaded {
                 msg.to_mut().push_str(" \u{2705}");

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -12,7 +12,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::util::{
-    replace_emojis_in_line, replace_emojis_in_span, replace_emojis_in_str, space_span, take_width,
+    replace_emojis_in_line,
+    replace_emojis_in_span,
+    replace_emojis_in_str,
+    space_span,
+    take_width,
 };
 
 /// Wrap styled text for the current terminal width.

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -11,7 +11,9 @@ use ratatui::text::{Line, Span, Text};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use crate::util::{space_span, take_width};
+use crate::util::{
+    replace_emojis_in_line, replace_emojis_in_span, replace_emojis_in_str, space_span, take_width,
+};
 
 /// Wrap styled text for the current terminal width.
 pub struct TextPrinter<'a> {
@@ -19,6 +21,7 @@ pub struct TextPrinter<'a> {
     width: usize,
     base_style: Style,
     hide_reply: bool,
+    emoji_shortcodes: bool,
 
     alignment: Alignment,
     curr_spans: Vec<Span<'a>>,
@@ -28,12 +31,13 @@ pub struct TextPrinter<'a> {
 
 impl<'a> TextPrinter<'a> {
     /// Create a new printer.
-    pub fn new(width: usize, base_style: Style, hide_reply: bool) -> Self {
+    pub fn new(width: usize, base_style: Style, hide_reply: bool, emoji_shortcodes: bool) -> Self {
         TextPrinter {
             text: Text::default(),
             width,
             base_style,
             hide_reply,
+            emoji_shortcodes,
 
             alignment: Alignment::Left,
             curr_spans: vec![],
@@ -59,6 +63,11 @@ impl<'a> TextPrinter<'a> {
         self.hide_reply
     }
 
+    /// Indicates whether emojis should be replaced by shortcodes
+    pub fn emoji_shortcodes(&self) -> bool {
+        self.emoji_shortcodes
+    }
+
     /// Indicates the current printer's width.
     pub fn width(&self) -> usize {
         self.width
@@ -71,6 +80,7 @@ impl<'a> TextPrinter<'a> {
             width: self.width.saturating_sub(indent),
             base_style: self.base_style,
             hide_reply: self.hide_reply,
+            emoji_shortcodes: self.emoji_shortcodes,
 
             alignment: self.alignment,
             curr_spans: vec![],
@@ -164,7 +174,10 @@ impl<'a> TextPrinter<'a> {
     }
 
     /// Push a [Span] that isn't allowed to break across lines.
-    pub fn push_span_nobreak(&mut self, span: Span<'a>) {
+    pub fn push_span_nobreak(&mut self, mut span: Span<'a>) {
+        if self.emoji_shortcodes {
+            replace_emojis_in_span(&mut span);
+        }
         let sw = UnicodeWidthStr::width(span.content.as_ref());
 
         if self.curr_width + sw > self.width {
@@ -200,10 +213,15 @@ impl<'a> TextPrinter<'a> {
                 continue;
             }
 
-            let sw = UnicodeWidthStr::width(word);
+            let cow = if self.emoji_shortcodes {
+                Cow::Owned(replace_emojis_in_str(word))
+            } else {
+                Cow::Borrowed(word)
+            };
+            let sw = UnicodeWidthStr::width(cow.as_ref());
 
             if sw > self.width {
-                self.push_str_wrapped(word, style);
+                self.push_str_wrapped(cow, style);
                 continue;
             }
 
@@ -211,13 +229,13 @@ impl<'a> TextPrinter<'a> {
                 // Word doesn't fit on this line, so start a new one.
                 self.commit();
 
-                if !self.literal && word.chars().all(char::is_whitespace) {
+                if !self.literal && cow.chars().all(char::is_whitespace) {
                     // Drop leading whitespace.
                     continue;
                 }
             }
 
-            let span = Span::styled(word, style);
+            let span = Span::styled(cow, style);
             self.curr_spans.push(span);
             self.curr_width += sw;
         }
@@ -229,14 +247,22 @@ impl<'a> TextPrinter<'a> {
     }
 
     /// Push a [Line] into the printer.
-    pub fn push_line(&mut self, line: Line<'a>) {
+    pub fn push_line(&mut self, mut line: Line<'a>) {
         self.commit();
+        if self.emoji_shortcodes {
+            replace_emojis_in_line(&mut line);
+        }
         self.text.lines.push(line);
     }
 
     /// Push multiline [Text] into the printer.
-    pub fn push_text(&mut self, text: Text<'a>) {
+    pub fn push_text(&mut self, mut text: Text<'a>) {
         self.commit();
+        if self.emoji_shortcodes {
+            for line in &mut text.lines {
+                replace_emojis_in_line(line);
+            }
+        }
         self.text.lines.extend(text.lines);
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,6 +183,7 @@ pub fn mock_tunables() -> TunableValues {
     TunableValues {
         default_room: None,
         log_level: Level::INFO,
+        message_shortcode_display: false,
         reaction_display: true,
         reaction_shortcode_display: false,
         read_receipt_send: true,

--- a/src/util.rs
+++ b/src/util.rs
@@ -156,14 +156,14 @@ fn replace_emoji_in_grapheme(grapheme: &str) -> String {
 
 pub fn replace_emojis_in_str(s: &str) -> String {
     let graphemes = s.graphemes(true);
-    graphemes.map(|x| replace_emoji_in_grapheme(x)).collect()
+    graphemes.map(replace_emoji_in_grapheme).collect()
 }
 
-pub fn replace_emojis_in_span<'a>(span: &mut Span<'a>) {
+pub fn replace_emojis_in_span(span: &mut Span) {
     span.content = Cow::Owned(replace_emojis_in_str(span.content.as_ref()))
 }
 
-pub fn replace_emojis_in_line<'a>(line: &mut Line<'a>) {
+pub fn replace_emojis_in_line(line: &mut Line) {
     for span in &mut line.spans {
         replace_emojis_in_span(span);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -147,6 +147,28 @@ pub fn join_cell_text<'a>(texts: Vec<(Text<'a>, usize)>, join: Span<'a>, style: 
     text
 }
 
+fn replace_emoji_in_grapheme(grapheme: &str) -> String {
+    emojis::get(grapheme)
+        .and_then(|emoji| emoji.shortcode())
+        .map(|shortcode| format!(":{shortcode}:"))
+        .unwrap_or_else(|| grapheme.to_owned())
+}
+
+pub fn replace_emojis_in_str(s: &str) -> String {
+    let graphemes = s.graphemes(true);
+    graphemes.map(|x| replace_emoji_in_grapheme(x)).collect()
+}
+
+pub fn replace_emojis_in_span<'a>(span: &mut Span<'a>) {
+    span.content = Cow::Owned(replace_emojis_in_str(span.content.as_ref()))
+}
+
+pub fn replace_emojis_in_line<'a>(line: &mut Line<'a>) {
+    for span in &mut line.spans {
+        replace_emojis_in_span(span);
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;


### PR DESCRIPTION
The font in my terminal doesn't support most emoji characters and shows ugly placeholders instead. For reactions, there is the setting `reaction_shortcode_display` that allows me to see human-readable shortcodes instead of the emojis. However, for emojis in messages there is no such feature.

I added a new setting `message_shortcode_display` that controls whether shortcodes are displayed instead of emojis in messages.

Replacing emojis with shortcodes happens in `TextPrinter` (or, for plain text, in `Message::show_msg()`).

I hope the changes are alright. I'd be happy to improve the code further and I'd be grateful for some feedback as I'm not very experienced in Rust yet.