### PR TITLE
Add `external_edit_file_suffix` to config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,7 @@ url = "https://matrix.org"
 
 [settings]
 default_room = "#iamb-users:0x.badd.cafe"
+external_edit_file_suffix = ".md"
 log_level = "warn"
 message_shortcode_display = false
 open_command = ["my-open", "--file"]

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,7 +126,7 @@ key and can be overridden as described in
 .Bl -tag -width Ds
 
 .It Sy external_edit_file_suffix
-An optional suffix to append to temporary files when using the editor command.
+An optional suffix to append to temporary files when using the :editor command.
 
 .It Sy default_room
 The room to show by default instead of the

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -125,6 +125,9 @@ key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
 
+.It Sy external_edit_file_suffix
+An optional suffix to append to temporary files when using the editor command.
+
 .It Sy default_room
 The room to show by default instead of the
 .Sy :welcome

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,7 +126,7 @@ key and can be overridden as described in
 .Bl -tag -width Ds
 
 .It Sy external_edit_file_suffix
-An optional suffix to append to temporary file names when using the :editor command.
+Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 
 .It Sy default_room
 The room to show by default instead of the

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,7 +126,7 @@ key and can be overridden as described in
 .Bl -tag -width Ds
 
 .It Sy external_edit_file_suffix
-An optional suffix to append to temporary files when using the :editor command.
+An optional suffix to append to temporary file names when using the :editor command.
 
 .It Sy default_room
 The room to show by default instead of the

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,9 +559,11 @@ impl Tunables {
             notifications: self.notifications.or(other.notifications),
             image_preview: self.image_preview.or(other.image_preview),
             user_gutter_width: self.user_gutter_width.or(other.user_gutter_width),
-            external_edit_file_suffix: self
-                .external_edit_file_suffix
-                .or(other.external_edit_file_suffix),
+            external_edit_file_suffix: Some(
+                self.external_edit_file_suffix
+                    .or(other.external_edit_file_suffix)
+                    .unwrap_or_else(|| ".md".to_string()),
+            ),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,7 +507,7 @@ pub struct TunableValues {
     pub notifications: Notifications,
     pub image_preview: Option<ImagePreviewValues>,
     pub user_gutter_width: usize,
-    pub external_edit_file_suffix: Option<String>,
+    pub external_edit_file_suffix: String,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -559,11 +559,9 @@ impl Tunables {
             notifications: self.notifications.or(other.notifications),
             image_preview: self.image_preview.or(other.image_preview),
             user_gutter_width: self.user_gutter_width.or(other.user_gutter_width),
-            external_edit_file_suffix: Some(
-                self.external_edit_file_suffix
-                    .or(other.external_edit_file_suffix)
-                    .unwrap_or_else(|| ".md".to_string()),
-            ),
+            external_edit_file_suffix: self
+                .external_edit_file_suffix
+                .or(other.external_edit_file_suffix),
         }
     }
 
@@ -587,7 +585,9 @@ impl Tunables {
             notifications: self.notifications.unwrap_or_default(),
             image_preview: self.image_preview.map(ImagePreview::values),
             user_gutter_width: self.user_gutter_width.unwrap_or(30),
-            external_edit_file_suffix: self.external_edit_file_suffix,
+            external_edit_file_suffix: self
+                .external_edit_file_suffix
+                .unwrap_or_else(|| ".md".to_string()),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,9 @@ const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 4] = [
 
 const DEFAULT_REQ_TIMEOUT: u64 = 120;
 
+//const DEFAULT_EXT_EDIT_FILE_SUFFIX: Option<String> = Some(".txt".to_string());
+//const DEFAULT_EXT_EDIT_FILE_SUFFIX: String = ".txt".to_string();
+
 const COLORS: [Color; 13] = [
     Color::Blue,
     Color::Cyan,
@@ -507,6 +510,7 @@ pub struct TunableValues {
     pub notifications: Notifications,
     pub image_preview: Option<ImagePreviewValues>,
     pub user_gutter_width: usize,
+    pub external_edit_file_suffix: Option<String>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -530,6 +534,7 @@ pub struct Tunables {
     pub notifications: Option<Notifications>,
     pub image_preview: Option<ImagePreview>,
     pub user_gutter_width: Option<usize>,
+    pub external_edit_file_suffix: Option<String>,
 }
 
 impl Tunables {
@@ -557,6 +562,8 @@ impl Tunables {
             notifications: self.notifications.or(other.notifications),
             image_preview: self.image_preview.or(other.image_preview),
             user_gutter_width: self.user_gutter_width.or(other.user_gutter_width),
+            external_edit_file_suffix: self.external_edit_file_suffix.or(other.external_edit_file_suffix),
+                    
         }
     }
 
@@ -580,6 +587,9 @@ impl Tunables {
             notifications: self.notifications.unwrap_or_default(),
             image_preview: self.image_preview.map(ImagePreview::values),
             user_gutter_width: self.user_gutter_width.unwrap_or(30),
+            //external_edit_file_suffix: self.external_edit_file_suffix.unwrap_or(DEFAULT_EXT_EDIT_FILE_SUFFIX),
+            //external_edit_file_suffix: self.external_edit_file_suffix.unwrap_or_else(|| DEFAULT_EXT_EDIT_FILE_SUFFIX.unwrap()),
+            external_edit_file_suffix: self.external_edit_file_suffix,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,8 +559,9 @@ impl Tunables {
             notifications: self.notifications.or(other.notifications),
             image_preview: self.image_preview.or(other.image_preview),
             user_gutter_width: self.user_gutter_width.or(other.user_gutter_width),
-            external_edit_file_suffix: self.external_edit_file_suffix.or(other.external_edit_file_suffix),
-                    
+            external_edit_file_suffix: self
+                .external_edit_file_suffix
+                .or(other.external_edit_file_suffix),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,9 +54,6 @@ const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 4] = [
 
 const DEFAULT_REQ_TIMEOUT: u64 = 120;
 
-//const DEFAULT_EXT_EDIT_FILE_SUFFIX: Option<String> = Some(".txt".to_string());
-//const DEFAULT_EXT_EDIT_FILE_SUFFIX: String = ".txt".to_string();
-
 const COLORS: [Color; 13] = [
     Color::Blue,
     Color::Cyan,
@@ -587,8 +584,6 @@ impl Tunables {
             notifications: self.notifications.unwrap_or_default(),
             image_preview: self.image_preview.map(ImagePreview::values),
             user_gutter_width: self.user_gutter_width.unwrap_or(30),
-            //external_edit_file_suffix: self.external_edit_file_suffix.unwrap_or(DEFAULT_EXT_EDIT_FILE_SUFFIX),
-            //external_edit_file_suffix: self.external_edit_file_suffix.unwrap_or_else(|| DEFAULT_EXT_EDIT_FILE_SUFFIX.unwrap()),
             external_edit_file_suffix: self.external_edit_file_suffix,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -186,7 +186,7 @@ pub fn mock_tunables() -> TunableValues {
         .into_iter()
         .collect::<HashMap<_, _>>(),
         open_command: None,
-        external_edit_file_suffix: None,
+        external_edit_file_suffix: String::from(".md"),
         username_display: UserDisplayStyle::Username,
         message_user_color: false,
         notifications: Notifications {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -186,6 +186,7 @@ pub fn mock_tunables() -> TunableValues {
         .into_iter()
         .collect::<HashMap<_, _>>(),
         open_command: None,
+        external_edit_file_suffix: None,
         username_display: UserDisplayStyle::Username,
         message_user_color: false,
         notifications: Notifications {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -482,7 +482,6 @@ impl ChatState {
                 let msg = self.tbox.get();
 
                 let msg = if let SendAction::SubmitFromEditor = act {
-                    //let suffix = store.application.settings.tunables.external_edit_file_suffix.as_ref().map(|s| s.as_str()).unwrap_or_default();
                     let suffix = store
                         .application
                         .settings

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -482,13 +482,8 @@ impl ChatState {
                 let msg = self.tbox.get();
 
                 let msg = if let SendAction::SubmitFromEditor = act {
-                    let suffix = store
-                        .application
-                        .settings
-                        .tunables
-                        .external_edit_file_suffix
-                        .as_deref()
-                        .unwrap_or_default();
+                    let suffix =
+                        store.application.settings.tunables.external_edit_file_suffix.as_str();
                     external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
                 } else if msg.is_blank() {
                     return Ok(None);

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -482,10 +482,15 @@ impl ChatState {
                 let msg = self.tbox.get();
 
                 let msg = if let SendAction::SubmitFromEditor = act {
-
-                    let suffix = store.application.settings.tunables.external_edit_file_suffix.as_ref().map(|s| s.as_str()).unwrap_or_default();
+                    //let suffix = store.application.settings.tunables.external_edit_file_suffix.as_ref().map(|s| s.as_str()).unwrap_or_default();
+                    let suffix = store
+                        .application
+                        .settings
+                        .tunables
+                        .external_edit_file_suffix
+                        .as_deref()
+                        .unwrap_or_default();
                     external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
-                
                 } else if msg.is_blank() {
                     return Ok(None);
                 } else {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -5,7 +5,8 @@ use std::fs;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use edit::edit as external_edit;
+use edit::edit_with_builder as external_edit;
+use edit::Builder;
 use modalkit::editing::store::RegisterError;
 use std::process::Command;
 use tokio;
@@ -481,7 +482,11 @@ impl ChatState {
                 let msg = self.tbox.get();
 
                 let msg = if let SendAction::SubmitFromEditor = act {
-                    external_edit(msg.trim_end().to_string())?
+
+                    let suffix = store.application.settings.tunables.external_edit_file_suffix.as_ref().map(|s| s.as_str()).unwrap_or_default();
+                    //external_edit(msg.trim_end().to_string(), Builder::new().suffix(""))?
+                    external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
+                
                 } else if msg.is_blank() {
                     return Ok(None);
                 } else {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -484,7 +484,6 @@ impl ChatState {
                 let msg = if let SendAction::SubmitFromEditor = act {
 
                     let suffix = store.application.settings.tunables.external_edit_file_suffix.as_ref().map(|s| s.as_str()).unwrap_or_default();
-                    //external_edit(msg.trim_end().to_string(), Builder::new().suffix(""))?
                     external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
                 
                 } else if msg.is_blank() {


### PR DESCRIPTION
When using the `editor` command in iamb, the temporary file currently has no file extension. This is probably a reasonable default behavior, but some users may want to hint to their editor a particular file type such as `.md` or `.txt` to make use of linters, formatters, spell checkers, or other file type specific editor configurations.

This PR ~~preserves the default behavior~~ sets the default suffix to `.md` while adding a `external_edit_file_suffix` configuration option which accepts a string to append to the end of the temporary file name passed to the users editor.