### PR TITLE
Allow typing newline with `<S-Enter>` and enable keyboard enhancement protocol

### DIFF
--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -3,13 +3,13 @@
 //! The keybindings are set up here. We define some iamb-specific keybindings, but the default Vim
 //! keys come from [modalkit::env::vim::keybindings].
 use modalkit::{
-    actions::{MacroAction, WindowAction},
+    actions::{InsertTextAction, MacroAction, WindowAction},
     env::vim::keybindings::{InputStep, VimBindings},
     env::vim::VimMode,
     env::CommonKeyClass,
     key::TerminalKey,
     keybindings::{EdgeEvent, EdgeRepeat, InputBindings},
-    prelude::Count,
+    prelude::*,
 };
 
 use crate::base::{IambAction, IambInfo, Keybindings, MATRIX_ID_WORD};
@@ -36,6 +36,7 @@ pub fn setup_keybindings() -> Keybindings {
     let ctrl_z = "<C-Z>".parse::<TerminalKey>().unwrap();
     let key_m_lc = "m".parse::<TerminalKey>().unwrap();
     let key_z_lc = "z".parse::<TerminalKey>().unwrap();
+    let shift_enter = "<S-Enter>".parse::<TerminalKey>().unwrap();
 
     let cwz = vec![once(&ctrl_w), once(&key_z_lc)];
     let cwcz = vec![once(&ctrl_w), once(&ctrl_z)];
@@ -57,6 +58,17 @@ pub fn setup_keybindings() -> Keybindings {
     ism.add_mapping(VimMode::Visual, &cwm, &stoggle);
     ism.add_mapping(VimMode::Normal, &cwcm, &stoggle);
     ism.add_mapping(VimMode::Visual, &cwcm, &stoggle);
+
+    let shift_enter = vec![once(&shift_enter)];
+    let newline = IambStep::new().actions(vec![InsertTextAction::Type(
+        Char::Single('\n').into(),
+        MoveDir1D::Previous,
+        1.into(),
+    )
+    .into()]);
+    ism.add_mapping(VimMode::Insert, &cwm, &newline);
+    ism.add_mapping(VimMode::Insert, &shift_enter, &newline);
+
     ism
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,9 @@ use modalkit::crossterm::{
         EnableFocusChange,
         Event,
         KeyEventKind,
+        KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, SetTitle},
@@ -250,16 +253,7 @@ impl Application {
         settings: ApplicationSettings,
         store: AsyncProgramStore,
     ) -> IambResult<Application> {
-        let mut stdout = stdout();
-        crossterm::terminal::enable_raw_mode()?;
-        crossterm::execute!(stdout, EnterAlternateScreen)?;
-        crossterm::execute!(stdout, EnableBracketedPaste)?;
-        crossterm::execute!(stdout, EnableFocusChange)?;
-
-        let title = format!("iamb ({})", settings.profile.user_id);
-        crossterm::execute!(stdout, SetTitle(title))?;
-
-        let backend = CrosstermBackend::new(stdout);
+        let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend)?;
 
         let mut bindings = crate::keybindings::setup_keybindings();
@@ -905,6 +899,70 @@ async fn login_normal(
     Ok(())
 }
 
+struct EnableModifyOtherKeys;
+struct DisableModifyOtherKeys;
+
+impl crossterm::Command for EnableModifyOtherKeys {
+    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
+        write!(f, "\x1B[>4;2m")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl crossterm::Command for DisableModifyOtherKeys {
+    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
+        write!(f, "\x1B[>4;0m")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Set up the terminal for drawing the TUI, and getting additional info.
+fn setup_tty(title: &str, enable_enhanced_keys: bool) -> std::io::Result<()> {
+    let title = format!("iamb ({})", title);
+
+    // Enable raw mode and enter the alternate screen.
+    crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(stdout(), EnterAlternateScreen)?;
+
+    if enable_enhanced_keys {
+        // Enable the Kitty keyboard enhancement protocol for improved keypresses.
+        crossterm::queue!(
+            stdout(),
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )?;
+    } else {
+        crossterm::queue!(stdout(), EnableModifyOtherKeys)?;
+    }
+
+    crossterm::execute!(stdout(), EnableBracketedPaste, EnableFocusChange, SetTitle(title))
+}
+
+// Do our best to reverse what we did in setup_tty() when we exit or crash.
+fn restore_tty(enable_enhanced_keys: bool) {
+    if enable_enhanced_keys {
+        let _ = crossterm::queue!(stdout(), PopKeyboardEnhancementFlags);
+    }
+
+    let _ = crossterm::execute!(
+        stdout(),
+        DisableModifyOtherKeys,
+        DisableBracketedPaste,
+        DisableFocusChange,
+        LeaveAlternateScreen,
+        CursorShow,
+    );
+
+    let _ = crossterm::terminal::disable_raw_mode();
+}
+
 async fn run(settings: ApplicationSettings) -> IambResult<()> {
     // Get old keys the first time we run w/ the upgraded SDK.
     let import_keys = check_import_keys(&settings).await?;
@@ -938,27 +996,30 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
         Ok(()) => (),
     }
 
-    fn restore_tty() {
-        let _ = crossterm::terminal::disable_raw_mode();
-        let _ = crossterm::execute!(stdout(), DisableBracketedPaste);
-        let _ = crossterm::execute!(stdout(), DisableFocusChange);
-        let _ = crossterm::execute!(stdout(), LeaveAlternateScreen);
-        let _ = crossterm::execute!(stdout(), CursorShow);
-    }
+    // Set up the terminal for drawing, and cleanup properly on panics.
+    let enable_enhanced_keys = match crossterm::terminal::supports_keyboard_enhancement() {
+        Ok(supported) => supported,
+        Err(e) => {
+            tracing::warn!(err = %e,
+               "Failed to determine whether the terminal supports keyboard enhancements");
+            false
+        },
+    };
+    setup_tty(settings.profile.user_id.as_str(), enable_enhanced_keys)?;
 
-    // Make sure panics clean up the terminal properly.
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        restore_tty();
+        restore_tty(enable_enhanced_keys);
         orig_hook(panic_info);
         process::exit(1);
     }));
 
+    // And finally, start running the terminal UI.
     let mut application = Application::new(settings, store).await?;
-
-    // We can now run the application.
     application.run().await?;
-    restore_tty();
+
+    // Clean up the terminal on exit.
+    restore_tty(enable_enhanced_keys);
 
     Ok(())
 }


### PR DESCRIPTION
This fixes #271 (and #255 in the right terminals) by enabling the Kitty keyboard enhancement protocol. In order to benefit from this, you'll need to be using a terminal that supports one of:

- The Kitty [keyboard enhancement protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) :
    - [alacritty](https://github.com/alacritty/alacritty/)
    - [foot](https://codeberg.org/dnkl/foot)
    - [kitty](https://sw.kovidgoyal.net/kitty/)
    - [rio](https://github.com/raphamorim/rio/)
    - [wezterm](https://wezfurlong.org/wezterm/)
- [Enabling the key sequence](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-gt-Pp;Pv-m.1EB3) for the xterm-style [`modifyOtherKeys`](https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys):
    - [xterm](https://invisible-island.net/xterm/)
    - [mlterm](https://github.com/arakiken/mlterm)
    - [iTerm2](https://iterm2.com/) (requires enabling Profiles > Keys > xterm control sequence can enable modifyOtherKeys mode)
    - Possibly others, but tracking down who does or doesn't have support for this one is harder than I would have thought! 
- A terminal that uses WinAPI to send keypresses
    - [Windows Terminal](https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-US&gl=US)
    - [ConEmu](https://conemu.github.io/)

I'd like to put together a Terminal Recommendations page on the website to help people find terminals with support for image previews and improved keypress support. I'll probably include all of the above there in a table, with columns to show what they support.

Terminals I tried that don't support any way to represent Shift + Enter:

- deepin-terminal
- Eterm (also seems unable to handle unicode)
- gnome-terminal ([tracking issue](https://gitlab.gnome.org/GNOME/vte/-/issues/2601))
- konsole ([tracking issue](https://bugs.kde.org/show_bug.cgi?id=435975))
- lxterminal
- mate-terminal
- qterminal
- st
- sakura
- Terminal.app
- terminology (cursor is shown in the wrong place for some reason?)
- urxvt
- xfce4-terminal
- yakuake
- zutty
- WSL in Windows Terminal ([tracking issue](https://github.com/microsoft/terminal/issues/11509))

deepin-terminal, konsole, qterminal, and yakuake generate `SS3 M` when you press Shift + Enter, which crossterm doesn't currently parse, but from what I can tell should be parsed as a numpad `Enter`.
