### PR TITLE
Update to `ratatui-image@8.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,9 +4392,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "6.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f868820aabfce698e69639620ab9100f2ca29319ba960b9ba218482065489d"
+checksum = "e8fe71c551c67f34e4fa49797227f614cd064b82855d7b72d424e40d08ec0542"
 dependencies = [
  "base64 0.21.7",
  "icy_sixel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nom = "7.0.0"
 open = "3.2.0"
 rand = "0.8.5"
 ratatui = "0.29.0"
-ratatui-image = { version = "~6.0.0", features = ["serde"] }
+ratatui-image = { version = "~8.0.1", features = ["serde"] }
 regex = "^1.5"
 rpassword = "^7.2"
 serde = "^1.0"

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -350,7 +350,7 @@ fn load_insert(
                         info.insert_with_preview(
                             room_id.clone(),
                             store.clone(),
-                            *picker,
+                            picker.clone(),
                             msg,
                             settings,
                             client.media(),
@@ -1002,7 +1002,7 @@ impl ClientWorker {
                     info.insert_with_preview(
                         room_id.to_owned(),
                         store.clone(),
-                        *picker,
+                        picker.clone(),
                         full_ev,
                         settings,
                         client.media(),


### PR DESCRIPTION
This updates `ratatui-image` to v8.0.1 in order to pull in benjajaja/ratatui-image#97, which fixes an issue someone noticed in `#iamb-users` with resizing images when using halfblocks noticed.