### PR TITLE
Add commands for viewing and clearing unreads

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -61,6 +61,8 @@ Log out of
 View a list of joined rooms.
 .It Sy ":spaces"
 View a list of joined spaces.
+.It Sy ":unreads"
+View a list of unread rooms.
 .It Sy ":welcome"
 View the startup Welcome window.
 .El
@@ -95,6 +97,8 @@ React to the selected message with an Emoji.
 Redact the selected message.
 .It Sy ":reply"
 Reply to the selected message.
+.It Sy ":unreads clear"
+Mark all unread rooms as read.
 .It Sy ":unreact [shortcode]"
 Remove your reaction from the selected message.
 When no arguments are given, remove all of your reactions from the message.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -307,6 +307,30 @@ fn iamb_chats(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     return Ok(step);
 }
 
+fn iamb_unreads(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let mut args = desc.arg.strings()?;
+
+    if args.len() > 1 {
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    match args.pop().as_deref() {
+        Some("clear") => {
+            let clear = IambAction::ClearUnreads;
+            let step = CommandStep::Continue(clear.into(), ctx.context.clone());
+
+            return Ok(step);
+        },
+        Some(_) => return Result::Err(CommandError::InvalidArgument),
+        None => {
+            let open = ctx.switch(OpenTarget::Application(IambId::UnreadList));
+            let step = CommandStep::Continue(open, ctx.context.clone());
+
+            return Ok(step);
+        },
+    }
+}
+
 fn iamb_spaces(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     if !desc.arg.text.is_empty() {
         return Result::Err(CommandError::InvalidArgument);
@@ -647,6 +671,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "spaces".into(),
         aliases: vec![],
         f: iamb_spaces,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "unreads".into(),
+        aliases: vec![],
+        f: iamb_unreads,
     });
     cmds.add_command(ProgramCommand {
         name: "unreact".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,6 +529,18 @@ impl Application {
         }
 
         let info = match action {
+            IambAction::ClearUnreads => {
+                let user_id = &store.application.settings.profile.user_id;
+
+                for room_id in store.application.sync_info.chats() {
+                    if let Some(room) = store.application.rooms.get_mut(room_id) {
+                        room.fully_read(user_id.clone());
+                    }
+                }
+
+                None
+            },
+
             IambAction::ToggleScrollbackFocus => {
                 self.screen.current_window_mut()?.focus_toggle();
 


### PR DESCRIPTION
This adds a `:unreads` command that opens a list of unread messages, and `:unreads clear` subcommand that marks all unread rooms as reads.