### PR TITLE
Display file sizes for attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,6 +2030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2104,7 @@ dependencies = [
  "futures",
  "gethostname",
  "html5ever",
+ "humansize",
  "image",
  "lazy_static 1.4.0",
  "libc",
@@ -2460,6 +2470,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ unicode-segmentation = "^1.7"
 unicode-width = "0.1.10"
 url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
+humansize = "2.0.0"
 
 [dependencies.modalkit]
 version = "0.0.19"

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -510,6 +510,27 @@ impl MessageEvent {
     }
 }
 
+/// Macro rule converting a File / Image / Audio / Video to its text content with the shape:
+/// `[Attached <type>: <content>[ (<human readable file size>)]]`
+macro_rules! display_file_to_text {
+    ( $msgtype:ident, $content:expr ) => {
+        return Cow::Owned(format!(
+            "[Attached {}: {}{}]",
+            stringify!($msgtype),
+            $content.body,
+            $content
+                .info
+                .as_ref()
+                .map(|info| {
+                    info.size
+                        .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
+                        .unwrap_or_else(String::new)
+                })
+                .unwrap_or_else(String::new)
+        ))
+    };
+}
+
 fn body_cow_content(content: &RoomMessageEventContent) -> Cow<'_, str> {
     let s = match &content.msgtype {
         MessageType::Text(content) => content.body.as_str(),
@@ -519,64 +540,16 @@ fn body_cow_content(content: &RoomMessageEventContent) -> Cow<'_, str> {
         MessageType::ServerNotice(content) => content.body.as_str(),
 
         MessageType::Audio(content) => {
-            return Cow::Owned(format!(
-                "[Attached Audio: {}{}]",
-                content.body,
-                content
-                    .info
-                    .as_ref()
-                    .map(|info| {
-                        info.size
-                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
-                            .unwrap_or_else(String::new)
-                    })
-                    .unwrap_or_else(String::new)
-            ));
+            display_file_to_text!(Audio, content);
         },
         MessageType::File(content) => {
-            return Cow::Owned(format!(
-                "[Attached File: {}{}]",
-                content.body,
-                content
-                    .info
-                    .as_ref()
-                    .map(|info| {
-                        info.size
-                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
-                            .unwrap_or_else(String::new)
-                    })
-                    .unwrap_or_else(String::new)
-            ));
+            display_file_to_text!(File, content);
         },
         MessageType::Image(content) => {
-            return Cow::Owned(format!(
-                "[Attached Image: {}{}]",
-                content.body,
-                content
-                    .info
-                    .as_ref()
-                    .map(|info| {
-                        info.size
-                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
-                            .unwrap_or_else(String::new)
-                    })
-                    .unwrap_or_else(String::new)
-            ));
+            display_file_to_text!(Image, content);
         },
         MessageType::Video(content) => {
-            return Cow::Owned(format!(
-                "[Attached Video: {}{}]",
-                content.body,
-                content
-                    .info
-                    .as_ref()
-                    .map(|info| {
-                        info.size
-                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
-                            .unwrap_or_else(String::new)
-                    })
-                    .unwrap_or_else(String::new)
-            ));
+            display_file_to_text!(Video, content);
         },
         _ => {
             return Cow::Owned(format!("[Unknown message type: {:?}]", content.msgtype()));

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1179,6 +1179,19 @@ impl ToString for Message {
 
 #[cfg(test)]
 pub mod tests {
+    use matrix_sdk::ruma::events::room::{
+        message::{
+            AudioInfo,
+            AudioMessageEventContent,
+            FileInfo,
+            FileMessageEventContent,
+            ImageMessageEventContent,
+            VideoInfo,
+            VideoMessageEventContent,
+        },
+        ImageInfo,
+    };
+
     use super::*;
     use crate::tests::*;
 
@@ -1426,6 +1439,85 @@ pub mod tests {
 ⌎⌏
 "#
             )
+        );
+    }
+
+    #[test]
+    fn test_display_attachment_size() {
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+                ImageMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(ImageInfo::default())))
+            ))),
+            "[Attached Image: Alt text]".to_string()
+        );
+
+        let mut info = ImageInfo::default();
+        info.size = Some(442630_u32.into());
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+                ImageMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(info)))
+            ))),
+            "[Attached Image: Alt text (442.63 kB)]".to_string()
+        );
+
+        let mut info = ImageInfo::default();
+        info.size = Some(12_u32.into());
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+                ImageMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(info)))
+            ))),
+            "[Attached Image: Alt text (12 B)]".to_string()
+        );
+
+        let mut info = AudioInfo::default();
+        info.size = Some(4294967295_u32.into());
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::Audio(
+                AudioMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(info)))
+            ))),
+            "[Attached Audio: Alt text (4.29 GB)]".to_string()
+        );
+
+        let mut info = FileInfo::default();
+        info.size = Some(4426300_u32.into());
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::File(
+                FileMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(info)))
+            ))),
+            "[Attached File: Alt text (4.43 MB)]".to_string()
+        );
+
+        let mut info = VideoInfo::default();
+        info.size = Some(44000_u32.into());
+        assert_eq!(
+            body_cow_content(&RoomMessageEventContent::new(MessageType::Video(
+                VideoMessageEventContent::plain(
+                    "Alt text".to_string(),
+                    "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
+                )
+                .info(Some(Box::new(info)))
+            ))),
+            "[Attached Video: Alt text (44 kB)]".to_string()
         );
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz, NaiveDateTime, TimeZone};
 use comrak::{markdown_to_html, ComrakOptions};
+use humansize::{format_size, DECIMAL};
 use serde_json::json;
 use unicode_width::UnicodeWidthStr;
 
@@ -518,16 +519,64 @@ fn body_cow_content(content: &RoomMessageEventContent) -> Cow<'_, str> {
         MessageType::ServerNotice(content) => content.body.as_str(),
 
         MessageType::Audio(content) => {
-            return Cow::Owned(format!("[Attached Audio: {}]", content.body));
+            return Cow::Owned(format!(
+                "[Attached Audio: {}{}]",
+                content.body,
+                content
+                    .info
+                    .as_ref()
+                    .map(|info| {
+                        info.size
+                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
+                            .unwrap_or_else(String::new)
+                    })
+                    .unwrap_or_else(String::new)
+            ));
         },
         MessageType::File(content) => {
-            return Cow::Owned(format!("[Attached File: {}]", content.body));
+            return Cow::Owned(format!(
+                "[Attached File: {}{}]",
+                content.body,
+                content
+                    .info
+                    .as_ref()
+                    .map(|info| {
+                        info.size
+                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
+                            .unwrap_or_else(String::new)
+                    })
+                    .unwrap_or_else(String::new)
+            ));
         },
         MessageType::Image(content) => {
-            return Cow::Owned(format!("[Attached Image: {}]", content.body));
+            return Cow::Owned(format!(
+                "[Attached Image: {}{}]",
+                content.body,
+                content
+                    .info
+                    .as_ref()
+                    .map(|info| {
+                        info.size
+                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
+                            .unwrap_or_else(String::new)
+                    })
+                    .unwrap_or_else(String::new)
+            ));
         },
         MessageType::Video(content) => {
-            return Cow::Owned(format!("[Attached Video: {}]", content.body));
+            return Cow::Owned(format!(
+                "[Attached Video: {}{}]",
+                content.body,
+                content
+                    .info
+                    .as_ref()
+                    .map(|info| {
+                        info.size
+                            .map(|s| format!(" ({})", format_size(u64::from(s), DECIMAL)))
+                            .unwrap_or_else(String::new)
+                    })
+                    .unwrap_or_else(String::new)
+            ));
         },
         _ => {
             return Cow::Owned(format!("[Unknown message type: {:?}]", content.msgtype()));


### PR DESCRIPTION
Hi, first PR to take a look at the code base of this project (and a bit more at matrix internals).

It displays the attachment file size by appending it in the displayed messages.
For example, it would show `[Attached Image: Alt Text (12.34 kB)]` or `[Attached Image: Alt Text]` if the `size` field is not present in the message information.

Adds the `humansize` crate to `Cargo.toml`.

Intends to fix #97 