### PR TITLE
Wait to log in before starting background tasks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -866,6 +866,7 @@ async fn login_normal(
 ) -> IambResult<()> {
     println!("* Logging in for {}...", settings.profile.user_id);
     login(worker, settings).await?;
+    println!("* Syncing...");
     worker::do_first_sync(&worker.client, store)
         .await
         .map_err(IambError::from)?;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1217,6 +1217,10 @@ impl ClientWorker {
             let settings = self.settings.clone();
 
             async move {
+                while !client.logged_in() {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+
                 let load = load_older_forever(&client, &store);
                 let rcpt = send_receipts_forever(&client, &store);
                 let room = refresh_rooms_forever(&client, &store);


### PR DESCRIPTION
There seems to be a race where sometimes the client crashes on the `client.notification_settings().await` call because the client isn't logged in yet. All of the background refresh/notification tasks can just until the client is successfully logged in before doing anything.  