### PR TITLE
Fix newer Clippy warnings for 1.80

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1346,9 +1346,7 @@ impl ChatStore {
 
     /// Get a joined room.
     pub fn get_joined_room(&self, room_id: &RoomId) -> Option<MatrixRoom> {
-        let Some(room) = self.worker.client.get_room(room_id) else {
-            return None;
-        };
+        let room = self.worker.client.get_room(room_id)?;
 
         if room.state() == MatrixRoomState::Joined {
             Some(room)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1173,7 +1173,7 @@ mod tests {
         let j = "j".parse::<TerminalKey>().unwrap();
         let esc = "<Esc>".parse::<TerminalKey>().unwrap();
 
-        let jj = Keys(vec![j.clone(), j], "jj".into());
+        let jj = Keys(vec![j, j], "jj".into());
         let run = mapped.get(&jj).unwrap();
         let exp = Keys(vec![esc], "<Esc>".into());
         assert_eq!(run, &exp);

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -260,6 +260,7 @@ pub enum StyleTreeNode {
     Anchor(Box<StyleTreeNode>, char, Url),
     Blockquote(Box<StyleTreeNode>),
     Break,
+    #[allow(dead_code)]
     Code(Box<StyleTreeNode>, Option<String>),
     Header(Box<StyleTreeNode>, usize),
     Image(Option<String>),

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -5,6 +5,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::hash_set;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 
@@ -1144,9 +1145,9 @@ impl From<RoomMessageEvent> for Message {
     }
 }
 
-impl ToString for Message {
-    fn to_string(&self) -> String {
-        self.event.body().into_owned()
+impl Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.event.body())
     }
 }
 
@@ -1423,7 +1424,7 @@ pub mod tests {
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
-                .info(Some(Box::new(ImageInfo::default())))
+                .info(Some(Box::default()))
             ))),
             "[Attached Image: Alt text]".to_string()
         );

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1087,7 +1087,6 @@ impl Display for DirectItem {
     }
 }
 
-
 impl ListItem<IambInfo> for DirectItem {
     fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
         let unread = self.unread.is_unread();

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -7,6 +7,7 @@
 //! example, [sending messages][crate::base::SendAction] delegate to the [room window][RoomState],
 //! where we have the message bar and room ID easily accesible and resetable.
 use std::cmp::{Ord, Ordering, PartialOrd};
+use std::fmt::{self, Display};
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -820,7 +821,7 @@ impl GenericChatItem {
         let name = info.name.clone().unwrap_or_default();
         let alias = room.canonical_alias();
         let unread = info.unreads(&store.application.settings);
-        info.tags = room_info.deref().1.clone();
+        info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
@@ -870,9 +871,9 @@ impl RoomLikeItem for GenericChatItem {
     }
 }
 
-impl ToString for GenericChatItem {
-    fn to_string(&self) -> String {
-        return self.name.clone();
+impl Display for GenericChatItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 
@@ -930,7 +931,7 @@ impl RoomItem {
         let name = info.name.clone().unwrap_or_default();
         let alias = room.canonical_alias();
         let unread = info.unreads(&store.application.settings);
-        info.tags = room_info.deref().1.clone();
+        info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
@@ -980,9 +981,9 @@ impl RoomLikeItem for RoomItem {
     }
 }
 
-impl ToString for RoomItem {
-    fn to_string(&self) -> String {
-        return self.name.clone();
+impl Display for RoomItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, ":verify request {}", self.name)
     }
 }
 
@@ -1034,7 +1035,7 @@ impl DirectItem {
         let info = store.application.rooms.get_or_default(room_id);
         let name = info.name.clone().unwrap_or_default();
         let unread = info.unreads(&store.application.settings);
-        info.tags = room_info.deref().1.clone();
+        info.tags.clone_from(&room_info.deref().1);
 
         DirectItem { room_info, name, alias, unread }
     }
@@ -1080,11 +1081,12 @@ impl RoomLikeItem for DirectItem {
     }
 }
 
-impl ToString for DirectItem {
-    fn to_string(&self) -> String {
-        return self.name.clone();
+impl Display for DirectItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, ":verify request {}", self.name)
     }
 }
+
 
 impl ListItem<IambInfo> for DirectItem {
     fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
@@ -1179,9 +1181,9 @@ impl RoomLikeItem for SpaceItem {
     }
 }
 
-impl ToString for SpaceItem {
-    fn to_string(&self) -> String {
-        return self.room_id().to_string();
+impl Display for SpaceItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, ":verify request {}", self.room_id())
     }
 }
 
@@ -1300,16 +1302,18 @@ impl From<(&String, &SasVerification)> for VerifyItem {
     }
 }
 
-impl ToString for VerifyItem {
-    fn to_string(&self) -> String {
+impl Display for VerifyItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.sasv1.is_done() {
-            String::new()
-        } else if self.sasv1.is_cancelled() {
-            format!(":verify request {}", self.sasv1.other_user_id())
+            return Ok(());
+        }
+
+        if self.sasv1.is_cancelled() {
+            write!(f, ":verify request {}", self.sasv1.other_user_id())
         } else if self.sasv1.emoji().is_some() {
-            format!(":verify confirm {}", self.user_dev)
+            write!(f, ":verify confirm {}", self.user_dev)
         } else {
-            format!(":verify accept {}", self.user_dev)
+            write!(f, ":verify accept {}", self.user_dev)
         }
     }
 }
@@ -1413,9 +1417,9 @@ impl MemberItem {
     }
 }
 
-impl ToString for MemberItem {
-    fn to_string(&self) -> String {
-        self.member.user_id().to_string()
+impl Display for MemberItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.member.user_id())
     }
 }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1457,11 +1457,11 @@ mod tests {
         assert_eq!(scrollback.cursor, MessageCursor::latest());
 
         // Search backwards to MSG4.
-        scrollback.search(prev.clone(), 1.into(), &ctx, &mut store).unwrap();
+        scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG4_KEY.clone().into());
 
         // Search backwards to MSG2.
-        scrollback.search(prev.clone(), 1.into(), &ctx, &mut store).unwrap();
+        scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
         assert_eq!(
             std::mem::take(&mut store.application.need_load)
@@ -1472,7 +1472,7 @@ mod tests {
         );
 
         // Can't go any further; need_load now contains the room ID.
-        scrollback.search(prev.clone(), 1.into(), &ctx, &mut store).unwrap();
+        scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
         assert_eq!(
             std::mem::take(&mut store.application.need_load)
@@ -1482,11 +1482,11 @@ mod tests {
         );
 
         // Search forward twice to MSG1.
-        scrollback.search(next.clone(), 2.into(), &ctx, &mut store).unwrap();
+        scrollback.search(next, 2.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG1_KEY.clone().into());
 
         // Can't go any further.
-        scrollback.search(next.clone(), 2.into(), &ctx, &mut store).unwrap();
+        scrollback.search(next, 2.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG1_KEY.clone().into());
     }
 


### PR DESCRIPTION
I'd like to take this client to my own use but as long as it breaks "broken glass" invariant I really cannot do that ;-) [1]

Is there something broken in the CI, I see that there are some clippy bits but cannot comprehend why those checks are not working?

[1] "Fight software rot" chapter in "Pragmatic Programmer"