### PR TITLE
Clear desktop notification when message is read

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -92,6 +92,7 @@ use modalkit::{
 
 use crate::config::ImagePreviewProtocolValues;
 use crate::message::ImageStatus;
+use crate::notifications::NotificationHandle;
 use crate::preview::{source_from_event, spawn_insert_preview};
 use crate::{
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
@@ -1556,6 +1557,9 @@ pub struct ChatStore {
 
     /// Collator for locale-aware text sorting.
     pub collator: feruca::Collator,
+
+    /// Notifications that should be dismissed when the user opens the room.
+    pub open_notifications: HashMap<OwnedRoomId, Vec<NotificationHandle>>,
 }
 
 impl ChatStore {
@@ -1580,6 +1584,7 @@ impl ChatStore {
             draw_curr: None,
             ring_bell: false,
             focused: true,
+            open_notifications: Default::default(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,6 +557,9 @@ impl Application {
             IambAction::ClearUnreads => {
                 let user_id = &store.application.settings.profile.user_id;
 
+                // Clear any notifications we displayed:
+                store.application.open_notifications.clear();
+
                 for room_id in store.application.sync_info.chats() {
                     if let Some(room) = store.application.rooms.get_mut(room_id) {
                         room.fully_read(user_id);

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -8,6 +8,7 @@ use matrix_sdk::{
         events::{room::message::MessageType, AnyMessageLikeEventContent, AnySyncTimelineEvent},
         serde::Raw,
         MilliSecondsSinceUnixEpoch,
+        OwnedRoomId,
         RoomId,
     },
     Client,
@@ -23,6 +24,19 @@ const IAMB_XDG_NAME: &str = match option_env!("IAMB_XDG_NAME") {
     None => "iamb",
     Some(iamb) => iamb,
 };
+
+/// Handle for an open notification that should be closed when the user views it.
+pub struct NotificationHandle(
+    #[cfg(all(feature = "desktop", unix, not(target_os = "macos")))]
+    notify_rust::NotificationHandle,
+);
+
+impl NotificationHandle {
+    pub fn close(self) {
+        #[cfg(all(feature = "desktop", unix, not(target_os = "macos")))]
+        self.0.close();
+    }
+}
 
 pub async fn register_notifications(
     client: &Client,
@@ -54,6 +68,7 @@ pub async fn register_notifications(
                     return;
                 }
 
+                let room_id = room.room_id().to_owned();
                 match notification.event {
                     RawAnySyncOrStrippedTimelineEvent::Sync(e) => {
                         match parse_full_notification(e, room, show_message).await {
@@ -66,8 +81,14 @@ pub async fn register_notifications(
                                     return;
                                 }
 
-                                send_notification(&notify_via, &store, &summary, body.as_deref())
-                                    .await;
+                                send_notification(
+                                    &notify_via,
+                                    &store,
+                                    &summary,
+                                    body.as_deref(),
+                                    room_id,
+                                )
+                                .await;
                             },
                             Err(err) => {
                                 tracing::error!("Failed to extract notification data: {err}")
@@ -89,10 +110,11 @@ async fn send_notification(
     store: &AsyncProgramStore,
     summary: &str,
     body: Option<&str>,
+    room_id: OwnedRoomId,
 ) {
     #[cfg(feature = "desktop")]
     if via.desktop {
-        send_notification_desktop(summary, body);
+        send_notification_desktop(store, summary, body, room_id).await;
     }
     #[cfg(not(feature = "desktop"))]
     {
@@ -110,7 +132,12 @@ async fn send_notification_bell(store: &AsyncProgramStore) {
 }
 
 #[cfg(feature = "desktop")]
-fn send_notification_desktop(summary: &str, body: Option<&str>) {
+async fn send_notification_desktop(
+    store: &AsyncProgramStore,
+    summary: &str,
+    body: Option<&str>,
+    room_id: OwnedRoomId,
+) {
     let mut desktop_notification = notify_rust::Notification::new();
     desktop_notification
         .summary(summary)
@@ -125,8 +152,18 @@ fn send_notification_desktop(summary: &str, body: Option<&str>) {
         desktop_notification.body(body);
     }
 
-    if let Err(err) = desktop_notification.show() {
-        tracing::error!("Failed to send notification: {err}")
+    match desktop_notification.show() {
+        Err(err) => tracing::error!("Failed to send notification: {err}"),
+        Ok(handle) => {
+            let mut locked = store.lock().await;
+            #[cfg(all(unix, not(target_os = "macos")))]
+            locked
+                .application
+                .open_notifications
+                .entry(room_id)
+                .or_default()
+                .push(NotificationHandle(handle));
+        },
     }
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -507,20 +507,17 @@ async fn send_receipts_forever(client: &Client, store: &AsyncProgramStore) {
         let user_id = &settings.profile.user_id;
 
         let mut updates = Vec::new();
-        let mut notifications = Vec::new();
         for room in client.joined_rooms() {
-            let room_id = room.room_id().to_owned();
-            let Some(info) = rooms.get(&room_id) else {
+            let room_id = room.room_id();
+            let Some(info) = rooms.get(room_id) else {
                 continue;
             };
 
             let changed = info.receipts(user_id).filter_map(|(thread, new_receipt)| {
-                let old_receipt = sent.get(&room_id).and_then(|ts| ts.get(thread));
+                let old_receipt = sent.get(room_id).and_then(|ts| ts.get(thread));
                 let changed = Some(new_receipt) != old_receipt;
                 if changed {
-                    if let Some(notification) = open_notifications.remove(&room_id) {
-                        notifications.extend(notification);
-                    }
+                    open_notifications.remove(room_id);
                 }
                 changed.then(|| (room_id.to_owned(), thread.to_owned(), new_receipt.to_owned()))
             });
@@ -528,10 +525,6 @@ async fn send_receipts_forever(client: &Client, store: &AsyncProgramStore) {
             updates.extend(changed);
         }
         drop(locked);
-
-        for notification in notifications {
-            notification.close();
-        }
 
         for (room_id, thread, new_receipt) in updates {
             use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;


### PR DESCRIPTION
Currently desktop notifications are never dismissed. When a user has a notification daemon that keeps all notifications until they are explicitly closed, they have to manually dismiss the notification to have an empty feed.

This adds logic to close the notification when a read receipt is sent. This matches the behavior of other clients like element-desktop.