### PR TITLE
Add metadata for `cargo-deb` and `cargo-generate-rpm`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,33 @@ pretty_assertions = "1.4.0"
 inherits = "release"
 incremental = false
 lto = true
+
+[package.metadata.deb]
+section = "net"
+license-file = ["LICENSE", "0"]
+assets = [
+    # Binary:
+    ["target/release/iamb", "usr/bin/iamb", "755"],
+    # Manual pages:
+    ["docs/iamb.1", "usr/share/man/man1/iamb.1", "644"],
+    ["docs/iamb.5", "usr/share/man/man5/iamb.5", "644"],
+    # Other assets:
+    ["iamb.desktop", "usr/share/applications/iamb.desktop", "644"],
+    ["config.example.toml", "usr/share/iamb/config.example.toml", "644"],
+    ["docs/iamb.svg", "usr/share/icons/hicolor/scalable/apps/iamb.svg", "644"],
+    ["docs/iamb.metainfo.xml", "usr/share/metainfo/iamb.metainfo.xml", "644"],
+]
+
+[package.metadata.generate-rpm]
+assets = [
+    # Binary:
+    { source = "target/release/iamb", dest = "/usr/bin/iamb", mode = "755" },
+    # Manual pages:
+    { source = "docs/iamb.1", dest = "/usr/share/man/man1/iamb.1", mode = "644" },
+    { source = "docs/iamb.5", dest = "/usr/share/man/man5/iamb.5", mode = "644" },
+    # Other assets:
+    { source = "iamb.desktop", dest = "/usr/share/applications/iamb.desktop", mode = "644" },
+    { source = "config.example.toml", dest = "/usr/share/iamb/config.example.toml", mode = "644"},
+    { source = "docs/iamb.svg", dest = "/usr/share/icons/hicolor/scalable/apps/iamb.svg", mode = "644"},
+    { source = "docs/iamb.metainfo.xml", dest = "/usr/share/metainfo/iamb.metainfo.xml", mode = "644"},
+]

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -28,6 +28,7 @@ and GCC are present.
 In addition to the compiled binary, there are other files in the repo that
 you'll want to install as part of a package:
 
+<!-- Please keep in sync w/ the `deb`/`generate-rpm` sections of `Cargo.toml` -->
 | Repository Path         | Installed Path (may vary per OS)                |
 | ----------------------- | ----------------------------------------------- |
 | /iamb.desktop           | /usr/share/applications/iamb.desktop            |


### PR DESCRIPTION
For the upcoming release I'd like to provide `.deb` and `.rpm` files in addition to the tarballs on the release page, which should make it easier for folks to just `dpkg -i ...` and have the binary in their `PATH` and the manual pages in their `MANPATH`. This adds the metadata for using [cargo-deb](https://crates.io/crates/cargo-deb) and [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm) to `Cargo.toml`.