### PR TITLE
Fix image preview placement when messages are preceded by a date in the timeline

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -961,6 +961,8 @@ impl Message {
         let proto = proto.map(|p| {
             let y_off = text.lines.len() as u16;
             let x_off = fmt.cols.user_gutter_width(settings);
+            // Adjust y_off by 1 if a date was printed before the message to account for the extra line.
+            let y_off = if fmt.date.is_some() { y_off + 1 } else { y_off };
             (p, x_off, y_off)
         });
 


### PR DESCRIPTION
Currently image previews are printed one line too high if the message had a date inserted into it indicating a change of date between the current and preceding message. With this PR we conditionally check if a date was inserted and adjust the y offset used to place the rendered the image.

Tested in: `XTerm(374)`, `wezterm 20240203-110809-5046fc22`, and `konsole 24.02.1`.

Before change:
<img width="592" alt="before change" src="https://github.com/ulyssa/iamb/assets/1653607/20faa265-b666-4019-9963-b68a1fd2d03e">

After change:
<img width="586" alt="after" src="https://github.com/ulyssa/iamb/assets/1653607/2a62c458-5c0b-468d-aaf1-e034421422b9">
