### PR TITLE
Fix Clippy warnings for 1.83

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -293,7 +293,7 @@ impl<'de> Deserialize<'de> for SortColumn<SortFieldRoom> {
 /// [serde] visitor for deserializing [SortColumn] for rooms and spaces.
 struct SortRoomVisitor;
 
-impl<'de> Visitor<'de> for SortRoomVisitor {
+impl Visitor<'_> for SortRoomVisitor {
     type Value = SortColumn<SortFieldRoom>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -346,7 +346,7 @@ impl<'de> Deserialize<'de> for SortColumn<SortFieldUser> {
 /// [serde] visitor for deserializing [SortColumn] for users.
 struct SortUserVisitor;
 
-impl<'de> Visitor<'de> for SortUserVisitor {
+impl Visitor<'_> for SortUserVisitor {
     type Value = SortColumn<SortFieldUser>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -1182,7 +1182,7 @@ impl RoomInfo {
 
     /// Indicates whether we've recently fetched scrollback for this room.
     pub fn recently_fetched(&self) -> bool {
-        self.fetch_last.map_or(false, |i| i.elapsed() < ROOM_FETCH_DEBOUNCE)
+        self.fetch_last.is_some_and(|i| i.elapsed() < ROOM_FETCH_DEBOUNCE)
     }
 
     fn clear_receipt(&mut self, user_id: &OwnedUserId) -> Option<()> {
@@ -1609,7 +1609,7 @@ impl<'de> Deserialize<'de> for IambId {
 /// [serde] visitor for deserializing [IambId].
 struct IambIdVisitor;
 
-impl<'de> Visitor<'de> for IambIdVisitor {
+impl Visitor<'_> for IambIdVisitor {
     type Value = IambId;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ fn validate_profile_name(name: &str) -> bool {
 
     let mut chars = name.chars();
 
-    if !chars.next().map_or(false, |c| c.is_ascii_alphanumeric()) {
+    if !chars.next().is_some_and(|c| c.is_ascii_alphanumeric()) {
         return false;
     }
 
@@ -152,7 +152,7 @@ pub enum ConfigError {
 pub struct Keys(pub Vec<TerminalKey>, pub String);
 pub struct KeysVisitor;
 
-impl<'de> Visitor<'de> for KeysVisitor {
+impl Visitor<'_> for KeysVisitor {
     type Value = Keys;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -183,7 +183,7 @@ impl<'de> Deserialize<'de> for Keys {
 pub struct VimModes(pub Vec<VimMode>);
 pub struct VimModesVisitor;
 
-impl<'de> Visitor<'de> for VimModesVisitor {
+impl Visitor<'_> for VimModesVisitor {
     type Value = VimModes;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -233,7 +233,7 @@ impl From<LogLevel> for Level {
     }
 }
 
-impl<'de> Visitor<'de> for LogLevelVisitor {
+impl Visitor<'_> for LogLevelVisitor {
     type Value = LogLevel;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -268,7 +268,7 @@ impl<'de> Deserialize<'de> for LogLevel {
 pub struct UserColor(pub Color);
 pub struct UserColorVisitor;
 
-impl<'de> Visitor<'de> for UserColorVisitor {
+impl Visitor<'_> for UserColorVisitor {
     type Value = UserColor;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -419,7 +419,7 @@ impl Default for NotifyVia {
     }
 }
 
-impl<'de> Visitor<'de> for NotifyViaVisitor {
+impl Visitor<'_> for NotifyViaVisitor {
     type Value = NotifyVia;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -906,7 +906,7 @@ impl<'a> Chat<'a> {
     }
 }
 
-impl<'a> StatefulWidget for Chat<'a> {
+impl StatefulWidget for Chat<'_> {
     type State = ChatState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1284,7 +1284,7 @@ impl<'a> Scrollback<'a> {
     }
 }
 
-impl<'a> StatefulWidget for Scrollback<'a> {
+impl StatefulWidget for Scrollback<'_> {
     type State = ScrollbackState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -184,7 +184,7 @@ impl<'a> Space<'a> {
     }
 }
 
-impl<'a> StatefulWidget for Space<'a> {
+impl StatefulWidget for Space<'_> {
     type State = SpaceState;
 
     fn render(self, area: Rect, buffer: &mut Buffer, state: &mut Self::State) {


### PR DESCRIPTION
Fix all warnings generated by `cargo clippy`.