### PR TITLE
Make export from sled to sqlite a build feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ build = "build.rs"
 
 [features]
 default = ["bundled"]
+sled-export = ["dep:temp-dir", "dep:sled"]
 bundled = ["matrix-sdk/bundled-sqlite", "rustls-tls"]
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
@@ -50,8 +51,8 @@ regex = "^1.5"
 rpassword = "^7.2"
 serde = "^1.0"
 serde_json = "^1.0"
-sled = "0.34.7"
-temp-dir = "0.1.12"
+sled = { version = "0.34.7", optional = true }
+temp-dir = { version = "0.1.12", optional = true }
 thiserror = "^1.0.37"
 toml = "^0.8.12"
 tracing = "~0.1.36"

--- a/src/base.rs
+++ b/src/base.rs
@@ -608,6 +608,7 @@ pub enum IambError {
     FailedKeyImport(#[from] matrix_sdk::encryption::RoomKeyImportError),
 
     /// A failure related to the cryptographic store.
+    #[cfg(feature = "sled-export")]
     #[error("Cannot export keys from sled: {0}")]
     UpgradeSled(#[from] crate::sled_export::SledMigrationError),
 
@@ -619,7 +620,7 @@ pub enum IambError {
     #[error("Matrix client error: {0}")]
     Matrix(#[from] matrix_sdk::Error),
 
-    /// A failure in the sled storage.
+    /// A failure in the storage.
     #[error("Matrix client storage error: {0}")]
     Store(#[from] matrix_sdk::StoreError),
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -748,6 +748,7 @@ pub struct ApplicationSettings {
     pub layout_json: PathBuf,
     pub session_json: PathBuf,
     pub session_json_old: PathBuf,
+    #[cfg(feature = "sled-export")]
     pub sled_dir: PathBuf,
     pub sqlite_dir: PathBuf,
     pub profile_name: String,
@@ -836,7 +837,9 @@ impl ApplicationSettings {
         profile_data_dir.push("profiles");
         profile_data_dir.push(profile_name.as_str());
 
+        #[cfg(feature = "sled-export")]
         let mut sled_dir = profile_dir.clone();
+        #[cfg(feature = "sled-export")]
         sled_dir.push("matrix");
 
         let mut sqlite_dir = profile_data_dir.clone();
@@ -857,6 +860,7 @@ impl ApplicationSettings {
         layout_json.push("layout.json");
 
         let settings = ApplicationSettings {
+            #[cfg(feature = "sled-export")]
             sled_dir,
             layout_json,
             session_json,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -204,6 +204,7 @@ pub fn mock_settings() -> ApplicationSettings {
         layout_json: PathBuf::new(),
         session_json: PathBuf::new(),
         session_json_old: PathBuf::new(),
+        #[cfg(feature = "sled-export")]
         sled_dir: PathBuf::new(),
         sqlite_dir: PathBuf::new(),
 


### PR DESCRIPTION
Hi 👋,
By making the sled export as a feature, this reduce compile time / dependencies for user that don't need it.
This also make the start a little bit faster as it don't check if this is the old sled backend...
This is mainly usefull for source based distro that have options like gentoo or derivative (don't know about nix but i suppose there is something similar).