### PR TITLE
Highlight border of focused window

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,8 @@ impl Application {
                 .show_mode(modestr)
                 .borders(true)
                 .border_style(Style::default().add_modifier(Modifier::DIM))
+                .tab_style(Style::default().add_modifier(Modifier::DIM))
+                .tab_style_focused(Style::default().remove_modifier(Modifier::DIM))
                 .focus(focused);
             f.render_stateful_widget(screen, area, sstate);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ use modalkit::crossterm::{
 use ratatui::{
     backend::CrosstermBackend,
     layout::Rect,
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
     text::Span,
     widgets::Paragraph,
     Terminal,
@@ -327,6 +327,7 @@ impl Application {
                 .show_dialog(dialogstr)
                 .show_mode(modestr)
                 .borders(true)
+                .border_style(Style::default().add_modifier(Modifier::DIM))
                 .focus(focused);
             f.render_stateful_widget(screen, area, sstate);
 


### PR DESCRIPTION
This makes the border of unfocused windows dim so the focused window stands out.

fixes #147