### PR TITLE
Support configuring user gutter width

### DIFF
--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -111,6 +111,10 @@ overridden as described in *PROFILES*.
 > *protocol.font_size* is an optional list of two numbers representing font
 > width and height in pixels.
 
+**user_gutter_width** (type: usize)
+> Specify the width of the column where usernames are displayed in a room.
+> Usernames that are too long are truncated.
+
 ## USER OVERRIDES
 
 Overrides are mapped onto matrix User IDs such as _@user:matrix.org_ and are

--- a/src/config.rs
+++ b/src/config.rs
@@ -485,6 +485,7 @@ pub struct TunableValues {
     pub open_command: Option<Vec<String>>,
     pub notifications: Notifications,
     pub image_preview: Option<ImagePreviewValues>,
+    pub user_gutter_width: usize,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -507,6 +508,7 @@ pub struct Tunables {
     pub open_command: Option<Vec<String>>,
     pub notifications: Option<Notifications>,
     pub image_preview: Option<ImagePreview>,
+    pub user_gutter_width: Option<usize>,
 }
 
 impl Tunables {
@@ -533,6 +535,7 @@ impl Tunables {
             open_command: self.open_command.or(other.open_command),
             notifications: self.notifications.or(other.notifications),
             image_preview: self.image_preview.or(other.image_preview),
+            user_gutter_width: self.user_gutter_width.or(other.user_gutter_width),
         }
     }
 
@@ -555,6 +558,7 @@ impl Tunables {
             open_command: self.open_command,
             notifications: self.notifications.unwrap_or_default(),
             image_preview: self.image_preview.map(ImagePreview::values),
+            user_gutter_width: self.user_gutter_width.unwrap_or(30 as usize),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,7 +558,7 @@ impl Tunables {
             open_command: self.open_command,
             notifications: self.notifications.unwrap_or_default(),
             image_preview: self.image_preview.map(ImagePreview::values),
-            user_gutter_width: self.user_gutter_width.unwrap_or(30 as usize),
+            user_gutter_width: self.user_gutter_width.unwrap_or(30),
         }
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -575,7 +575,7 @@ impl<'a> MessageFormatter<'a> {
         let user_gutter_empty = std::iter::repeat(' ')
             .take(self.settings.tunables.user_gutter_width)
             .collect::<String>();
-        let user_gutter_empty_span: Span<'a> = Span::raw(user_gutter_empty);
+        let user_gutter_empty_span = space_span(self.settings.tunables.user_gutter_width, Style::default());
 
         match self.cols {
             MessageColumns::Four => {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -572,9 +572,6 @@ impl<'a> MessageFormatter<'a> {
             text.lines.push(Line::from(vec![leading, date, trailing]));
         }
 
-        let user_gutter_empty = std::iter::repeat(' ')
-            .take(self.settings.tunables.user_gutter_width)
-            .collect::<String>();
         let user_gutter_empty_span = space_span(self.settings.tunables.user_gutter_width, Style::default());
 
         match self.cols {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -572,7 +572,8 @@ impl<'a> MessageFormatter<'a> {
             text.lines.push(Line::from(vec![leading, date, trailing]));
         }
 
-        let user_gutter_empty_span = space_span(self.settings.tunables.user_gutter_width, Style::default());
+        let user_gutter_empty_span =
+            space_span(self.settings.tunables.user_gutter_width, Style::default());
 
         match self.cols {
             MessageColumns::Four => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -203,6 +203,7 @@ pub fn mock_tunables() -> TunableValues {
         message_user_color: false,
         notifications: Notifications { enabled: false, show_message: None },
         image_preview: None,
+        user_gutter_width: 30,
     }
 }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1352,7 +1352,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
             let txt = item.show(prev, foc && sel, &state.viewctx, info, settings);
 
             let mut msg_preview = if picker.is_some() {
-                item.line_preview(prev, &state.viewctx, info)
+                item.line_preview(prev, &state.viewctx, info, settings)
             } else {
                 None
             };


### PR DESCRIPTION
I found the user gutter too wide by default, especially when using localpart or display name for usernames so i made it configurable. Seems to work fine but I'm not a rustacean so there is perhaps a more idiomatic way to do this.