### PR TITLE
Allow notifications on open room if terminal not focused

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1344,7 +1344,7 @@ impl ChatStore {
             sync_info: Default::default(),
             draw_curr: None,
             ring_bell: false,
-            focused: false,
+            focused: true,
         }
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -1319,6 +1319,9 @@ pub struct ChatStore {
 
     /// Whether to ring the terminal bell on the next redraw.
     pub ring_bell: bool,
+
+    /// Whether the application is currently focused
+    pub focused: bool,
 }
 
 impl ChatStore {
@@ -1341,6 +1344,7 @@ impl ChatStore {
             sync_info: Default::default(),
             draw_curr: None,
             ring_bell: false,
+            focused: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,9 +355,13 @@ impl Application {
                     // Do nothing for now.
                 },
                 Event::FocusGained => {
+                    let mut store = self.store.lock().await;
+                    store.application.focused = true;
                     self.focused = true;
                 },
                 Event::FocusLost => {
+                    let mut store = self.store.lock().await;
+                    store.application.focused = false;
                     self.focused = false;
                 },
                 Event::Resize(_, _) => {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -44,7 +44,7 @@ pub async fn register_notifications(
                     return;
                 }
 
-                if is_open(&store, room.room_id()).await {
+                if is_focused(&store).await && is_open(&store, room.room_id()).await {
                     return;
                 }
 
@@ -137,6 +137,11 @@ async fn is_open(store: &AsyncProgramStore, room_id: &RoomId) -> bool {
         }
     }
     false
+}
+
+async fn is_focused(store: &AsyncProgramStore) -> bool {
+    let locked = store.lock().await;
+    locked.application.focused
 }
 
 pub async fn parse_notification(

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -14,7 +14,7 @@ use matrix_sdk::{
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
-    base::{AsyncProgramStore, IambError, IambResult},
+    base::{AsyncProgramStore, IambError, IambResult, ProgramStore},
     config::{ApplicationSettings, NotifyVia},
 };
 
@@ -44,7 +44,7 @@ pub async fn register_notifications(
                     return;
                 }
 
-                if is_focused(&store).await && is_open(&store, room.room_id()).await {
+                if is_visible_room(&store, room.room_id()).await {
                     return;
                 }
 
@@ -128,8 +128,7 @@ fn is_missing_mention(body: &Option<String>, mode: RoomNotificationMode, client:
     false
 }
 
-async fn is_open(store: &AsyncProgramStore, room_id: &RoomId) -> bool {
-    let mut locked = store.lock().await;
+fn is_open(locked: &mut ProgramStore, room_id: &RoomId) -> bool {
     if let Some(draw_curr) = locked.application.draw_curr {
         let info = locked.application.get_room_info(room_id.to_owned());
         if let Some(draw_last) = info.draw_last {
@@ -139,9 +138,14 @@ async fn is_open(store: &AsyncProgramStore, room_id: &RoomId) -> bool {
     false
 }
 
-async fn is_focused(store: &AsyncProgramStore) -> bool {
-    let locked = store.lock().await;
+fn is_focused(locked: &ProgramStore) -> bool {
     locked.application.focused
+}
+
+async fn is_visible_room(store: &AsyncProgramStore, room_id: &RoomId) -> bool {
+    let mut locked = store.lock().await;
+
+    is_focused(&locked) && is_open(&mut locked, room_id)
 }
 
 pub async fn parse_notification(


### PR DESCRIPTION
Hi,

This PR is to implement #276.

It does this by putting the `focused` state of the application into the store and then checks it in the notifications handler.

This results in notifications being muted only if the room is currently displayed and the terminal is in focus.

If you would like a config entry to control this just let me know. :)