### PR TITLE
Update to latest `modalkit`, `modalkit-ratatui` and `ratatui-image`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1451,12 +1457,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ed25519"
@@ -2505,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.2"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
 dependencies = [
  "byteorder-lite",
  "quick-error",
@@ -2785,7 +2785,8 @@ dependencies = [
 [[package]]
 name = "keybindings"
 version = "0.0.1"
-source = "git+https://github.com/ulyssa/modalkit?rev=45855daeeb7081eec626a8f9cf657f0fc2ff0a7a#45855daeeb7081eec626a8f9cf657f0fc2ff0a7a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680e4699c91c0622dd70da32c274881aadb1ac86252d738c3641266e90e4ca15"
 dependencies = [
  "textwrap",
  "unicode-segmentation",
@@ -3227,7 +3228,7 @@ checksum = "da30f51dbfcd03297a04f49f92c365a41cb2b012ad3338c0fc5d4efafcbff88b"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.15",
  "gloo-utils",
  "hkdf",
@@ -3277,7 +3278,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc8b6650757f953664e5f906988690cef05c09d83081946adce446c45810a2d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chacha20poly1305",
  "hmac",
@@ -3298,6 +3299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3394,8 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.20"
-source = "git+https://github.com/ulyssa/modalkit?rev=45855daeeb7081eec626a8f9cf657f0fc2ff0a7a#45855daeeb7081eec626a8f9cf657f0fc2ff0a7a"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7599fc1bcd2f0a0b4598f23433b45613345a46419ab27d3a9adecb57acd648"
 dependencies = [
  "anymap2",
  "arboard",
@@ -3415,8 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "modalkit-ratatui"
-version = "0.0.20"
-source = "git+https://github.com/ulyssa/modalkit?rev=45855daeeb7081eec626a8f9cf657f0fc2ff0a7a#45855daeeb7081eec626a8f9cf657f0fc2ff0a7a"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3d88c86435d4b1fb22c7c0f978b09cb888338cafc10336715aa5070e92b6f6"
 dependencies = [
  "crossterm",
  "intervaltree",
@@ -4367,39 +4371,40 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.8.0",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
  "instability",
  "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.13",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "ratatui-image"
-version = "1.0.5"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de94276254cb20fb7431726875bd2ac6391a6ffc26f4b8e3d23f79d1286b491e"
+checksum = "d6f868820aabfce698e69639620ab9100f2ca29319ba960b9ba218482065489d"
 dependencies = [
- "base64",
- "dyn-clone",
+ "base64 0.21.7",
  "icy_sixel",
  "image",
  "rand 0.8.5",
  "ratatui",
  "rustix 0.38.44",
  "serde",
+ "thiserror 1.0.63",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4448,6 +4453,7 @@ dependencies = [
  "loop9",
  "quick-error",
  "rav1e",
+ "rayon",
  "rgb",
 ]
 
@@ -4551,7 +4557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4599,9 +4605,6 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "ring"
@@ -4718,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1058c04b8dd62f4fba71c9f65112fb79bc332438d11aefe1e8edf67b7fb58a98"
 dependencies = [
  "as_variant",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.15",
@@ -5418,7 +5421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006851c9ccefa3c38a7646b8cec804bb429def3da10497bfa977179869c3e8e2"
 dependencies = [
  "quick-xml 0.30.0",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -6053,7 +6056,7 @@ checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
 dependencies = [
  "aes",
  "arrayvec",
- "base64",
+ "base64 0.22.1",
  "base64ct",
  "cbc",
  "chacha20poly1305",
@@ -6344,6 +6347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6359,6 +6372,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ emojis = "0.5"
 futures = "0.3"
 gethostname = "0.4.1"
 html5ever = "0.26.0"
-image = "0.25.2"
+image = "^0.25.6"
 libc = "0.2"
 markup5ever_rcdom = "0.2.0"
 mime = "^0.3.16"
@@ -45,8 +45,8 @@ mime_guess = "^2.0.4"
 nom = "7.0.0"
 open = "3.2.0"
 rand = "0.8.5"
-ratatui = "0.28.1"
-ratatui-image = { version = "=1.0.5", features = ["serde"] }
+ratatui = "0.29.0"
+ratatui-image = { version = "~6.0.0", features = ["serde"] }
 regex = "^1.5"
 rpassword = "^7.2"
 serde = "^1.0"
@@ -76,13 +76,15 @@ features = ["zbus", "serde"]
 optional = true
 
 [dependencies.modalkit]
+version = "0.0.21"
 default-features = false
-git = "https://github.com/ulyssa/modalkit"
-rev = "45855daeeb7081eec626a8f9cf657f0fc2ff0a7a"
+#git = "https://github.com/ulyssa/modalkit"
+#rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 
 [dependencies.modalkit-ratatui]
-git = "https://github.com/ulyssa/modalkit"
-rev = "45855daeeb7081eec626a8f9cf657f0fc2ff0a7a"
+version = "0.0.21"
+#git = "https://github.com/ulyssa/modalkit"
+#rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 
 [dependencies.matrix-sdk]
 version = "0.10.0"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1319,7 +1319,7 @@ fn emoji_map() -> CompletionMap<String, &'static Emoji> {
 
 #[cfg(unix)]
 fn picker_from_termios(protocol_type: Option<ProtocolType>) -> Option<Picker> {
-    let mut picker = match Picker::from_termios() {
+    let mut picker = match Picker::from_query_stdio() {
         Ok(picker) => picker,
         Err(e) => {
             tracing::error!("Failed to setup image previews: {e}");
@@ -1327,12 +1327,8 @@ fn picker_from_termios(protocol_type: Option<ProtocolType>) -> Option<Picker> {
         },
     };
 
-    // `guess_protocol` also does tmux detection,
-    // run it always then overwrite the guessed protocol if needed
-    picker.guess_protocol();
-
     if let Some(protocol_type) = protocol_type {
-        picker.protocol_type = protocol_type;
+        picker.set_protocol_type(protocol_type);
     }
 
     Some(picker)
@@ -1355,8 +1351,8 @@ fn picker_from_settings(settings: &ApplicationSettings) -> Option<Picker> {
     }) = image_preview_protocol
     {
         // User forced type and font_size: use that.
-        let mut picker = Picker::new(font_size);
-        picker.protocol_type = protocol_type;
+        let mut picker = Picker::from_fontsize(font_size);
+        picker.set_protocol_type(protocol_type);
         Some(picker)
     } else {
         // Guess, but use type if forced.

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -70,7 +70,7 @@ mod printer;
 
 pub use self::compose::text_to_message;
 
-type ProtocolPreview<'a> = (&'a dyn Protocol, u16, u16);
+type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 
 pub type MessageKey = (MessageTimeStamp, OwnedEventId);
 
@@ -826,7 +826,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loaded(Box<dyn Protocol>),
+    Loaded(Protocol),
     Error(String),
 }
 
@@ -1046,7 +1046,7 @@ impl Message {
         style: Style,
         hide_reply: bool,
         emoji_shortcodes: bool,
-    ) -> (Text, Option<&dyn Protocol>) {
+    ) -> (Text, Option<&Protocol>) {
         if let Some(html) = &self.html {
             (html.to_text(width, style, hide_reply, emoji_shortcodes), None)
         } else {
@@ -1066,8 +1066,8 @@ impl Message {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
-                    proto = Some(backend.as_ref());
-                    placeholder_frame(Some("Loading..."), width, &backend.rect().into())
+                    proto = Some(backend);
+                    placeholder_frame(Some("Loading..."), width, &backend.area().into())
                 },
                 ImageStatus::Error(err) => Some(format!("[Image error: {err}]\n")),
             };

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1402,7 +1402,7 @@ impl<'a> StatefulWidget for Scrollback<'a> {
         // line.
         for (x, y, backend) in image_previews {
             let image_widget = Image::new(backend);
-            let mut rect = backend.rect();
+            let mut rect = backend.area();
             rect.x = x;
             rect.y = y;
             // Don't render outside of scrollback area


### PR DESCRIPTION
This updates to `modalkit@0.0.21`, `modalkit-ratatui@0.0.21`, and `ratatui-image@5.0.0` (but pointing at a Git SHA that includes benjajaja/ratatui-image#91 for now).