### PR TITLE
Implement set/unset/show for alternative and canonical aliases

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -134,10 +134,14 @@ Unset the topic of the currently focused room.
 Create and point the given alias to the room.
 .It Sy ":room alias unset [alias]"
 Delete the provided alias from the room's alternative alias list.
+.It Sy ":room alias show"
+Show alternative aliases to the room, if any are set.
 .It Sy ":room canonicalalias set [alias]"
 Set the room's canonical alias to the one provided, deleting the previous one.
 .It Sy ":room canonicalalias unset [alias]"
 Delete the room's canonical alias.
+.It Sy ":room canonicalalias show"
+Show the room's canonical alias, if any is set.
 .El
 
 .Sh "WINDOW COMMANDS"

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -130,6 +130,14 @@ Remove a tag from the currently focused room.
 Set the topic of the currently focused room.
 .It Sy ":room topic unset"
 Unset the topic of the currently focused room.
+.It Sy ":room alias set [alias]"
+Create and point the given alias to the room.
+.It Sy ":room alias unset [alias]"
+Delete the provided alias from the room's alternative alias list.
+.It Sy ":room canonicalalias set [alias]"
+Set the room's canonical alias to the one provided, deleting the previous one.
+.It Sy ":room canonicalalias unset [alias]"
+Delete the room's canonical alias.
 .El
 
 .Sh "WINDOW COMMANDS"

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -136,11 +136,11 @@ Create and point the given alias to the room.
 Delete the provided alias from the room's alternative alias list.
 .It Sy ":room alias show"
 Show alternative aliases to the room, if any are set.
-.It Sy ":room canonicalalias set [alias]"
-Set the room's canonical alias to the one provided, deleting the previous one.
-.It Sy ":room canonicalalias unset [alias]"
+.It Sy ":room canon set [alias]"
+Set the room's canonical alias to the one provided, and make the previous one an alternative alias.
+.It Sy ":room canon unset [alias]"
 Delete the room's canonical alias.
-.It Sy ":room canonicalalias show"
+.It Sy ":room canon show"
 Show the room's canonical alias, if any is set.
 .El
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -608,6 +608,10 @@ pub enum IambError {
     #[error("Invalid user identifier: {0}")]
     InvalidUserId(String),
 
+    /// An invalid user identifier was specified.
+    #[error("Invalid room alias: {0}")]
+    InvalidRoomAlias(String),
+
     /// An invalid verification identifier was specified.
     #[error("Invalid verification user/device pair: {0}")]
     InvalidVerificationId(String),

--- a/src/base.rs
+++ b/src/base.rs
@@ -369,6 +369,15 @@ pub enum RoomField {
 
     /// The room topic.
     Topic,
+
+    /// The room's entire list of alternative aliases.
+    Aliases,
+
+    /// A specific alternative alias to the room.
+    Alias(String),
+
+    /// The room's canonical alias.
+    CanonicalAlias,
 }
 
 /// An action that operates on a focused room.
@@ -658,6 +667,10 @@ pub enum IambError {
     /// An unknown room was specified.
     #[error("Unknown room identifier: {0}")]
     UnknownRoom(OwnedRoomId),
+
+    /// An invalid room alias id was specified.
+    #[error("Invalid room alias id: {0}")]
+    InvalidRoomAliasId(#[from] matrix_sdk::ruma::IdParseError),
 
     /// A failure occurred during verification.
     #[error("Verification request error: {0}")]

--- a/src/base.rs
+++ b/src/base.rs
@@ -406,6 +406,9 @@ pub enum RoomAction {
 
     /// Unset a room property.
     Unset(RoomField),
+
+    /// List the values in a list room property.
+    Show(RoomField),
 }
 
 /// An action that sends a message to a room.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -454,6 +454,10 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         ("tag", "unset", Some(s)) => RoomAction::Unset(RoomField::Tag(tag_name(s)?)).into(),
         ("tag", "unset", None) => return Result::Err(CommandError::InvalidArgument),
 
+        // :room aliases show
+        ("alias", "show", None) => RoomAction::Show(RoomField::Aliases).into(),
+        ("alias", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
         // :room aliases unset <alias>
         ("alias", "unset", Some(s)) => RoomAction::Unset(RoomField::Alias(s)).into(),
         ("alias", "unset", None) => return Result::Err(CommandError::InvalidArgument),
@@ -461,6 +465,10 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         // :room aliases set <alias>
         ("alias", "set", Some(s)) => RoomAction::Set(RoomField::Alias(s), "".into()).into(),
         ("alias", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room canonicalalias show
+        ("canonicalalias", "show", None) => RoomAction::Show(RoomField::CanonicalAlias).into(),
+        ("canonicalalias", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
 
         // :room canonicalalias set
         ("canonicalalias", "set", Some(s)) => RoomAction::Set(RoomField::CanonicalAlias, s).into(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -467,16 +467,28 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         ("alias", "set", None) => return Result::Err(CommandError::InvalidArgument),
 
         // :room canonicalalias show
-        ("canonicalalias", "show", None) => RoomAction::Show(RoomField::CanonicalAlias).into(),
-        ("canonicalalias", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+        ("canonicalalias" | "canon", "show", None) => {
+            RoomAction::Show(RoomField::CanonicalAlias).into()
+        },
+        ("canonicalalias" | "canon", "show", Some(_)) => {
+            return Result::Err(CommandError::InvalidArgument)
+        },
 
         // :room canonicalalias set
-        ("canonicalalias", "set", Some(s)) => RoomAction::Set(RoomField::CanonicalAlias, s).into(),
-        ("canonicalalias", "set", None) => return Result::Err(CommandError::InvalidArgument),
+        ("canonicalalias" | "canon", "set", Some(s)) => {
+            RoomAction::Set(RoomField::CanonicalAlias, s).into()
+        },
+        ("canonicalalias" | "canon", "set", None) => {
+            return Result::Err(CommandError::InvalidArgument)
+        },
 
         // :room canonicalalias unset
-        ("canonicalalias", "unset", None) => RoomAction::Unset(RoomField::CanonicalAlias).into(),
-        ("canonicalalias", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+        ("canonicalalias" | "canon", "unset", None) => {
+            RoomAction::Unset(RoomField::CanonicalAlias).into()
+        },
+        ("canonicalalias" | "canon", "unset", Some(_)) => {
+            return Result::Err(CommandError::InvalidArgument)
+        },
 
         _ => return Result::Err(CommandError::InvalidArgument),
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -454,6 +454,22 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         ("tag", "unset", Some(s)) => RoomAction::Unset(RoomField::Tag(tag_name(s)?)).into(),
         ("tag", "unset", None) => return Result::Err(CommandError::InvalidArgument),
 
+        // :room aliases unset <alias>
+        ("alias", "unset", Some(s)) => RoomAction::Unset(RoomField::Alias(s)).into(),
+        ("alias", "unset", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room aliases set <alias>
+        ("alias", "set", Some(s)) => RoomAction::Set(RoomField::Alias(s), "".into()).into(),
+        ("alias", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room canonicalalias set
+        ("canonicalalias", "set", Some(s)) => RoomAction::Set(RoomField::CanonicalAlias, s).into(),
+        ("canonicalalias", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room canonicalalias unset
+        ("canonicalalias", "unset", None) => RoomAction::Unset(RoomField::CanonicalAlias).into(),
+        ("canonicalalias", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
         _ => return Result::Err(CommandError::InvalidArgument),
     };
 


### PR DESCRIPTION
This commit solves #50 by providing a way to:
 - Set the canonical alias of a room (destroying the previous one if any)
 - Unset the canonical alias of a room (destroying the previous one if any)
 - Add an alternative alias to a room
 - Delete an alternative alias to a room (destroying it afterwards)