### PR TITLE
Fix image previews in replies

### DIFF
--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1292,7 +1292,6 @@ impl<'a> StatefulWidget for Scrollback<'a> {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let info = self.store.application.rooms.get_or_default(state.room_id.clone());
         let settings = &self.store.application.settings;
-        let picker = &self.store.application.picker;
         let area = if state.cursor.timestamp.is_some() {
             render_jump_to_recent(area, buf, self.focused)
         } else {
@@ -1343,13 +1342,8 @@ impl<'a> StatefulWidget for Scrollback<'a> {
 
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
-            let txt = item.show(prev, foc && sel, &state.viewctx, info, settings);
-
-            let mut msg_preview = if picker.is_some() {
-                item.line_preview(prev, &state.viewctx, info, settings)
-            } else {
-                None
-            };
+            let (txt, mut msg_preview) =
+                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
 
             let incomplete_ok = !full || !sel;
 


### PR DESCRIPTION
If an image preview is in a reply to a multiline message then the offset it's displayed at is wrong. This moves the logic for calculating it into `show_with_preview` where it can be done together with calculating the image text. 