### PR TITLE
Use color overrides for users when `message_user_color` is enabled

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -912,15 +912,16 @@ impl ApplicationSettings {
             .unwrap_or_default()
     }
 
-    pub fn get_user_style(&self, user_id: &UserId) -> Style {
-        let color = self
-            .tunables
+    pub fn get_user_color(&self, user_id: &UserId) -> Color {
+        self.tunables
             .users
             .get(user_id)
             .and_then(|user| user.color.as_ref().map(|c| c.0))
-            .unwrap_or_else(|| user_color(user_id.as_str()));
+            .unwrap_or_else(|| user_color(user_id.as_str()))
+    }
 
-        user_style_from_color(color)
+    pub fn get_user_style(&self, user_id: &UserId) -> Style {
+        user_style_from_color(self.get_user_color(user_id))
     }
 
     pub fn get_user_span<'a>(&self, user_id: &'a UserId, info: &'a RoomInfo) -> Span<'a> {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -863,7 +863,7 @@ impl Message {
         }
 
         if settings.tunables.message_user_color {
-            let color = crate::config::user_color(self.sender.as_str());
+            let color = settings.get_user_color(&self.sender);
             style = style.fg(color);
         }
 


### PR DESCRIPTION
This fixes #243 by adding a method to get the user color override or the default when there isn't one from `ApplicationSettings`.