### PR TITLE
Fix `ratatui-image` tmux detection when used with a configured image protocol

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1276,10 +1276,12 @@ fn picker_from_termios(protocol_type: Option<ProtocolType>) -> Option<Picker> {
         },
     };
 
+    // `guess_protocol` also does tmux detection,
+    // run it always then overwrite the guessed protocol if needed
+    picker.guess_protocol();
+
     if let Some(protocol_type) = protocol_type {
         picker.protocol_type = protocol_type;
-    } else {
-        picker.guess_protocol();
     }
 
     Some(picker)


### PR DESCRIPTION
I finally tracked down part of the problems from #345, `ratatui-image` only does its tmux detection when `guess_protocol` is called.

This is required for kitty (and presumably iterm2) protocol to work inside tmux, for sixel it's not _required_ since tmux actually implements sixel support itself, but it does appear to give better results by bypassing tmux and passing the sixel data directly to the terminal.