### PR TITLE
Add error for missing username on `:logout`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -515,6 +515,9 @@ fn iamb_open(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 fn iamb_logout(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     let args = desc.arg.strings()?;
 
+    if args.is_empty() {
+        return Result::Err(CommandError::Error("Missing username".to_string()));
+    }
     if args.len() != 1 {
         return Result::Err(CommandError::InvalidArgument);
     }


### PR DESCRIPTION
Adds error message if no argument is supplied.
Now `Failed command: Error: Missing username` is displayed if no username is given.

Did not remove username requirement for single account clients since different behavior depending on number of accounts could be confusing.

Fix for #268 