### PR TITLE
Fix image preview in replies and threads

### DIFF
--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1340,7 +1340,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
 
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
-            let (txt, mut msg_preview) =
+            let (txt, [mut msg_preview, mut reply_preview]) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
 
             let incomplete_ok = !full || !sel;
@@ -1357,11 +1357,17 @@ impl<'a> StatefulWidget for Scrollback<'a> {
                     continue;
                 }
 
+                // Only take the preview into the matching row number.
+                // `reply` and `msg` previews are on rows,
+                // so an `or` works to pick the one that matches (if any)
                 let line_preview = match msg_preview {
-                    // Only take the preview into the matching row number.
                     Some((_, _, y)) if y as usize == row => msg_preview.take(),
                     _ => None,
-                };
+                }
+                .or(match reply_preview {
+                    Some((_, _, y)) if y as usize == row => reply_preview.take(),
+                    _ => None,
+                });
 
                 lines.push((key, row, line, line_preview));
                 sawit |= sel;


### PR DESCRIPTION
Hi,

This PR is a fix for #362

The root cause was that the image protocol from a reply header was being ignored.

An image in a reply header is now handled in the same way as an image in the body of the message, with the image position offsets modified to account for the difference in formatting (vertical lines, indent, etc).

It was necessary to break out `Message::show_msg` from `MessageFormatter::push_in_reply` due to the lifetime of the image protocol. 

`Message::show_with_preview` now returns the image protocols of both the body and the reply header. `Scrollback::render` was updated to handle this.