### PR TITLE
Trim `:editor` output and check if it's empty

### DIFF
--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -484,7 +484,14 @@ impl ChatState {
                 let msg = if let SendAction::SubmitFromEditor = act {
                     let suffix =
                         store.application.settings.tunables.external_edit_file_suffix.as_str();
-                    external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
+                    let edited_msg =
+                        external_edit(msg.trim_end().to_string(), Builder::new().suffix(suffix))?
+                            .trim_end()
+                            .to_string();
+                    if edited_msg.is_empty() {
+                        return Ok(None);
+                    }
+                    edited_msg
                 } else if msg.is_blank() {
                     return Ok(None);
                 } else {


### PR DESCRIPTION
Hi,

Quick fix for #246 by trimming the editor output and checking if it's empty.