### PR TITLE
Don't try to hide ambiguous usernames

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -22,7 +22,6 @@ use url::Url;
 use matrix_sdk::{
     authentication::matrix::MatrixSession,
     config::{RequestConfig, SyncSettings},
-    deserialized_responses::DisplayName,
     encryption::verification::{SasVerification, Verification},
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_handler::Ctx,
@@ -1094,30 +1093,15 @@ impl ClientWorker {
         );
 
         let _ = self.client.add_event_handler(
-            |ev: OriginalSyncRoomMemberEvent,
-             room: MatrixRoom,
-             client: Client,
-             store: Ctx<AsyncProgramStore>| {
+            |ev: OriginalSyncRoomMemberEvent, room: MatrixRoom, store: Ctx<AsyncProgramStore>| {
                 async move {
                     let room_id = room.room_id();
                     let user_id = ev.state_key;
 
-                    let ambiguous_name = DisplayName::new(
-                        ev.content.displayname.as_deref().unwrap_or_else(|| user_id.as_str()),
-                    );
-                    let ambiguous = client
-                        .state_store()
-                        .get_users_with_display_name(room_id, &ambiguous_name)
-                        .await
-                        .map(|users| users.len() > 1)
-                        .unwrap_or_default();
-
                     let mut locked = store.lock().await;
                     let info = locked.application.get_room_info(room_id.to_owned());
 
-                    if ambiguous {
-                        info.display_names.remove(&user_id);
-                    } else if let Some(display) = ev.content.displayname {
+                    if let Some(display) = ev.content.displayname {
                         info.display_names.insert(user_id, display);
                     } else {
                         info.display_names.remove(&user_id);


### PR DESCRIPTION
## reasons
- users are still distinguished by color
- The names get loaded via plans anyway and `worker.rs:members_insert` doesn't check for ambiguous names so there is a race condition
- bridges to other chat platforms sometime have multiple puppet accounts with the same user name and just an id as a localpart which is useless for identifying the user to a human

## alternatives
- fix the insert logic in `members_insert` and add a config option