### PR TITLE
Support notifications via terminal bell

### DIFF
--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -93,6 +93,7 @@ overridden as described in *PROFILES*.
 > Configures push-notifications, which are delivered as desktop 
 > notifications if available.
 > *enabled* `true` to enable the feature, defaults to `false`.
+> *via* `"desktop"` to use desktop mechanism, or `"bell"` to use terminal bell.
 > *show_message* to show the message in the desktop notification. Defaults
 > to `true`. Messages are truncated beyond a small length.
 > The notification _rules_ are stored server side, loaded once at startup,

--- a/docs/iamb.5.md
+++ b/docs/iamb.5.md
@@ -90,10 +90,10 @@ overridden as described in *PROFILES*.
 > Defines whether or not the message body is colored like the username.
 
 **notifications** (type: notifications object)
-> Configures push-notifications, which are delivered as desktop 
-> notifications if available.
+> Configures push-notifications.
 > *enabled* `true` to enable the feature, defaults to `false`.
-> *via* `"desktop"` to use desktop mechanism, or `"bell"` to use terminal bell.
+> *via* `"desktop"` to use desktop mechanism (default), or `"bell"` to use
+> terminal bell.
 > *show_message* to show the message in the desktop notification. Defaults
 > to `true`. Messages are truncated beyond a small length.
 > The notification _rules_ are stored server side, loaded once at startup,

--- a/src/base.rs
+++ b/src/base.rs
@@ -1273,6 +1273,9 @@ pub struct ChatStore {
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
+
+    /// Whether to ring the terminal bell on the next redraw.
+    pub ring_bell: bool,
 }
 
 impl ChatStore {
@@ -1294,6 +1297,7 @@ impl ChatStore {
             need_load: Default::default(),
             sync_info: Default::default(),
             draw_curr: None,
+            ring_bell: false,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,10 @@ fn is_profile_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '.' || c == '-'
 }
 
+fn default_true() -> bool {
+    true
+}
+
 fn validate_profile_name(name: &str) -> bool {
     if name.is_empty() {
         return false;
@@ -391,10 +395,24 @@ pub enum UserDisplayStyle {
     DisplayName,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum NotifyVia {
+    /// Deliver notifications via terminal bell.
+    Bell,
+    /// Deliver notifications via desktop mechanism.
+    #[default]
+    Desktop,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 pub struct Notifications {
+    #[serde(default)]
     pub enabled: bool,
-    pub show_message: Option<bool>,
+    #[serde(default)]
+    pub via: NotifyVia,
+    #[serde(default = "default_true")]
+    pub show_message: bool,
 }
 
 #[derive(Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::fmt::Display;
 use std::fs::{create_dir_all, File};
-use std::io::{stdout, BufWriter, Stdout};
+use std::io::{stdout, BufWriter, Stdout, Write};
 use std::ops::DerefMut;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -292,6 +292,10 @@ impl Application {
         let focused = self.focused;
         let sstate = &mut self.screen;
         let term = &mut self.terminal;
+
+        if store.application.ring_bell {
+            store.application.ring_bell = term.backend_mut().write_all(&[7]).is_err();
+        }
 
         if full {
             term.clear()?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,6 +28,7 @@ use crate::{
         ApplicationSettings,
         DirectoryValues,
         Notifications,
+        NotifyVia,
         ProfileConfig,
         SortOverrides,
         TunableValues,
@@ -187,7 +188,11 @@ pub fn mock_tunables() -> TunableValues {
         open_command: None,
         username_display: UserDisplayStyle::Username,
         message_user_color: false,
-        notifications: Notifications { enabled: false, show_message: None },
+        notifications: Notifications {
+            enabled: false,
+            via: NotifyVia::Desktop,
+            show_message: true,
+        },
         image_preview: None,
         user_gutter_width: 30,
     }


### PR DESCRIPTION
This adds a `via` field to the `notifications` object that allows configuring whether to send notifications using the desktop mechanism (`"desktop"`, the default), or the terminal bell (`"bell"`).