### PR TITLE
Add more compatibility for unreads

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1155,11 +1155,7 @@ impl RoomInfo {
             }
         });
 
-        let last_receipt = if last_receipt >= last_unthreaded {
-            last_receipt
-        } else {
-            last_unthreaded
-        };
+        let last_receipt = std::cmp::max(last_receipt, last_unthreaded);
 
         match (last_message, last_receipt) {
             (Some(((ts, _), _)), Some((read_ts, _))) => {


### PR DESCRIPTION
I have a problem where my read receipt for the main thread isn't updated if there is already an unthreaded receipt for the same event. I'm not sure if this is the sdk or synapse but it messes up the read receipts in some rooms. This will use either the main thread or the unthreaded receipt depending on which one is newer.