### PR TITLE
Open `:members` in the same window by default

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,7 @@ default_room = "#iamb-users:0x.badd.cafe"
 default_split = "vertical"
 external_edit_file_suffix = ".md"
 log_level = "warn"
+members_split = "vertical"
 message_shortcode_display = false
 open_command = ["my-open", "--file"]
 reaction_display = true

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -205,6 +205,15 @@ for more details.
 .It Sy message_shortcode_display
 Defines whether or not Emoji characters in messages should be replaced by their
 respective shortcodes.
+.It Sy members_split
+When set, this forces the
+.Sy :members
+command to open in a new window split instead of in the same window.
+Possible values are
+.Dq Sy vertical
+or
+.Dq Sy horizontal ,
+to control what kind of split is done.
 .It Sy message_user_color
 Defines whether or not the message body is colored like the username.
 .It Sy normal_after_send

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,10 @@ use ratatui_image::picker::ProtocolType;
 use serde::{Deserialize, Deserializer, Serialize, de::Error as SerdeError, de::Visitor};
 use url::Url;
 
-use modalkit::{env::vim::VimMode, key::TerminalKey, keybindings::InputKey};
+use modalkit::env::vim::VimMode;
+use modalkit::key::TerminalKey;
+use modalkit::keybindings::InputKey;
+use modalkit::prelude::Axis;
 
 use super::base::{
     IambError,
@@ -463,6 +466,15 @@ pub enum SplitDirection {
     Vertical,
 }
 
+impl SplitDirection {
+    pub fn to_axis(self) -> Axis {
+        match self {
+            Self::Horizontal => Axis::Horizontal,
+            Self::Vertical => Axis::Vertical,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NotifyVia {
     /// Deliver notifications via terminal bell.
@@ -818,6 +830,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub members_split: Option<SplitDirection>,
     pub default_split: SplitDirection,
     pub ssl_verify: bool,
 }
@@ -865,6 +878,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub members_split: Option<SplitDirection>,
     pub default_split: Option<SplitDirection>,
     pub ssl_verify: Option<bool>,
 }
@@ -911,6 +925,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            members_split: self.members_split.or(other.members_split),
             default_split: self.default_split.or(other.default_split),
             ssl_verify: self.ssl_verify.or(other.ssl_verify),
         }
@@ -949,6 +964,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            members_split: self.members_split,
             default_split: self.default_split.unwrap_or_default(),
             ssl_verify: self.ssl_verify.unwrap_or(true),
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -204,6 +204,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        members_split: Default::default(),
         default_split: Default::default(),
         ssl_verify: true,
     }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -46,6 +46,7 @@ use modalkit::actions::{
     PromptAction,
     Promptable,
     Scrollable,
+    WindowAction,
 };
 use modalkit::errors::{EditResult, UIError};
 use modalkit::prelude::*;
@@ -340,13 +341,10 @@ impl RoomState {
 
                 Ok(vec![])
             },
-            RoomAction::Members(mut cmd) => {
-                let width = Count::Exact(30);
-                let act =
-                    cmd.default_axis(Axis::Vertical).default_relation(MoveDir1D::Next).window(
-                        OpenTarget::Application(IambId::MemberList(self.id().to_owned())),
-                        width.into(),
-                    );
+            RoomAction::Members(cmd) => {
+                let act = Action::Window(WindowAction::Switch(OpenTarget::Application(
+                    IambId::MemberList(self.id().to_owned()),
+                )));
 
                 Ok(vec![(act, cmd.context.clone())])
             },

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -40,7 +40,6 @@ use modalkit::actions::{
     PromptAction,
     Promptable,
     Scrollable,
-    WindowAction,
 };
 use modalkit::errors::{EditResult, UIError};
 use modalkit::prelude::*;
@@ -201,9 +200,14 @@ pub async fn room_command(
             Ok(vec![])
         },
         RoomAction::Members(mut cmd) => {
-            let act = Action::Window(WindowAction::Switch(OpenTarget::Application(
-                IambId::MemberList(id.to_owned()),
-            )));
+            let id = IambId::MemberList(id.to_owned());
+            let target = OpenTarget::Application(id);
+            let cmd = cmd.default_relation(MoveDir1D::Next);
+
+            let act = match store.application.settings.tunables.members_split {
+                Some(dir) => cmd.default_axis(dir.to_axis()).window(target, None),
+                None => cmd.switch(target),
+            };
 
             Ok(vec![(act, cmd.context.clone())])
         },


### PR DESCRIPTION
Afaik `:members` is the only command that opens a split. This is disrupting for a workflow that uses only one window and the jumplist.

The old behavior can be recreated using the macro `:rightb :vs<Enter>:vert :res 30<Enter>:members<Enter>`.