### PR TITLE
Add command for setting room history visibility

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -369,6 +369,9 @@ impl<'de> Visitor<'de> for SortUserVisitor {
 /// A room property.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RoomField {
+    /// The room's history visibility.
+    History,
+
     /// The room name.
     Name,
 
@@ -636,6 +639,10 @@ pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId)>;
 /// Errors encountered during application use.
 #[derive(thiserror::Error, Debug)]
 pub enum IambError {
+    /// An invalid history visibility was specified.
+    #[error("Invalid history visibility setting: {0}")]
+    InvalidHistoryVisibility(String),
+
     /// An invalid notification level was specified.
     #[error("Invalid notification level: {0}")]
     InvalidNotificationLevel(String),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -423,6 +423,18 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
             RoomAction::MemberUpdate(MemberUpdateAction::Unban, u.into(), r, desc.bang).into()
         },
 
+        // :room history set <visibility>
+        ("history", "set", Some(s)) => RoomAction::Set(RoomField::History, s).into(),
+        ("history", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room history unset
+        ("history", "unset", None) => RoomAction::Unset(RoomField::History).into(),
+        ("history", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room history show
+        ("history", "show", None) => RoomAction::Show(RoomField::History).into(),
+        ("history", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
         // :room name set <room-name>
         ("name", "set", Some(s)) => RoomAction::Set(RoomField::Name, s).into(),
         ("name", "set", None) => return Result::Err(CommandError::InvalidArgument),


### PR DESCRIPTION
This fixes #91 by adding a `:room history set [level]` command with `unset` and `show` variants. The different visibility levels are:

- `invited`, which configures the room to allow people to see history from the point they were invited onwards.
- `joined`, which configures the room to allow people to see history from the point they actually join the room.
- `shared`, which configures the room to allow people to see all history once they are joined, including messages from before they joined.
- `world` which configures the room to allow anyone to see the room history regardless of whether they are joined and in it.