### PR TITLE
Render image previews lazily

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -138,6 +138,13 @@ Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
 The available fields in this object are:
 .Bl -tag -width Ds
+.It Sy lazy_load
+If
+.Sy true
+(the default), download and render image previews when viewing a message with an image.
+If
+.Sy false ,
+load previews as soon as a message with an image is received.
 .It Sy size
 An optional object with
 .Sy width
@@ -538,8 +545,6 @@ Configured as an object under the key
 .It Sy cache
 Specifies where to store assets and temporary data in.
 (For example,
-.Sy image_preview
-and
 .Sy logs
 will also go in here by default.)
 Defaults to
@@ -554,11 +559,6 @@ Defaults to
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
-.It Sy image_previews
-Specifies where to store automatically downloaded image previews.
-Defaults to
-.Ev ${cache}/image_preview_downloads .
 
 .It Sy logs
 Specifies where to store log files.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -138,6 +138,13 @@ Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
 The available fields in this object are:
 .Bl -tag -width Ds
+.It Sy lazy_load
+If
+.Sy true
+(the default), download and render image previews when viewing a message with an image.
+If
+.Sy false ,
+load previews as soon as a message with an image is received.
 .It Sy size
 An optional object with
 .Sy width
@@ -588,8 +595,6 @@ Configured as an object under the key
 .It Sy cache
 Specifies where to store assets and temporary data in.
 (For example,
-.Sy image_preview
-and
 .Sy logs
 will also go in here by default.)
 Defaults to
@@ -604,11 +609,6 @@ Defaults to
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
-.It Sy image_previews
-Specifies where to store automatically downloaded image previews.
-Defaults to
-.Ev ${cache}/image_preview_downloads .
 
 .It Sy logs
 Specifies where to store log files.

--- a/src/base.rs
+++ b/src/base.rs
@@ -1239,7 +1239,7 @@ impl RoomInfo {
         &mut self,
         room_id: OwnedRoomId,
         store: AsyncProgramStore,
-        picker: Option<Picker>,
+        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
         settings: &mut ApplicationSettings,
         media: matrix_sdk::Media,
@@ -1259,6 +1259,7 @@ impl RoomInfo {
                     source,
                     media,
                     settings.dirs.image_previews.clone(),
+                    image_preview.size.clone(),
                 )
             }
         }
@@ -1602,7 +1603,7 @@ pub struct ChatStore {
     pub sync_info: SyncInfo,
 
     /// Image preview "protocol" picker.
-    pub picker: Option<Picker>,
+    pub picker: Option<Arc<Picker>>,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1628,7 +1629,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker,
+            picker: picker.map(Into::into),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -1238,7 +1238,7 @@ impl RoomInfo {
         &mut self,
         room_id: OwnedRoomId,
         store: AsyncProgramStore,
-        picker: Option<Picker>,
+        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
         settings: &mut ApplicationSettings,
         media: matrix_sdk::Media,
@@ -1258,6 +1258,7 @@ impl RoomInfo {
                     source,
                     media,
                     settings.dirs.image_previews.clone(),
+                    image_preview.size.clone(),
                 )
             }
         }
@@ -1601,7 +1602,7 @@ pub struct ChatStore {
     pub sync_info: SyncInfo,
 
     /// Image preview "protocol" picker.
-    pub picker: Option<Picker>,
+    pub picker: Option<Arc<Picker>>,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1627,7 +1628,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker,
+            picker: picker.map(Into::into),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -90,9 +90,8 @@ use modalkit::{
 };
 
 use crate::config::ImagePreviewProtocolValues;
-use crate::message::ImageStatus;
 use crate::notifications::NotificationHandle;
-use crate::preview::{source_from_event, spawn_insert_preview};
+use crate::preview::{source_from_event, PreviewManager};
 use crate::{
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
     worker::Requester,
@@ -1232,34 +1231,23 @@ impl RoomInfo {
         }
     }
 
-    /// Insert a new message event, and spawn a task for image-preview if it has an image
-    /// attachment.
+    /// Insert a new message event, and prepare for image-preview if it has an image attachment.
     pub fn insert_with_preview(
         &mut self,
-        room_id: OwnedRoomId,
-        store: AsyncProgramStore,
-        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
-        settings: &mut ApplicationSettings,
-        media: matrix_sdk::Media,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
+        worker: &Requester,
     ) {
-        let source = picker.and_then(|_| source_from_event(&ev));
+        let source = source_from_event(&ev);
         self.insert(ev);
 
         if let Some((event_id, source)) = source {
             if let (Some(msg), Some(image_preview)) =
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
             {
-                msg.image_preview = ImageStatus::Downloading(image_preview.size.clone());
-                spawn_insert_preview(
-                    store,
-                    room_id,
-                    event_id,
-                    source,
-                    media,
-                    settings.dirs.image_previews.clone(),
-                    image_preview.size.clone(),
-                )
+                msg.image_preview = Some(source.clone());
+                previews.register_preview(settings, source, image_preview.size, worker)
             }
         }
     }
@@ -1601,8 +1589,8 @@ pub struct ChatStore {
     /// Information gathered by the background thread.
     pub sync_info: SyncInfo,
 
-    /// Image preview "protocol" picker.
-    pub picker: Option<Arc<Picker>>,
+    /// Rendered image previews.
+    pub previews: PreviewManager,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1628,7 +1616,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker: picker.map(Into::into),
+            previews: PreviewManager::new(picker),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use emojis::Emoji;
+
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::events::sticker::StickerEvent;
 use ratatui::{
     buffer::Buffer,
@@ -1184,12 +1186,10 @@ impl RoomInfo {
     /// Insert a sticker
     pub fn insert_sticker(
         &mut self,
-        room_id: OwnedRoomId,
-        store: AsyncProgramStore,
-        picker: Option<Picker>,
         sticker: StickerEvent,
         settings: &ApplicationSettings,
-        media: matrix_sdk::Media,
+        previews: &mut PreviewManager,
+        worker: &Requester,
     ) {
         match sticker {
             MessageLikeEvent::Original(ref sticker_content) => {
@@ -1201,21 +1201,13 @@ impl RoomInfo {
                 self.keys.insert(sticker_content.event_id.clone(), loc);
                 self.messages.insert_message(key.clone(), sticker.clone());
 
-                if picker.is_some() {
-                    if let (Some(msg), Some(image_preview)) = (
-                        self.get_event_mut(&sticker_content.event_id),
-                        &settings.tunables.image_preview,
-                    ) {
-                        msg.image_preview = ImageStatus::Downloading(image_preview.size.clone());
-                        spawn_insert_preview(
-                            store,
-                            room_id,
-                            sticker_content.event_id.clone(),
-                            sticker_content.content.source.clone().into(),
-                            media,
-                            settings.dirs.image_previews.clone(),
-                        )
-                    }
+                if let (Some(msg), Some(image_preview)) = (
+                    self.get_event_mut(&sticker_content.event_id),
+                    &settings.tunables.image_preview,
+                ) {
+                    let source: MediaSource = sticker_content.content.source.clone().into();
+                    msg.image_preview = Some(source.clone());
+                    previews.register_preview(settings, source, image_preview.size, worker);
                 }
             },
             MessageLikeEvent::Redacted(ref redaction) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -489,12 +489,14 @@ pub struct Notifications {
 
 #[derive(Clone)]
 pub struct ImagePreviewValues {
+    pub lazy_load: bool,
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
+    pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
@@ -502,13 +504,14 @@ pub struct ImagePreview {
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
+            lazy_load: self.lazy_load.unwrap_or(true),
             size: self.size.unwrap_or_default(),
             protocol: self.protocol,
         }
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
@@ -683,19 +686,17 @@ pub struct DirectoryValues {
     pub data: PathBuf,
     pub logs: PathBuf,
     pub downloads: Option<PathBuf>,
-    pub image_previews: PathBuf,
 }
 
 impl DirectoryValues {
     fn create_dir_all(&self) -> std::io::Result<()> {
         use std::fs::create_dir_all;
 
-        let Self { cache, data, logs, downloads, image_previews } = self;
+        let Self { cache, data, logs, downloads } = self;
 
         create_dir_all(cache)?;
         create_dir_all(data)?;
         create_dir_all(logs)?;
-        create_dir_all(image_previews)?;
 
         if let Some(downloads) = downloads {
             create_dir_all(downloads)?;
@@ -711,7 +712,6 @@ pub struct Directories {
     pub data: Option<String>,
     pub logs: Option<String>,
     pub downloads: Option<String>,
-    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -721,7 +721,6 @@ impl Directories {
             data: self.data.or(other.data),
             logs: self.logs.or(other.logs),
             downloads: self.downloads.or(other.downloads),
-            image_previews: self.image_previews.or(other.image_previews),
         }
     }
 
@@ -776,20 +775,7 @@ impl Directories {
             })
             .or_else(dirs::download_dir);
 
-        let image_previews = self
-            .image_previews
-            .map(|dir| {
-                let dir = shellexpand::full(&dir)
-                    .expect("unable to expand shell variables in dirs.cache");
-                Path::new(dir.as_ref()).to_owned()
-            })
-            .unwrap_or_else(|| {
-                let mut dir = cache.clone();
-                dir.push("image_preview_downloads");
-                dir
-            });
-
-        DirectoryValues { cache, data, logs, downloads, image_previews }
+        DirectoryValues { cache, data, logs, downloads }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,12 +447,14 @@ pub struct Notifications {
 
 #[derive(Clone)]
 pub struct ImagePreviewValues {
+    pub lazy_load: bool,
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
+    pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
@@ -460,13 +462,14 @@ pub struct ImagePreview {
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
+            lazy_load: self.lazy_load.unwrap_or(true),
             size: self.size.unwrap_or_default(),
             protocol: self.protocol,
         }
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
@@ -645,19 +648,17 @@ pub struct DirectoryValues {
     pub data: PathBuf,
     pub logs: PathBuf,
     pub downloads: Option<PathBuf>,
-    pub image_previews: PathBuf,
 }
 
 impl DirectoryValues {
     fn create_dir_all(&self) -> std::io::Result<()> {
         use std::fs::create_dir_all;
 
-        let Self { cache, data, logs, downloads, image_previews } = self;
+        let Self { cache, data, logs, downloads } = self;
 
         create_dir_all(cache)?;
         create_dir_all(data)?;
         create_dir_all(logs)?;
-        create_dir_all(image_previews)?;
 
         if let Some(downloads) = downloads {
             create_dir_all(downloads)?;
@@ -673,7 +674,6 @@ pub struct Directories {
     pub data: Option<String>,
     pub logs: Option<String>,
     pub downloads: Option<String>,
-    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -683,7 +683,6 @@ impl Directories {
             data: self.data.or(other.data),
             logs: self.logs.or(other.logs),
             downloads: self.downloads.or(other.downloads),
-            image_previews: self.image_previews.or(other.image_previews),
         }
     }
 
@@ -738,20 +737,7 @@ impl Directories {
             })
             .or_else(dirs::download_dir);
 
-        let image_previews = self
-            .image_previews
-            .map(|dir| {
-                let dir = shellexpand::full(&dir)
-                    .expect("unable to expand shell variables in dirs.cache");
-                Path::new(dir.as_ref()).to_owned()
-            })
-            .unwrap_or_else(|| {
-                let mut dir = cache.clone();
-                dir.push("image_preview_downloads");
-                dir
-            });
-
-        DirectoryValues { cache, data, logs, downloads, image_previews }
+        DirectoryValues { cache, data, logs, downloads }
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
+use image::DynamicImage;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -844,6 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
+    Loading(Option<DynamicImage>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }
@@ -1085,6 +1087,9 @@ impl Message {
                 ImageStatus::None => None,
                 ImageStatus::Downloading(image_preview_size) => {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                ImageStatus::Loading(_, image_preview_size) => {
+                    placeholder_frame(Some("Loading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::DynamicImage;
+use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -845,7 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loading(Option<DynamicImage>, ImagePreviewSize),
+    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,8 +10,8 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::MediaSource;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
@@ -56,6 +56,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
+use crate::preview::{ImageStatus, PreviewManager};
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -713,6 +714,7 @@ impl<'a> MessageFormatter<'a> {
         text: &mut Text<'a>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
             style.patch(settings.get_user_color(&msg.sender))
@@ -722,7 +724,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, previews);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -823,21 +825,13 @@ impl<'a> MessageFormatter<'a> {
     }
 }
 
-pub enum ImageStatus {
-    None,
-    Downloading(ImagePreviewSize),
-    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
-    Loaded(Protocol),
-    Error(String),
-}
-
 pub struct Message {
     pub event: MessageEvent,
     pub sender: OwnedUserId,
     pub timestamp: MessageTimeStamp,
     pub downloaded: bool,
     pub html: Option<StyleTree>,
-    pub image_preview: ImageStatus,
+    pub image_preview: Option<MediaSource>,
 }
 
 impl Message {
@@ -851,7 +845,7 @@ impl Message {
             timestamp,
             downloaded,
             html,
-            image_preview: ImageStatus::None,
+            image_preview: None,
         }
     }
 
@@ -876,7 +870,7 @@ impl Message {
         }
     }
 
-    fn thread_root(&self) -> Option<OwnedEventId> {
+    pub fn thread_root(&self) -> Option<OwnedEventId> {
         let content = match &self.event {
             MessageEvent::EncryptedOriginal(_) => return None,
             MessageEvent::EncryptedRedacted(_) => return None,
@@ -983,6 +977,7 @@ impl Message {
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
         let width = vwctx.get_width();
 
@@ -998,11 +993,11 @@ impl Message {
             .and_then(|e| info.get_event(&e));
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
-            fmt.push_in_reply(r, style, &mut text, info, settings)
+            fmt.push_in_reply(r, style, &mut text, info, settings, previews)
         });
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings);
+        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews);
 
         // Given our text so far, determine the image offset.
         let proto_main = proto.map(|p| {
@@ -1040,8 +1035,9 @@ impl Message {
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> Text<'a> {
-        self.show_with_preview(prev, selected, vwctx, info, settings).0
+        self.show_with_preview(prev, selected, vwctx, info, settings, previews).0
     }
 
     fn show_msg<'a>(
@@ -1050,6 +1046,7 @@ impl Message {
         style: Style,
         hide_reply: bool,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> (Text<'a>, Option<&'a Protocol>) {
         if let Some(html) = &self.html {
             (html.to_text(width, style, hide_reply, settings), None)
@@ -1064,20 +1061,21 @@ impl Message {
             }
 
             let mut proto = None;
-            let placeholder = match &self.image_preview {
-                ImageStatus::None => None,
-                ImageStatus::Downloading(image_preview_size) => {
-                    placeholder_frame(Some("Downloading..."), width, image_preview_size)
-                },
-                ImageStatus::Loading(_, image_preview_size) => {
-                    placeholder_frame(Some("Loading..."), width, image_preview_size)
-                },
-                ImageStatus::Loaded(backend) => {
-                    proto = Some(backend);
-                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
-                },
-                ImageStatus::Error(err) => Some(format!("[Image error: {err}]\n")),
-            };
+            let placeholder =
+                match self.image_preview.as_ref().and_then(|source| previews.get(source)) {
+                    None => None,
+                    Some(ImageStatus::Queued(image_preview_size)) => {
+                        placeholder_frame(Some("Queued..."), width, image_preview_size)
+                    },
+                    Some(ImageStatus::Downloading(image_preview_size)) => {
+                        placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                    },
+                    Some(ImageStatus::Loaded(backend)) => {
+                        proto = Some(backend);
+                        placeholder_frame(Some("No Space..."), width, &backend.area().into())
+                    },
+                    Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
+                };
 
             if let Some(placeholder) = placeholder {
                 msg.to_mut().insert_str(0, &placeholder);
@@ -1129,7 +1127,7 @@ impl Message {
         self.event.redact(redaction);
         self.html = None;
         self.downloaded = false;
-        self.image_preview = ImageStatus::None;
+        self.image_preview = None;
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::DynamicImage;
+use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use unicode_width::UnicodeWidthStr;
 
@@ -826,7 +826,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loading(Option<DynamicImage>, ImagePreviewSize),
+    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
+use image::DynamicImage;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use unicode_width::UnicodeWidthStr;
 
@@ -825,6 +826,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
+    Loading(Option<DynamicImage>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }
@@ -1066,6 +1068,9 @@ impl Message {
                 ImageStatus::None => None,
                 ImageStatus::Downloading(image_preview_size) => {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                ImageStatus::Loading(_, image_preview_size) => {
+                    placeholder_frame(Some("Loading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,11 +1,7 @@
-use std::{
-    fs::File,
-    io::{Read, Write},
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{
-    media::{MediaFormat, MediaRequestParameters},
+    media::{MediaFormat, MediaRequestParameters, UniqueKey},
     ruma::{
         events::{
             room::{
@@ -15,18 +11,101 @@ use matrix_sdk::{
             MessageLikeEvent,
         },
         OwnedEventId,
-        OwnedRoomId,
     },
     Media,
 };
 use ratatui::layout::Rect;
-use ratatui_image::Resize;
+use ratatui_image::{picker::Picker, protocol::Protocol, Resize};
+use tokio::sync::Semaphore;
 
 use crate::{
-    base::{AsyncProgramStore, ChatStore, IambError},
-    config::ImagePreviewSize,
-    message::ImageStatus,
+    base::{AsyncProgramStore, IambError},
+    config::{ApplicationSettings, ImagePreviewSize},
+    worker::Requester,
 };
+
+pub enum ImageStatus {
+    Queued(ImagePreviewSize),
+    Downloading(ImagePreviewSize),
+    Loaded(Protocol),
+    Error(String),
+}
+
+pub struct PreviewManager {
+    /// Image preview "protocol" picker.
+    picker: Option<Arc<Picker>>,
+
+    /// Permits for rendering images in background thread.
+    permits: Arc<Semaphore>,
+
+    /// Indexed by [`MediaSource::unique_key`]
+    previews: HashMap<String, ImageStatus>,
+}
+
+impl PreviewManager {
+    pub fn new(picker: Option<Picker>) -> Self {
+        Self {
+            picker: picker.map(Into::into),
+            permits: Arc::new(Semaphore::new(2)),
+            previews: Default::default(),
+        }
+    }
+
+    pub fn get(&self, source: &MediaSource) -> Option<&ImageStatus> {
+        self.previews.get(&source.unique_key())
+    }
+
+    fn insert(&mut self, key: String, status: ImageStatus) {
+        self.previews.insert(key, status);
+    }
+
+    /// Queue download and preparation of preview
+    pub fn load(&mut self, source: &MediaSource, worker: &Requester) {
+        let Some(status) = self.previews.get_mut(&source.unique_key()) else {
+            return;
+        };
+        let Some(picker) = &self.picker else { return };
+
+        if let ImageStatus::Queued(size) = status {
+            let size = *size;
+            *status = ImageStatus::Downloading(size);
+
+            worker.load_image(
+                source.to_owned(),
+                size.to_owned(),
+                Arc::clone(picker),
+                Arc::clone(&self.permits),
+            );
+        }
+    }
+
+    pub fn register_preview(
+        &mut self,
+        settings: &ApplicationSettings,
+        source: MediaSource,
+        size: ImagePreviewSize,
+        worker: &Requester,
+    ) {
+        if self.picker.is_none() {
+            return;
+        }
+
+        let key = source.unique_key();
+        if self.previews.contains_key(&key) {
+            return;
+        }
+        self.previews.insert(key, ImageStatus::Queued(size));
+
+        if settings
+            .tunables
+            .image_preview
+            .as_ref()
+            .is_some_and(|setting| !setting.lazy_load)
+        {
+            self.load(&source, worker);
+        }
+    }
+}
 
 pub fn source_from_event(
     ev: &MessageLikeEvent<RoomMessageEventContent>,
@@ -50,171 +129,54 @@ impl From<Rect> for ImagePreviewSize {
     }
 }
 
-/// Download and prepare the preview, and then lock the store to insert it.
-pub fn spawn_insert_preview(
+pub async fn load_image(
     store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    source: MediaSource,
     media: Media,
-    cache_dir: PathBuf,
-    preview: ImagePreviewSize,
+    source: MediaSource,
+    picker: Arc<Picker>,
+    permits: Arc<Semaphore>,
+    size: ImagePreviewSize,
 ) {
-    tokio::spawn(async move {
-        let img = download_or_load(event_id.to_owned(), source, media, cache_dir)
+    async fn load_image_inner(
+        media: Media,
+        source: MediaSource,
+        picker: Arc<Picker>,
+        permits: Arc<Semaphore>,
+        size: ImagePreviewSize,
+    ) -> Result<ImageStatus, IambError> {
+        let reader = media
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
             .await
             .map(std::io::Cursor::new)
             .map(image::ImageReader::new)
             .map_err(IambError::Matrix)
-            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError));
+            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError))?;
 
-        match img {
-            Err(err) => {
-                try_set_msg_preview_error(
-                    &mut store.lock().await.application,
-                    room_id,
-                    event_id,
-                    err,
-                );
-            },
-            Ok(img) => {
-                let mut locked = store.lock().await;
+        let image = reader.decode().map_err(IambError::Image)?;
 
-                match locked
-                    .application
-                    .rooms
-                    .get_or_default(room_id.clone())
-                    .get_event_mut(&event_id)
-                    .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-                {
-                    Err(err) => {
-                        try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-                    },
-                    Ok(msg) => msg.image_preview = ImageStatus::Loading(Some(img), preview),
-                }
-            },
-        }
-    });
-}
+        let permit = permits
+            .acquire()
+            .await
+            .map_err(|err| IambError::Preview(err.to_string()))?;
 
-pub async fn render_preview(
-    store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-) {
-    let mut locked = store.lock().await;
-
-    let picker = locked.application.picker.clone();
-    let Some(img) = locked
-        .application
-        .rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .map(|msg| {
-            if let ImageStatus::Loading(reader, size) = &mut msg.image_preview {
-                reader.take().map(|reader| (reader, size.clone()))
-            } else {
-                None
-            }
-        })
-        .transpose()
-    else {
-        // ignore if image is already being loaded
-        return;
-    };
-
-    // make shure to unlock store while computing `new_protocol`
-    drop(locked);
-
-    let image = picker
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .and_then(|picker| {
-            let (reader, size) = img?;
-            Ok((picker, reader, size))
-        })
-        .and_then(|(picker, reader, size)| {
-            let image = reader.decode().map_err(IambError::Image)?;
-            Ok((picker, image, size))
-        })
-        .and_then(|(picker, image, size)| {
+        let handle = tokio::task::spawn_blocking(move || {
             picker
                 .new_protocol(image, size.into(), Resize::Fit(None))
-                .map_err(|err| IambError::Preview(format!("{err}")))
+                .map_err(|err| IambError::Preview(err.to_string()))
         });
 
+        let image = handle.await.map_err(|err| IambError::Preview(err.to_string()))??;
+        std::mem::drop(permit);
+
+        Ok(ImageStatus::Loaded(image))
+    }
+    let key = source.unique_key();
+
+    let status = match load_image_inner(media, source, picker, permits, size).await {
+        Ok(status) => status,
+        Err(err) => ImageStatus::Error(format!("{err:?}")),
+    };
+
     let mut locked = store.lock().await;
-
-    match image {
-        Err(err) => {
-            try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-        },
-        Ok(backend) => {
-            locked
-                .application
-                .rooms
-                .get_or_default(room_id)
-                .get_event_mut(&event_id)
-                .unwrap()
-                .image_preview = ImageStatus::Loaded(backend);
-        },
-    }
-}
-
-fn try_set_msg_preview_error(
-    application: &mut ChatStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    err: IambError,
-) {
-    let rooms = &mut application.rooms;
-
-    match rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-    {
-        Ok(msg) => msg.image_preview = ImageStatus::Error(format!("{err:?}")),
-        Err(err) => {
-            tracing::error!(
-                "Failed to set error on msg.image_backend for event {}, room {}: {}",
-                event_id,
-                room_id,
-                err
-            )
-        },
-    }
-}
-
-async fn download_or_load(
-    event_id: OwnedEventId,
-    source: MediaSource,
-    media: Media,
-    mut cache_path: PathBuf,
-) -> Result<Vec<u8>, matrix_sdk::Error> {
-    cache_path.push(Path::new(event_id.localpart()));
-
-    match File::open(&cache_path) {
-        Ok(mut f) => {
-            let mut buffer = Vec::new();
-            f.read_to_end(&mut buffer)?;
-            Ok(buffer)
-        },
-        Err(_) => {
-            media
-                .get_media_content(
-                    &MediaRequestParameters { source, format: MediaFormat::File },
-                    true,
-                )
-                .await
-                .and_then(|buffer| {
-                    if let Err(err) =
-                        File::create(&cache_path).and_then(|mut f| f.write_all(&buffer))
-                    {
-                        return Err(err.into());
-                    }
-                    Ok(buffer)
-                })
-        },
-    }
+    locked.application.previews.insert(key, status);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -163,7 +163,6 @@ pub fn mock_dirs() -> DirectoryValues {
         data: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
-        image_previews: PathBuf::new(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,7 +164,6 @@ pub fn mock_dirs() -> DirectoryValues {
         data: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
-        image_previews: PathBuf::new(),
     }
 }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,7 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageKey, Messages},
+    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -1347,6 +1347,14 @@ impl StatefulWidget for Scrollback<'_> {
 
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
+
+            if let ImageStatus::Loading(_, _) = &item.image_preview {
+                self.store
+                    .application
+                    .worker
+                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
+            }
+
             let (txt, [mut msg_preview, mut reply_preview]) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,8 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
+    message::{Message, MessageCursor, MessageKey, Messages},
+    preview::PreviewManager,
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -270,6 +271,7 @@ impl ScrollbackState {
         pos: MovePosition,
         info: &RoomInfo,
         settings: &ApplicationSettings,
+        previews: &PreviewManager,
     ) {
         let Some(thread) = self.get_thread(info) else {
             return;
@@ -292,7 +294,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     if key == &idx {
                         lines += len / 2;
@@ -315,7 +318,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     lines += len;
 
@@ -338,7 +342,12 @@ impl ScrollbackState {
         self.jumped.push(self.cursor.clone());
     }
 
-    fn shift_cursor(&mut self, info: &RoomInfo, settings: &ApplicationSettings) {
+    fn shift_cursor(
+        &mut self,
+        info: &RoomInfo,
+        settings: &ApplicationSettings,
+        previews: &PreviewManager,
+    ) {
         let Some(thread) = self.get_thread(info) else {
             return;
         };
@@ -368,7 +377,10 @@ impl ScrollbackState {
                 break;
             }
 
-            lines += item.show(prev, false, &self.viewctx, info, settings).height().max(1);
+            lines += item
+                .show(prev, false, &self.viewctx, info, settings, previews)
+                .height()
+                .max(1);
 
             if lines >= self.viewctx.get_height() {
                 // We've reached the end of the viewport; move cursor into it.
@@ -1067,6 +1079,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
     ) -> EditResult<EditInfo, IambInfo> {
         let info = store.application.rooms.get_or_default(self.room_id.clone());
         let settings = &store.application.settings;
+        let previews = &store.application.previews;
         let mut corner = self.viewctx.corner.clone();
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
@@ -1094,7 +1107,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 for (key, item) in thread.range(..=&corner_key).rev() {
                     let sel = key == cursor_key;
                     let prev = prevmsg(key, thread);
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1122,7 +1135,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                 for (key, item) in thread.range(&corner_key..) {
                     let sel = key == cursor_key;
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1160,7 +1173,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         }
 
         self.viewctx.corner = corner;
-        self.shift_cursor(info, settings);
+        self.shift_cursor(info, settings, previews);
 
         Ok(None)
     }
@@ -1182,10 +1195,11 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
             Axis::Vertical => {
                 let info = store.application.rooms.get_or_default(self.room_id.clone());
                 let settings = &store.application.settings;
+                let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
                 if let Some(key) = self.cursor.to_key(thread).cloned() {
-                    self.scrollview(key, pos, info, settings);
+                    self.scrollview(key, pos, info, settings, previews);
                 }
 
                 Ok(None)
@@ -1345,18 +1359,33 @@ impl StatefulWidget for Scrollback<'_> {
         let mut sawit = false;
         let mut prev = prevmsg(&corner_key, thread);
 
+        // load image previews
+        for (_, item) in thread.range(&corner_key..).rev() {
+            if let Some(source) = &item.image_preview {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+            let reply = item
+                .reply_to()
+                .or_else(|| item.thread_root())
+                .and_then(|e| info.get_event(&e))
+                .and_then(|msg| msg.image_preview.as_ref());
+            if let Some(source) = reply {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+        }
+
+        let previews = &self.store.application.previews;
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            if let ImageStatus::Loading(_, _) = &item.image_preview {
-                self.store
-                    .application
-                    .worker
-                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
-            }
-
             let (txt, [mut msg_preview, mut reply_preview]) =
-                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
+                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
 
             let incomplete_ok = !full || !sel;
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -90,6 +90,7 @@ use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::MessageNeed;
 use crate::notifications::register_notifications;
+use crate::preview::render_preview;
 use crate::{
     base::{
         AsyncProgramStore,
@@ -635,6 +636,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
+    RenderImage(OwnedRoomId, OwnedEventId),
 }
 
 impl Debug for WorkerTask {
@@ -696,6 +698,12 @@ impl Debug for WorkerTask {
                 f.debug_tuple("WorkerTask::VerifyRequest")
                     .field(user_id)
                     .field(&format_args!("_"))
+                    .finish()
+            },
+            WorkerTask::RenderImage(room_id, message_id) => {
+                f.debug_tuple("WorkerTask::RenderImage")
+                    .field(room_id)
+                    .field(message_id)
                     .finish()
             },
         }
@@ -843,6 +851,10 @@ impl Requester {
 
         return response.recv();
     }
+
+    pub fn render_image(&self, room_id: OwnedRoomId, message_id: OwnedEventId) {
+        self.tx.send(WorkerTask::RenderImage(room_id, message_id)).unwrap();
+    }
 }
 
 pub struct ClientWorker {
@@ -851,6 +863,9 @@ pub struct ClientWorker {
     client: Client,
     load_handle: Option<JoinHandle<()>>,
     sync_handle: Option<JoinHandle<()>>,
+
+    /// Take care when locking since worker commands are sent with the lock already hold
+    store: Option<AsyncProgramStore>,
 }
 
 impl ClientWorker {
@@ -863,6 +878,7 @@ impl ClientWorker {
             client: client.clone(),
             load_handle: None,
             sync_handle: None,
+            store: None,
         };
 
         tokio::spawn(async move {
@@ -935,6 +951,10 @@ impl ClientWorker {
             WorkerTask::VerifyRequest(user_id, reply) => {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
+            },
+            WorkerTask::RenderImage(room_id, message_id) => {
+                assert!(self.initialized);
+                tokio::spawn(render_preview(self.store.clone().unwrap(), room_id, message_id));
             },
         }
     }
@@ -1246,6 +1266,8 @@ impl ClientWorker {
                 }
             },
         );
+
+        self.store = Some(store.clone());
 
         self.load_handle = tokio::spawn({
             let client = self.client.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
+use matrix_sdk::ruma::events::room::MediaSource;
+use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -89,8 +91,9 @@ use modalkit::errors::UIError;
 use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::MessageNeed;
+use crate::config::ImagePreviewSize;
 use crate::notifications::register_notifications;
-use crate::preview::render_preview;
+use crate::preview::load_image;
 use crate::{
     base::{
         AsyncProgramStore,
@@ -255,11 +258,10 @@ async fn run_plan(client: &Client, store: &AsyncProgramStore, plan: Plan, permit
         Plan::Messages(room_id, fetch_id, message_need) => {
             let limit = MIN_MSG_LOAD;
             let client = client.clone();
-            let store_clone = store.clone();
 
             let res = load_older_one(&client, &room_id, fetch_id, limit).await;
             let mut locked = store.lock().await;
-            load_insert(room_id, res, locked.deref_mut(), store_clone, message_need);
+            load_insert(room_id, res, locked.deref_mut(), message_need);
         },
         Plan::Members(room_id) => {
             let res = members_load(client, &room_id).await;
@@ -321,13 +323,11 @@ fn load_insert(
     room_id: OwnedRoomId,
     res: MessageFetchResult,
     locked: &mut ProgramStore,
-    store: AsyncProgramStore,
     message_needs: Vec<MessageNeed>,
 ) {
-    let ChatStore { presences, rooms, worker, picker, settings, .. } = &mut locked.application;
+    let ChatStore { presences, rooms, previews, settings, worker, .. } = &mut locked.application;
     let info = rooms.get_or_default(room_id.clone());
     info.fetching = false;
-    let client = &worker.client;
 
     match res {
         Ok((fetch_id, msgs)) => {
@@ -344,14 +344,7 @@ fn load_insert(
                         info.insert_encrypted(msg);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(msg)) => {
-                        info.insert_with_preview(
-                            room_id.clone(),
-                            store.clone(),
-                            picker.clone(),
-                            msg,
-                            settings,
-                            client.media(),
-                        );
+                        info.insert_with_preview(msg, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Reaction(ev)) => {
                         info.insert_reaction(ev);
@@ -636,7 +629,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
-    RenderImage(OwnedRoomId, OwnedEventId),
+    LoadImage(MediaSource, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
 }
 
 impl Debug for WorkerTask {
@@ -700,10 +693,12 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::RenderImage(room_id, message_id) => {
+            WorkerTask::LoadImage(source, size, _, _) => {
                 f.debug_tuple("WorkerTask::RenderImage")
-                    .field(room_id)
-                    .field(message_id)
+                    .field(source)
+                    .field(size)
+                    .field(&format_args!("_"))
+                    .field(&format_args!("_"))
                     .finish()
             },
         }
@@ -852,8 +847,14 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn render_image(&self, room_id: OwnedRoomId, message_id: OwnedEventId) {
-        self.tx.send(WorkerTask::RenderImage(room_id, message_id)).unwrap();
+    pub fn load_image(
+        &self,
+        source: MediaSource,
+        size: ImagePreviewSize,
+        picker: Arc<Picker>,
+        permits: Arc<Semaphore>,
+    ) {
+        self.tx.send(WorkerTask::LoadImage(source, size, picker, permits)).unwrap();
     }
 }
 
@@ -952,9 +953,16 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
             },
-            WorkerTask::RenderImage(room_id, message_id) => {
+            WorkerTask::LoadImage(source, size, picker, permits) => {
                 assert!(self.initialized);
-                tokio::spawn(render_preview(self.store.clone().unwrap(), room_id, message_id));
+                tokio::spawn(load_image(
+                    self.store.clone().unwrap(),
+                    self.client.media(),
+                    source,
+                    picker,
+                    permits,
+                    size,
+                ));
             },
         }
     }
@@ -1030,20 +1038,14 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let ChatStore { rooms, picker, settings, .. } = &mut locked.application;
+                    let ChatStore { rooms, previews, settings, worker, .. } =
+                        &mut locked.application;
                     let info = rooms.get_or_default(room_id.to_owned());
 
                     update_event_receipts(info, &room, ev.event_id()).await;
 
                     let full_ev = ev.into_full_event(room_id.to_owned());
-                    info.insert_with_preview(
-                        room_id.to_owned(),
-                        store.clone(),
-                        picker.clone(),
-                        full_ev,
-                        settings,
-                        client.media(),
-                    );
+                    info.insert_with_preview(full_ev, settings, previews, worker);
                 }
             },
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -324,14 +324,7 @@ fn load_insert(
                         info.insert_reaction(ev);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Sticker(ev)) => {
-                        info.insert_sticker(
-                            room_id.clone(),
-                            store.clone(),
-                            picker.clone(),
-                            ev,
-                            settings,
-                            client.media(),
-                        );
+                        info.insert_sticker(ev, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(_) => {
                         continue;
@@ -1041,7 +1034,6 @@ impl ClientWorker {
         let _ = self.client.add_event_handler(
             |ev: SyncMessageLikeEvent<StickerEventContent>,
              room: MatrixRoom,
-             client: Client,
              store: Ctx<AsyncProgramStore>| {
                 async move {
                     let room_id = room.room_id();
@@ -1051,21 +1043,15 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let ChatStore { rooms, picker, settings, .. } = &mut locked.application;
+                    let ChatStore { rooms, settings, previews, worker, .. } =
+                        &mut locked.application;
 
                     let info = rooms.get_or_default(room_id.to_owned());
 
                     update_event_receipts(info, &room, ev.event_id()).await;
 
                     let full_ev = ev.into_full_event(room_id.to_owned());
-                    info.insert_sticker(
-                        room_id.to_owned(),
-                        store.clone(),
-                        picker.clone(),
-                        full_ev,
-                        settings,
-                        client.media(),
-                    );
+                    info.insert_sticker(full_ev, settings, previews, worker);
                 }
             },
         );


### PR DESCRIPTION
Profiling the startup of iamb in `foot` using `flamegraph`, I noticed that most of the cpu time was spent rendering image previews. This PR changes the rendering to be in the background (not blocking ui responsiveness) and lazily (on message rendering).

~I had some bugs if the last message is an image:~
- ~Scrolling with ^E and ^Y doesn't work if the last message is focused~
- ~if only one image is loaded and the rest of the loaded events are reactions, older events don't load~

# Profiling data
before optimizations:
![flamegraph-original](https://github.com/user-attachments/assets/6aa5995c-5092-44ec-b5f7-522b200b6b6c)
with lazily computed sixel preview:
![flamegraph-lazy-sixel](https://github.com/user-attachments/assets/38be338c-b4d1-44c0-b1cf-2edc5d32e630)
and lazily decoded jpg:
![flamegraph-lazy-jpg](https://github.com/user-attachments/assets/781d14cb-f1c4-40a1-b6cf-96afd0e58a72)
