### PR TITLE
Add ban/unban/kick room commands

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -161,6 +161,12 @@ Set the room's canonical alias to the one provided, and make the previous one an
 Delete the room's canonical alias.
 .It Sy ":room canon show"
 Show the room's canonical alias, if any is set.
+.It Sy ":room ban [user] [reason]"
+Ban a user from this room with an optional reason.
+.It Sy ":room unban [user] [reason]"
+Unban a user from this room with an optional reason.
+.It Sy ":room kick [user] [reason]"
+Kick a user from this room with an optional reason.
 .El
 
 .Sh "WINDOW COMMANDS"

--- a/src/base.rs
+++ b/src/base.rs
@@ -391,6 +391,24 @@ pub enum RoomField {
     CanonicalAlias,
 }
 
+/// An action that operates on a room member.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MemberUpdateAction {
+    Ban,
+    Kick,
+    Unban,
+}
+
+impl Display for MemberUpdateAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MemberUpdateAction::Ban => write!(f, "ban"),
+            MemberUpdateAction::Kick => write!(f, "kick"),
+            MemberUpdateAction::Unban => write!(f, "unban"),
+        }
+    }
+}
+
 /// An action that operates on a focused room.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RoomAction {
@@ -405,6 +423,9 @@ pub enum RoomAction {
 
     /// Leave this room.
     Leave(bool),
+
+    /// Update a user's membership in this room.
+    MemberUpdate(MemberUpdateAction, String, Option<String>, bool),
 
     /// Open the members window.
     Members(Box<CommandContext>),


### PR DESCRIPTION
This adds commands for managing room memberships, each accepting an optional reason:

- `:room ban [user] [reason]`
- `:room unban [user] [reason]` 
- `:room unban [user] [reason]` 