### PR TITLE
Reset message bar when `!` is passed with :cancel

### DIFF
--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -185,12 +185,14 @@ impl ChatState {
 
         match act {
             MessageAction::Cancel(skip_confirm) => {
-                self.reply_to = None;
-                self.editing = None;
-
                 if skip_confirm {
+                    self.reset();
+
                     return Ok(None);
                 }
+
+                self.reply_to = None;
+                self.editing = None;
 
                 let msg = "Would you like to clear the message bar?";
                 let act = PromptAction::Abort(false);


### PR DESCRIPTION
Adding a `!` to `:cancel` should do the same behaviour as running `:cancel` and typing `y` just like `!` does with other commands.