### PR TITLE
Do proper Unicode collation on room names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1620,6 +1640,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "feruca"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06eccaab9dc53ad4bffb4ed748baf5c1f9475d5e9cac35e1b8eac69dac56899e"
+dependencies = [
+ "bincode",
+ "bstr",
+ "once_cell",
+ "rustc-hash",
+ "unicode-canonical-combining-class",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2231,7 @@ dependencies = [
  "dirs",
  "edit",
  "emojis",
+ "feruca",
  "futures",
  "gethostname",
  "html5ever",
@@ -5712,6 +5746,12 @@ name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-canonical-combining-class"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41c99d5174052d02ce765418e826597a1be18f32c114e35d9e22f92390239561"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ clap = {version = "~4.3", features = ["derive"]}
 css-color-parser = "0.1.2"
 dirs = "4.0.0"
 emojis = "0.5"
+feruca = "0.10.1"
 futures = "0.3"
 gethostname = "0.4.1"
 html5ever = "0.26.0"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1486,6 +1486,9 @@ pub struct ChatStore {
 
     /// Whether the application is currently focused
     pub focused: bool,
+
+    /// Collator for locale-aware text sorting.
+    pub collator: feruca::Collator,
 }
 
 impl ChatStore {
@@ -1500,6 +1503,7 @@ impl ChatStore {
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 
+            collator: Default::default(),
             names: Default::default(),
             rooms: Default::default(),
             presences: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! # Logic for loading and validating application configuration
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
@@ -105,7 +105,7 @@ fn validate_profile_name(name: &str) -> bool {
     name.chars().all(is_profile_char)
 }
 
-fn validate_profile_names(names: &HashMap<String, ProfileConfig>) {
+fn validate_profile_names(names: &BTreeMap<String, ProfileConfig>) {
     for name in names.keys() {
         if validate_profile_name(name.as_str()) {
             continue;
@@ -787,7 +787,7 @@ pub struct ProfileConfig {
 
 #[derive(Clone, Deserialize)]
 pub struct IambConfig {
-    pub profiles: HashMap<String, ProfileConfig>,
+    pub profiles: BTreeMap<String, ProfileConfig>,
     pub default_profile: Option<String>,
     pub settings: Option<Tunables>,
     pub dirs: Option<Directories>,

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -214,7 +214,8 @@ impl StatefulWidget for Space<'_> {
                         })
                         .collect::<Vec<_>>();
                     let fields = &self.store.application.settings.tunables.sort.rooms;
-                    items.sort_by(|a, b| room_fields_cmp(a, b, fields));
+                    let collator = &mut self.store.application.collator;
+                    items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
 
                     state.list.set(items);
                     state.last_fetch = Some(Instant::now());


### PR DESCRIPTION
This uses the `feruca` crate to help collate room names so that folks can get something better than the byte comparisons that Rust does by default.

I've also updated profiles to be deserialized into a `BTreeMap` so that they'll be consistently printed in the same order in the list added in #432.