### PR TITLE
Update to `mozilla-actions/sccache-action@v0.0.9`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Check formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check Clippy


### PR DESCRIPTION
This pulls in the latest `sccache-action` version in order to fix the broken CI.