### PR TITLE
Fix a compiler warning

### DIFF
--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -260,6 +260,7 @@ pub enum StyleTreeNode {
     Anchor(Box<StyleTreeNode>, char, Url),
     Blockquote(Box<StyleTreeNode>),
     Break,
+    #[allow(dead_code)]
     Code(Box<StyleTreeNode>, Option<String>),
     Header(Box<StyleTreeNode>, usize),
     Image(Option<String>),


### PR DESCRIPTION
```
warning: field `1` is never read
   --> src/message/html.rs:263:30
```