### PR TITLE
Add missing `<s>` tag in HTML parsing

### DIFF
--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -748,7 +748,7 @@ fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
 
                     StyleTreeNode::Style(c, s)
                 },
-                "del" | "strike" => {
+                "del" | "s" | "strike" => {
                     let c = c2t(&node.children.borrow(), state);
                     let s = Style::default().add_modifier(StyleModifier::CROSSED_OUT);
 


### PR DESCRIPTION
According to the [spec](https://spec.matrix.org/v1.14/client-server-api/#mroommessage-msgtypes), the html `<s>` tag should be supported.

Maybe we also want to remove `<strike>` since it is [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/strike) and the matrix spec doesn't suggest it.