### PR TITLE
Support an `"invite"` field in the room sorting settings

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -334,6 +334,26 @@ window.
 Defaults to
 .Sy ["power",\ "id"] .
 .El
+
+The available values are:
+.Bl -tag -width Ds
+.It Sy favorite
+Put favorite rooms before other rooms.
+.It Sy lowpriority
+Put lowpriority rooms after other rooms.
+.It Sy name
+Sort rooms by alphabetically ascending room name.
+.It Sy alias
+Sort rooms by alphabetically ascending canonical room alias.
+.It Sy id
+Sort rooms by alphabetically ascending Matrix room identifier.
+.It Sy unread
+Put unread rooms before other rooms.
+.It Sy recent
+Sort rooms by most recent message timestamp.
+.It Sy invite
+Put invites before other rooms.
+.El
 .El
 
 .Ss Example 1: Group room members by ther server first

--- a/src/base.rs
+++ b/src/base.rs
@@ -243,6 +243,9 @@ pub enum SortFieldRoom {
 
     /// Sort rooms by the timestamps of their most recent messages.
     Recent,
+
+    /// Sort rooms by whether they are invites.
+    Invite,
 }
 
 /// Fields that users can be sorted by.
@@ -307,6 +310,7 @@ impl<'de> Visitor<'de> for SortRoomVisitor {
             "name" => SortFieldRoom::Name,
             "alias" => SortFieldRoom::Alias,
             "id" => SortFieldRoom::RoomId,
+            "invite" => SortFieldRoom::Invite,
             _ => {
                 let msg = format!("Unknown sort field: {value:?}");
                 return Err(E::custom(msg));

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,8 +45,9 @@ const DEFAULT_MEMBERS_SORT: [SortColumn<SortFieldUser>; 2] = [
     SortColumn(SortFieldUser::UserId, SortOrder::Ascending),
 ];
 
-const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 4] = [
+const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 5] = [
     SortColumn(SortFieldRoom::Favorite, SortOrder::Ascending),
+    SortColumn(SortFieldRoom::Invite, SortOrder::Ascending),
     SortColumn(SortFieldRoom::LowPriority, SortOrder::Ascending),
     SortColumn(SortFieldRoom::Unread, SortOrder::Ascending),
     SortColumn(SortFieldRoom::Name, SortOrder::Ascending),

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1758,13 +1758,19 @@ mod tests {
 
         // Sort invites first
         let mut rooms = vec![&room1, &room2, &room3];
-        let fields = &[SortColumn(SortFieldRoom::Invite, SortOrder::Ascending)];
+        let fields = &[
+            SortColumn(SortFieldRoom::Invite, SortOrder::Ascending),
+            SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
+        ];
         rooms.sort_by(|a, b| room_fields_cmp(a, b, fields));
         assert_eq!(rooms, vec![&room3, &room1, &room2]);
 
         // Sort invites after
         let mut rooms = vec![&room1, &room2, &room3];
-        let fields = &[SortColumn(SortFieldRoom::Invite, SortOrder::Descending)];
+        let fields = &[
+            SortColumn(SortFieldRoom::Invite, SortOrder::Descending),
+            SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
+        ];
         rooms.sort_by(|a, b| room_fields_cmp(a, b, fields));
         assert_eq!(rooms, vec![&room1, &room2, &room3]);
     }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1578,7 +1578,7 @@ mod tests {
         alias: Option<OwnedRoomAliasId>,
         name: &'static str,
         unread: UnreadInfo,
-        invite: bool
+        invite: bool,
     }
 
     impl RoomLikeItem for &TestRoomItem {


### PR DESCRIPTION
Adds a new order to the settings.sort configuration which puts invites before other rooms. This should counter missing out on invites when the order is set to e.g. "recent".

Note: I did not change any defaults, but would favor `["invites", "favorite", "lowpriority", "unread", "name"]` as default since a user hasn't had a chance to "favorite" or "lowpriority" a new room.