### PR TITLE
Remove modifyOtherKeys enablement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -916,31 +916,6 @@ async fn login_normal(
     Ok(())
 }
 
-struct EnableModifyOtherKeys;
-struct DisableModifyOtherKeys;
-
-impl crossterm::Command for EnableModifyOtherKeys {
-    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
-        write!(f, "\x1B[>4;2m")
-    }
-
-    #[cfg(windows)]
-    fn execute_winapi(&self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-impl crossterm::Command for DisableModifyOtherKeys {
-    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
-        write!(f, "\x1B[>4;0m")
-    }
-
-    #[cfg(windows)]
-    fn execute_winapi(&self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 /// Set up the terminal for drawing the TUI, and getting additional info.
 fn setup_tty(title: &str, enable_enhanced_keys: bool) -> std::io::Result<()> {
     let title = format!("iamb ({})", title);
@@ -955,8 +930,6 @@ fn setup_tty(title: &str, enable_enhanced_keys: bool) -> std::io::Result<()> {
             stdout(),
             PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
         )?;
-    } else {
-        crossterm::queue!(stdout(), EnableModifyOtherKeys)?;
     }
 
     crossterm::execute!(stdout(), EnableBracketedPaste, EnableFocusChange, SetTitle(title))
@@ -970,7 +943,6 @@ fn restore_tty(enable_enhanced_keys: bool) {
 
     let _ = crossterm::execute!(
         stdout(),
-        DisableModifyOtherKeys,
         DisableBracketedPaste,
         DisableFocusChange,
         LeaveAlternateScreen,


### PR DESCRIPTION
I somehow hallucinated support for xterm's `modifyOtherKeys` in `crossterm` when I did #272. If it ever does gain it, then I'll revert this. I don't know how I concluded that it supports them, but since it doesn't it breaks terminals like xterm or wezterm that do have support for them. (I suspect that I was initially using `\x1B[>4;1m` and then at some point switched to `\x1B[>4;2m` without retesting in those terminals.)