### PR TITLE
Enable autolinking when rendering Markdown

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -129,6 +129,7 @@ const TIME_GUTTER_EMPTY_SPAN: Span<'static> = span_static(TIME_GUTTER_EMPTY);
 
 fn text_to_message_content(input: String) -> TextMessageEventContent {
     let mut options = ComrakOptions::default();
+    options.extension.autolink = true;
     options.extension.shortcodes = true;
     options.extension.strikethrough = true;
     options.render.hardbreaks = true;
@@ -1233,6 +1234,33 @@ pub mod tests {
 
         // MessageCursor::latest() should point at the most recent message after conversion.
         assert_eq!(identity(&mc6), mc1);
+    }
+
+    #[test]
+    fn test_markdown_autolink() {
+        let input = "http://example.com\n";
+        let content = text_to_message_content(input.into());
+        assert_eq!(content.body, input);
+        assert_eq!(
+            content.formatted.unwrap().body,
+            "<p><a href=\"http://example.com\">http://example.com</a></p>\n"
+        );
+
+        let input = "www.example.com\n";
+        let content = text_to_message_content(input.into());
+        assert_eq!(content.body, input);
+        assert_eq!(
+            content.formatted.unwrap().body,
+            "<p><a href=\"http://www.example.com\">www.example.com</a></p>\n"
+        );
+
+        let input = "See docs (they're at https://iamb.chat)\n";
+        let content = text_to_message_content(input.into());
+        assert_eq!(content.body, input);
+        assert_eq!(
+            content.formatted.unwrap().body,
+            "<p>See docs (they're at <a href=\"https://iamb.chat\">https://iamb.chat</a>)</p>\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
It would be nice to have `http[s]://` links automatically linked without always having to do the `<https://...>` syntax.