### PR TITLE
Support adding rooms to spaces

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -173,6 +173,14 @@ Unban a user from this room with an optional reason.
 Kick a user from this room with an optional reason.
 .El
 
+.Sh "SPACE COMMANDS"
+.Bl -tag -width Ds
+.It Sy ":space child set [room_id]"
+Add a room to the currently focused space.
+.It Sy ":space child remove"
+Remove the selected room room the currently focused space.
+.El
+
 .Sh "WINDOW COMMANDS"
 .Bl -tag -width Ds
 .It Sy ":horizontal [cmd]"

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -159,6 +159,8 @@ Create and point the given alias to the room.
 Delete the provided alias from the room's alternative alias list.
 .It Sy ":room alias show"
 Show alternative aliases to the room, if any are set.
+.It Sy ":room id show"
+Show the Matrix identifier for the room.
 .It Sy ":room canon set [alias]"
 Set the room's canonical alias to the one provided, and make the previous one an alternative alias.
 .It Sy ":room canon unset [alias]"
@@ -178,7 +180,7 @@ Kick a user from this room with an optional reason.
 .It Sy ":space child set [room_id]"
 Add a room to the currently focused space.
 .It Sy ":space child remove"
-Remove the selected room room the currently focused space.
+Remove the selected room from the currently focused space.
 .El
 
 .Sh "WINDOW COMMANDS"

--- a/src/base.rs
+++ b/src/base.rs
@@ -182,8 +182,8 @@ pub enum MessageAction {
 pub enum SpaceAction {
     /// Add a room or update metadata.
     ///
-    /// The [Option<String>] argument is the order parameter.
-    /// The [bool] argument indicates whether the room is suggested.
+    /// The [`Option<String>`] argument is the order parameter.
+    /// The [`bool`] argument indicates whether the room is suggested.
     SetChild(OwnedRoomId, Option<String>, bool),
 
     /// Remove the selected room.

--- a/src/base.rs
+++ b/src/base.rs
@@ -375,6 +375,9 @@ pub enum RoomField {
     /// The room name.
     Name,
 
+    /// The room id.
+    Id,
+
     /// A room tag.
     Tag(TagName),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -748,6 +748,10 @@ pub enum IambError {
     #[error("Current window is not a room or space")]
     NoSelectedRoomOrSpace,
 
+    /// A failure due to not having a room or space item selected in a list.
+    #[error("No room or space currently selected in list")]
+    NoSelectedRoomOrSpaceItem,
+
     /// A failure due to not having a room selected.
     #[error("Current window is not a room")]
     NoSelectedRoom,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -531,6 +531,10 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
             return Result::Err(CommandError::InvalidArgument)
         },
 
+        // :room id show
+        ("id", "show", None) => RoomAction::Show(RoomField::Id).into(),
+        ("", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
         _ => return Result::Err(CommandError::InvalidArgument),
     };
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -815,7 +815,7 @@ pub fn setup_commands() -> ProgramCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use matrix_sdk::ruma::user_id;
+    use matrix_sdk::ruma::{room_id, user_id};
     use modalkit::actions::WindowAction;
     use modalkit::editing::context::EditContext;
 
@@ -1155,6 +1155,103 @@ mod tests {
         let res = cmds.input_cmd(&cmd, ctx.clone()).unwrap();
         let act = RoomAction::Show(RoomField::NotificationMode);
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
+    }
+
+    #[test]
+    fn test_cmd_room_id_show() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let res = cmds.input_cmd("room id show", ctx.clone()).unwrap();
+        let act = RoomAction::Show(RoomField::Id);
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds.input_cmd("room id show foo", ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+    }
+
+    #[test]
+    fn test_cmd_space_child() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let cmd = "space";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let cmd = "space ++foo bar baz";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let cmd = "space child foo";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+    }
+
+    #[test]
+    fn test_cmd_space_child_set() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let cmd = "space child set !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
+        let act = SpaceAction::SetChild(room_id!("!roomid:example.org").to_owned(), None, false);
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let cmd = "space child set ++order=abcd ++suggested !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
+        let act = SpaceAction::SetChild(
+            room_id!("!roomid:example.org").to_owned(),
+            Some("abcd".into()),
+            true,
+        );
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let cmd = "space child set ++order=abcd ++order=1234 !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(
+            res,
+            Err(CommandError::Error("Multiple ++order arguments are not allowed".into()))
+        );
+
+        let cmd = "space child set !roomid:example.org !otherroom:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::Error("Multiple room arguments are not allowed".into())));
+
+        let cmd = "space child set ++foo=abcd !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let cmd = "space child set ++foo !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let cmd = "space child ++order=abcd ++suggested set !roomid:example.org";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let cmd = "space child set foo";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::Error("Invalid room id specified".into())));
+
+        let cmd = "space child set";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::Error("Must specify a room to add".into())));
+    }
+
+    #[test]
+    fn test_cmd_space_child_remove() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let cmd = "space child remove";
+        let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
+        let act = SpaceAction::RemoveChild;
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let cmd = "space child remove foo";
+        let res = cmds.input_cmd(cmd, ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -538,7 +538,7 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
         // :room id show
         ("id", "show", None) => RoomAction::Show(RoomField::Id).into(),
-        ("", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+        ("id", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
 
         _ => return Result::Err(CommandError::InvalidArgument),
     };
@@ -555,14 +555,10 @@ fn iamb_space(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         return Err(CommandError::InvalidArgument);
     }
 
-    let field = if let OptionType::Positional(field) = args.remove(0) {
-        field
-    } else {
+    let OptionType::Positional(field) = args.remove(0) else {
         return Err(CommandError::InvalidArgument);
     };
-    let action = if let OptionType::Positional(action) = args.remove(0) {
-        action
-    } else {
+    let OptionType::Positional(action) = args.remove(0) else {
         return Err(CommandError::InvalidArgument);
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,6 +557,9 @@ impl Application {
             IambAction::Message(act) => {
                 self.screen.current_window_mut()?.message_command(act, ctx, store).await?
             },
+            IambAction::Space(act) => {
+                self.screen.current_window_mut()?.space_command(act, ctx, store).await?
+            },
             IambAction::Room(act) => {
                 let acts = self.screen.current_window_mut()?.room_command(act, ctx, store).await?;
                 self.action_prepend(acts);

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -75,6 +75,7 @@ use crate::base::{
     SortFieldRoom,
     SortFieldUser,
     SortOrder,
+    SpaceAction,
     UnreadInfo,
 };
 
@@ -349,6 +350,19 @@ impl IambWindow {
     ) -> IambResult<EditInfo> {
         if let IambWindow::Room(w) = self {
             w.message_command(act, ctx, store).await
+        } else {
+            return Err(IambError::NoSelectedRoom.into());
+        }
+    }
+
+    pub async fn space_command(
+        &mut self,
+        act: SpaceAction,
+        ctx: ProgramContext,
+        store: &mut ProgramStore,
+    ) -> IambResult<EditInfo> {
+        if let IambWindow::Room(w) = self {
+            w.space_command(act, ctx, store).await
         } else {
             return Err(IambError::NoSelectedRoom.into());
         }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -66,6 +66,7 @@ use crate::base::{
     RoomAction,
     RoomField,
     SendAction,
+    SpaceAction,
 };
 
 use self::chat::ChatState;
@@ -211,6 +212,18 @@ impl RoomState {
         match self {
             RoomState::Chat(chat) => chat.message_command(act, ctx, store).await,
             RoomState::Space(_) => Err(IambError::NoSelectedMessage.into()),
+        }
+    }
+
+    pub async fn space_command(
+        &mut self,
+        act: SpaceAction,
+        ctx: ProgramContext,
+        store: &mut ProgramStore,
+    ) -> IambResult<EditInfo> {
+        match self {
+            RoomState::Space(space) => space.space_command(act, ctx, store).await,
+            RoomState::Chat(_) => Err(IambError::NoSelectedSpace.into()),
         }
     }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -595,7 +595,7 @@ impl RoomState {
                     },
                     RoomField::Id => {
                         let id = room.room_id();
-                        format!("Room id: {id}")
+                        format!("Room identifier: {id}")
                     },
                     RoomField::Name => {
                         match room.name() {

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -464,6 +464,9 @@ impl RoomState {
                     RoomField::Aliases => {
                         // This never happens, aliases is only used for showing
                     },
+                    RoomField::Id => {
+                        // This never happens, id is only used for showing
+                    },
                 }
 
                 Ok(vec![])
@@ -559,6 +562,9 @@ impl RoomState {
                     RoomField::Aliases => {
                         // This will not happen, you cannot unset all aliases
                     },
+                    RoomField::Id => {
+                        // This never happens, id is only used for showing
+                    },
                 }
 
                 Ok(vec![])
@@ -573,6 +579,10 @@ impl RoomState {
                     RoomField::History => {
                         let visibility = room.history_visibility();
                         format!("Room history visibility: {visibility}")
+                    },
+                    RoomField::Id => {
+                        let id = room.room_id();
+                        format!("Room id: {id}")
                     },
                     RoomField::Name => {
                         match room.name() {

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -2,11 +2,14 @@
 use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
+use matrix_sdk::ruma::events::space::child::SpaceChildEventContent;
+use matrix_sdk::ruma::events::StateEventType;
 use matrix_sdk::{
     room::Room as MatrixRoom,
     ruma::{OwnedRoomId, RoomId},
 };
 
+use modalkit::prelude::{EditInfo, InfoMessage};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -22,9 +25,18 @@ use modalkit_ratatui::{
     WindowOps,
 };
 
-use crate::base::{IambBufferId, IambInfo, ProgramStore, RoomFocus};
+use crate::base::{
+    IambBufferId,
+    IambError,
+    IambInfo,
+    IambResult,
+    ProgramContext,
+    ProgramStore,
+    RoomFocus,
+    SpaceAction,
+};
 
-use crate::windows::{room_fields_cmp, RoomItem};
+use crate::windows::{room_fields_cmp, RoomItem, RoomLikeItem};
 
 const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 
@@ -66,6 +78,71 @@ impl SpaceState {
             room: self.room.clone(),
             list: self.list.dup(store),
             last_fetch: self.last_fetch,
+        }
+    }
+
+    pub async fn space_command(
+        &mut self,
+        act: SpaceAction,
+        _: ProgramContext,
+        store: &mut ProgramStore,
+    ) -> IambResult<EditInfo> {
+        match act {
+            SpaceAction::SetChild(child_id, order, suggested) => {
+                if !self
+                    .room
+                    .can_user_send_state(
+                        &store.application.settings.profile.user_id,
+                        StateEventType::SpaceChild,
+                    )
+                    .await
+                    .map_err(IambError::from)?
+                {
+                    return Err(IambError::InsufficientPermission.into());
+                }
+
+                let via = self.room.route().await.map_err(IambError::from)?;
+                let mut ev = SpaceChildEventContent::new(via);
+                ev.order = order;
+                ev.suggested = suggested;
+                let _ = self
+                    .room
+                    .send_state_event_for_key(&child_id, ev)
+                    .await
+                    .map_err(IambError::from)?;
+
+                Ok(InfoMessage::from("Room added").into())
+            },
+            SpaceAction::RemoveChild => {
+                let space = self.list.get().ok_or(IambError::NoSelectedMessage)?;
+                if !self
+                    .room
+                    .can_user_send_state(
+                        &store.application.settings.profile.user_id,
+                        StateEventType::SpaceChild,
+                    )
+                    .await
+                    .map_err(IambError::from)?
+                {
+                    return Err(IambError::InsufficientPermission.into());
+                }
+
+                let ev = SpaceChildEventContent::new(vec![]);
+                let event_id = self
+                    .room
+                    .send_state_event_for_key(&space.room_id().to_owned(), ev)
+                    .await
+                    .map_err(IambError::from)?;
+
+                // Fix for element (see https://github.com/element-hq/element-web/issues/29606)
+                let _ = self
+                    .room
+                    .redact(&event_id.event_id, Some("workaround for element bug"), None)
+                    .await
+                    .map_err(IambError::from)?;
+
+                Ok(InfoMessage::from("Room removed").into())
+            },
         }
     }
 }

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -111,10 +111,10 @@ impl SpaceState {
                     .await
                     .map_err(IambError::from)?;
 
-                Ok(InfoMessage::from("Room added").into())
+                Ok(InfoMessage::from("Space updated").into())
             },
             SpaceAction::RemoveChild => {
-                let space = self.list.get().ok_or(IambError::NoSelectedMessage)?;
+                let space = self.list.get().ok_or(IambError::NoSelectedRoomOrSpaceItem)?;
                 if !self
                     .room
                     .can_user_send_state(


### PR DESCRIPTION
fixes #49 

Implements commands:
- `:room id show` to show the id of the current room
- `:space child set [++order=<order>] [++suggested] <room-id>` to add the room specified by the id to the currently focused space
  - arguments `order` and `suggested` set/update the parameters according to [spec](https://spec.matrix.org/latest/client-server-api/#mspacechild)
- `:space child remove` to remove the selected room from the focused space
  - includes a workaround for element-hq/element-web#29606