### PR TITLE
Support reacting literally with non-Emojis

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -152,7 +152,11 @@ pub enum MessageAction {
     Edit,
 
     /// React to a message with an Emoji.
-    React(String),
+    ///
+    /// `:react` will by default try to convert the [String] argument to an Emoji, and error when
+    /// it doesn't recognize it. The second [bool] argument forces it to be interpreted literally
+    /// when it is `true`.
+    React(String, bool),
 
     /// Redact a message, with an optional reason.
     ///
@@ -166,7 +170,11 @@ pub enum MessageAction {
     ///
     /// If no specific Emoji to remove to is specified, then all reactions from the user on the
     /// message are removed.
-    Unreact(Option<String>),
+    ///
+    /// Like `:react`, `:unreact` will by default try to convert the [String] argument to an Emoji,
+    /// and error when it doesn't recognize it. The second [bool] argument forces it to be
+    /// interpreted literally when it is `true`.
+    Unreact(Option<String>, bool),
 }
 
 /// The type of room being created.


### PR DESCRIPTION
Folks were talking about custom reactions and literal text reactions in the `#offtopic:archlinux.org` room earlier tonight. This PR changes `:react`/`:unreact` to prompt whether you want to use the literal text when it's not a shortcode, and allows using `:react!`/`:unreact!` to force it to be interpreted literally. (So `:react wave` sends the :wave: Emoji, and `:react! wave` reacts with the literal text "wave".)

I'd love to eventually support something like [MSC4027](https://github.com/matrix-org/matrix-spec-proposals/pull/4027), but that'll have to wait for some future PR.