### PR TITLE
Bump minimum supported Rust version to 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Install Rust (1.76 w/ clippy)
-      uses: dtolnay/rust-toolchain@1.76
+    - name: Install Rust (1.83 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.83
       with:
           components: clippy
     - name: Install Rust (nightly w/ rustfmt)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = [".github", "CONTRIBUTING.md"]
 keywords = ["matrix", "chat", "tui", "vim"]
 categories = ["command-line-utilities"]
-rust-version = "1.82"
+rust-version = "1.83"
 build = "build.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ user_id = "@user:example.com"
 
 ## Installation (via `crates.io`)
 
-Install Rust (1.76.0 or above) and Cargo, and then run:
+Install Rust (1.83.0 or above) and Cargo, and then run:
 
 ```
 cargo install --locked iamb

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83"
+components = [ "clippy" ]


### PR DESCRIPTION
As of #397, building `iamb` now requires at least Rust 1.83 to build. This PR updates CI and adds a `rust-toolchain.toml` to help people using `cargo` with `rustup` to automatically pull down newer Rust versions.