### PR TITLE
Fix entering thread view when there's no messages yet

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ use tracing::Level;
 use url::Url;
 
 use crate::{
-    base::{ChatStore, EventLocation, ProgramStore, RoomFetchStatus, RoomInfo},
+    base::{ChatStore, EventLocation, ProgramStore, RoomInfo},
     config::{
         user_color,
         user_style_from_color,
@@ -148,25 +148,11 @@ pub fn mock_messages() -> Messages {
 }
 
 pub fn mock_room() -> RoomInfo {
-    RoomInfo {
-        name: Some("Watercooler Discussion".into()),
-        tags: None,
-
-        keys: mock_keys(),
-        messages: mock_messages(),
-        threads: HashMap::default(),
-
-        event_receipts: HashMap::new(),
-        user_receipts: HashMap::new(),
-        reactions: HashMap::new(),
-
-        fetching: false,
-        fetch_id: RoomFetchStatus::NotStarted,
-        fetch_last: None,
-        users_typing: None,
-        display_names: HashMap::new(),
-        draw_last: None,
-    }
+    let mut room = RoomInfo::default();
+    room.name = Some("Watercooler Discussion".into());
+    room.keys = mock_keys();
+    *room.get_thread_mut(None) = mock_messages();
+    room
 }
 
 pub fn mock_dirs() -> DirectoryValues {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -52,7 +52,7 @@ use matrix_sdk::{
                 member::OriginalSyncRoomMemberEvent,
                 message::{MessageType, RoomMessageEventContent},
                 name::RoomNameEventContent,
-                redaction::{OriginalSyncRoomRedactionEvent, SyncRoomRedactionEvent},
+                redaction::OriginalSyncRoomRedactionEvent,
             },
             tag::Tags,
             typing::SyncTypingEvent,
@@ -93,7 +93,6 @@ use crate::{
         ChatStore,
         CreateRoomFlags,
         CreateRoomType,
-        EventLocation,
         IambError,
         IambResult,
         ProgramStore,
@@ -1063,35 +1062,7 @@ impl ClientWorker {
 
                     let mut locked = store.lock().await;
                     let info = locked.application.get_room_info(room_id.to_owned());
-
-                    let Some(redacts) = &ev.redacts else {
-                        return;
-                    };
-
-                    match info.keys.get(redacts) {
-                        None => return,
-                        Some(EventLocation::Message(None, key)) => {
-                            if let Some(msg) = info.messages.get_mut(key) {
-                                let ev = SyncRoomRedactionEvent::Original(ev);
-                                msg.redact(ev, room_version);
-                            }
-                        },
-                        Some(EventLocation::Message(Some(root), key)) => {
-                            if let Some(thread) = info.threads.get_mut(root) {
-                                if let Some(msg) = thread.get_mut(key) {
-                                    let ev = SyncRoomRedactionEvent::Original(ev);
-                                    msg.redact(ev, room_version);
-                                }
-                            }
-                        },
-                        Some(EventLocation::Reaction(event_id)) => {
-                            if let Some(reactions) = info.reactions.get_mut(event_id) {
-                                reactions.remove(redacts);
-                            }
-
-                            info.keys.remove(redacts);
-                        },
-                    }
+                    info.redact(ev, room_version);
                 }
             },
         );


### PR DESCRIPTION
#152 defaulted to showing the non-thread messages when trying to enter a brand-new thread, which is confusing. The `ScrollbackState::get_thread` method should return an `Option` when there's nothing to view.

I've also refactored `Message::show` to make it easier to follow now that it's also got the thread count logic.