### PR TITLE
Support automatically toggling room focus

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1766,6 +1766,13 @@ impl RoomFocus {
     pub fn is_msgbar(&self) -> bool {
         matches!(self, RoomFocus::MessageBar)
     }
+
+    pub fn toggle(&mut self) {
+        *self = match self {
+            RoomFocus::MessageBar => RoomFocus::Scrollback,
+            RoomFocus::Scrollback => RoomFocus::MessageBar,
+        };
+    }
 }
 
 /// Identifiers used to track where a mark was placed.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1141,18 +1141,18 @@ mod tests {
         let mut cmds = setup_commands();
         let ctx = EditContext::default();
 
-        let cmd = format!("room notify set mute");
-        let res = cmds.input_cmd(&cmd, ctx.clone()).unwrap();
+        let cmd = "room notify set mute";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
         let act = RoomAction::Set(RoomField::NotificationMode, "mute".into());
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
-        let cmd = format!("room notify unset");
-        let res = cmds.input_cmd(&cmd, ctx.clone()).unwrap();
+        let cmd = "room notify unset";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
         let act = RoomAction::Unset(RoomField::NotificationMode);
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
-        let cmd = format!("room notify show");
-        let res = cmds.input_cmd(&cmd, ctx.clone()).unwrap();
+        let cmd = "room notify show";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
         let act = RoomAction::Show(RoomField::NotificationMode);
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
     }

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -79,14 +79,20 @@ fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
 }
 
 fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
-    nth_key_before(pos, n, thread).into()
+    let key = nth_key_before(pos, n, thread);
+
+    if matches!(thread.last_key_value(), Some((last, _)) if &key == last) {
+        MessageCursor::latest()
+    } else {
+        MessageCursor::from(key)
+    }
 }
 
-fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
+fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<MessageKey> {
     let mut end = &pos;
-    let iter = thread.range(&pos..).enumerate();
+    let mut iter = thread.range(&pos..).enumerate();
 
-    for (i, (key, _)) in iter {
+    for (i, (key, _)) in iter.by_ref() {
         end = key;
 
         if i >= n {
@@ -94,11 +100,12 @@ fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
         }
     }
 
-    end.clone()
+    // Avoid returning the key if it's at the end.
+    iter.next().map(|_| end.clone())
 }
 
 fn nth_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
-    nth_key_after(pos, n, thread).into()
+    nth_key_after(pos, n, thread).map(MessageCursor::from).unwrap_or_default()
 }
 
 fn prevmsg<'a>(key: &MessageKey, thread: &'a Messages) -> Option<&'a Message> {
@@ -148,6 +155,10 @@ impl ScrollbackState {
             jumped,
             show_full_on_redraw,
         }
+    }
+
+    pub fn is_latest(&self) -> bool {
+        self.cursor.timestamp.is_none()
     }
 
     pub fn goto_latest(&mut self) {
@@ -1524,8 +1535,9 @@ mod tests {
         scrollback.edit(&EditAction::Motion, &next(1), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG5_KEY.clone().into());
 
+        // And one more becomes "latest" cursor:
         scrollback.edit(&EditAction::Motion, &next(1), &ctx, &mut store).unwrap();
-        assert_eq!(scrollback.cursor, MSG1_KEY.clone().into());
+        assert_eq!(scrollback.cursor, MessageCursor::latest());
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR adds support for automatically switching focus to the message bar when entering Insert mode in a room, and also allows using `k`/`<Up>` to move up from the message bar into the message scrollback.

Opening as draft for now because I would like to add tests and maybe also revisit some of the scrolling behaviour.