### PR TITLE
Fix display of tabs in code blocks

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -231,6 +231,10 @@ Possible values are
 Specify the width of the column where usernames are displayed in a room.
 Usernames that are too long are truncated.
 Defaults to 30.
+
+.It Sy tabstop
+Number of spaces that a <Tab> counts for.
+Defaults to 4.
 .El
 
 .Ss Example 1: Avoid showing Emojis (useful for terminals w/o support)

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,6 +574,7 @@ pub struct TunableValues {
     pub image_preview: Option<ImagePreviewValues>,
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
+    pub tabstop: usize,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -600,6 +601,7 @@ pub struct Tunables {
     pub image_preview: Option<ImagePreview>,
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
+    pub tabstop: Option<usize>,
 }
 
 impl Tunables {
@@ -632,6 +634,7 @@ impl Tunables {
             external_edit_file_suffix: self
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
+            tabstop: self.tabstop.or(other.tabstop),
         }
     }
 
@@ -660,6 +663,7 @@ impl Tunables {
             external_edit_file_suffix: self
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
+            tabstop: self.tabstop.unwrap_or(4),
         }
     }
 }

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -1415,13 +1415,14 @@ pub mod tests {
         let s = concat!(
             "<pre><code class=\"language-rust\">",
             "fn hello() -&gt; usize {\n",
+            " \t// weired\n",
             "    return 5;\n",
             "}\n",
             "</code></pre>\n"
         );
         let tree = parse_matrix_html(s);
         let text = tree.to_text(25, Style::default(), true, &settings);
-        assert_eq!(text.lines.len(), 5);
+        assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
             Line::from(vec![
@@ -1454,6 +1455,20 @@ pub mod tests {
             text.lines[2],
             Line::from(vec![
                 Span::raw(line::VERTICAL),
+                Span::raw(" "),
+                Span::raw("   "),
+                Span::raw("/"),
+                Span::raw("/"),
+                Span::raw(" "),
+                Span::raw("weired"),
+                Span::raw("          "),
+                Span::raw(line::VERTICAL)
+            ])
+        );
+        assert_eq!(
+            text.lines[3],
+            Line::from(vec![
+                Span::raw(line::VERTICAL),
                 Span::raw("    "),
                 Span::raw("return"),
                 Span::raw(" "),
@@ -1464,7 +1479,7 @@ pub mod tests {
             ])
         );
         assert_eq!(
-            text.lines[3],
+            text.lines[4],
             Line::from(vec![
                 Span::raw(line::VERTICAL),
                 Span::raw("}"),
@@ -1473,7 +1488,7 @@ pub mod tests {
             ])
         );
         assert_eq!(
-            text.lines[4],
+            text.lines[5],
             Line::from(vec![
                 Span::raw(line::BOTTOM_LEFT),
                 Span::raw(line::HORIZONTAL.repeat(23)),

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -216,6 +216,8 @@ impl<'a> TextPrinter<'a> {
             return;
         }
 
+        let tabstop = self.settings().tunables.tabstop;
+
         for mut word in UnicodeSegmentation::split_word_bounds(s) {
             if let "\n" | "\r\n" = word {
                 if self.literal {
@@ -232,11 +234,17 @@ impl<'a> TextPrinter<'a> {
                 continue;
             }
 
-            let cow = if self.emoji_shortcodes() {
+            let mut cow = if self.emoji_shortcodes() {
                 Cow::Owned(replace_emojis_in_str(word))
             } else {
                 Cow::Borrowed(word)
             };
+
+            if cow == "\t" {
+                let tablen = tabstop - (self.curr_width % tabstop);
+                cow = Cow::Owned(" ".repeat(tablen));
+            }
+
             let sw = UnicodeWidthStr::width(cow.as_ref());
 
             if sw > self.width {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -198,6 +198,7 @@ pub fn mock_tunables() -> TunableValues {
         },
         image_preview: None,
         user_gutter_width: 30,
+        tabstop: 4,
     }
 }
 


### PR DESCRIPTION
see `#iamb-users` for context

This converts tabs to spaces according to the new config option `tabstop`.