### PR TITLE
Do not use icons in MetaInfo

### DIFF
--- a/docs/iamb.metainfo.xml
+++ b/docs/iamb.metainfo.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="console-application">
-  <id>iamb</id>
+  <id>chat.iamb.iamb</id>
 
   <name>iamb</name>
   <summary>A terminal Matrix client for Vim addicts</summary>
   <url type="homepage">https://iamb.chat</url>
 
   <releases>
-    <release version="0.0.9" date="2024-03-28"/>
     <release version="0.0.10" date="2024-08-20"/>
+    <release version="0.0.9" date="2024-03-28"/>
   </releases>
 
   <developer id="dev.ulyssa">
     <name>Ulyssa</name>
   </developer>
 
+  <developer_name>Ulyssa</developer_name>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>Apache-2.0</project_license>
 
@@ -38,7 +39,6 @@
     </p>
   </description>
 
-  <icon type="remote">https://iamb.chat/images/iamb.svg</icon>
   <launchable type="desktop-id">iamb.desktop</launchable>
 
   <categories>


### PR DESCRIPTION
I was told not to use remote icons with FlatHub, and the `stock` icons don't seem to play nicely with `appstream-compose`, so I'm just going to remove it. The icon is already included in the `iamb.desktop` file so it should hopefully get picked up from that.