### PR TITLE
Updated rust version and added sqlite in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         # We only need the nightly overlay in the devShell because .rs files are formatted with nightly.
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        rustNightly = pkgs.rust-bin.nightly."2024-03-08".default;
+        rustNightly = pkgs.rust-bin.nightly."2024-12-12".default;
       in
       with pkgs;
       {
@@ -27,7 +27,7 @@
           };
           nativeBuildInputs = [ pkg-config ];
           buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin
-            (with darwin.apple_sdk.frameworks; [ AppKit Security Cocoa]);
+            (with darwin.apple_sdk.frameworks; [ AppKit Security Cocoa ]);
         };
 
         devShell = mkShell {
@@ -38,6 +38,7 @@
             pkg-config
             cargo-tarpaulin
             cargo-watch
+            sqlite
           ];
         };
       });


### PR DESCRIPTION
The original flake.nix did not work to build the latest commit with. This one does, at least in my local tests. I've only tested on an MBP M1, and I don't have any other system with nix (yet), so please test if anyone have other platforms.