### PR TITLE
Make scrollback display stable with `typing_notice_display = false`

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1361,7 +1361,9 @@ impl RoomInfo {
         }
 
         if !settings.tunables.typing_notice_display {
-            return area;
+            // still keep one line blank, so `render_jump_to_recent` doesn't immediately hide the
+            // last line in scrollback
+            return Rect::new(area.x, area.y, area.width, area.height - 1);
         }
 
         let top = Rect::new(area.x, area.y, area.width, area.height - 1);

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1571,7 +1571,7 @@ mod tests {
         // MSG1: |                   XXXday, Month NN 20XX                    |
         //       |           @user1:example.com  writhe                       |
         //       |------------------------------------------------------------|
-        let area = Rect::new(0, 0, 60, 4);
+        let area = Rect::new(0, 0, 60, 5);
         let mut buffer = Buffer::empty(area);
         scrollback.draw(area, &mut buffer, true, &mut store);
 


### PR DESCRIPTION
When selecting an older line in scrollback, the last line of the newest message is replaced by "Use G to jump to latest message". This is annoying since the newest message is oftentimes the most relevant one.

This PR adds a blank line even if typing notices are disabled to prevent this from happening.