### PR TITLE
Update to modalkit{,-ratatui}@0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,6 +1443,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "editor-types"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e99679670f67825fcd24a23cb4eb655a0f92c82bd4d1c1a1357c0cd71e87"
+dependencies = [
+ "bitflags 2.9.1",
+ "editor-types-macros",
+ "keybindings",
+ "regex",
+]
+
+[[package]]
+name = "editor-types-macros"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42680de76cf91f231abd90cc623750d39077f7d2fadb7962325fb082871f4c66"
+dependencies = [
+ "editor-types-parser",
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "editor-types-parser"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac4b91fe830fbbe0a60c37ba0264b6e9ffc70e3664c028234dac59e79299ad4"
+dependencies = [
+ "nom",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "keybindings"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680e4699c91c0622dd70da32c274881aadb1ac86252d738c3641266e90e4ca15"
+checksum = "19a726307ed87e05155c31329676130e6a237e62dda80211f7e1ed811e47630f"
 dependencies = [
  "textwrap",
  "unicode-segmentation",
@@ -3292,15 +3327,16 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.21"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7599fc1bcd2f0a0b4598f23433b45613345a46419ab27d3a9adecb57acd648"
+checksum = "6ed06f32b03a7504acadcb0d95d06f3d55258934c34b620ed95e3dae24f081a5"
 dependencies = [
  "anymap2",
  "arboard",
  "bitflags 2.9.1",
  "crossterm",
  "derive_more",
+ "editor-types",
  "intervaltree",
  "keybindings",
  "nom",
@@ -3314,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "modalkit-ratatui"
-version = "0.0.21"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3d88c86435d4b1fb22c7c0f978b09cb888338cafc10336715aa5070e92b6f6"
+checksum = "a33bd64f6dd0011ee88f4f12b28108d3e63df0a5c86fe595d24561be9522f6ea"
 dependencies = [
  "crossterm",
  "intervaltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,13 +77,13 @@ features = ["zbus", "serde"]
 optional = true
 
 [dependencies.modalkit]
-version = "0.0.21"
+version = "0.0.23"
 default-features = false
 #git = "https://github.com/ulyssa/modalkit"
 #rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 
 [dependencies.modalkit-ratatui]
-version = "0.0.21"
+version = "0.0.23"
 #git = "https://github.com/ulyssa/modalkit"
 #rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ use crate::{
         ChatStore,
         HomeserverAction,
         IambAction,
+        IambCompleter,
         IambError,
         IambId,
         IambInfo,
@@ -529,7 +530,7 @@ impl Application {
             },
 
             // Unimplemented.
-            Action::KeywordLookup => {
+            Action::KeywordLookup(_) => {
                 // XXX: implement
                 None
             },
@@ -1011,7 +1012,9 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     // Set up the async worker thread and global store.
     let worker = ClientWorker::spawn(client.clone(), settings.clone()).await;
     let store = ChatStore::new(worker.clone(), settings.clone());
-    let store = Store::new(store);
+    let mut store = Store::new(store);
+    store.completer = Box::new(IambCompleter);
+
     let store = Arc::new(AsyncMutex::new(store));
     worker.init(store.clone());
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -864,16 +864,16 @@ impl PromptActions<ProgramContext, ProgramStore, IambInfo> for ChatState {
 
     fn recall(
         &mut self,
+        filter: &RecallFilter,
         dir: &MoveDir1D,
         count: &Count,
-        prefixed: bool,
         ctx: &ProgramContext,
         _: &mut ProgramStore,
     ) -> EditResult<Vec<(ProgramAction, ProgramContext)>, IambInfo> {
         let count = ctx.resolve(count);
         let rope = self.tbox.get();
 
-        let text = self.sent.recall(&rope, &mut self.sent_scrollback, *dir, prefixed, count);
+        let text = self.sent.recall(&rope, &mut self.sent_scrollback, filter, *dir, count);
 
         if let Some(text) = text {
             self.tbox.set_text(text);
@@ -897,9 +897,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ChatState {
         match act {
             PromptAction::Submit => self.submit(ctx, store),
             PromptAction::Abort(empty) => self.abort(*empty, ctx, store),
-            PromptAction::Recall(dir, count, prefixed) => {
-                self.recall(dir, count, *prefixed, ctx, store)
-            },
+            PromptAction::Recall(filter, dir, count) => self.recall(filter, dir, count, ctx, store),
         }
     }
 }

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -840,8 +840,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
     fn complete(
         &mut self,
+        _: &CompletionStyle,
         _: &CompletionType,
-        _: &CompletionSelection,
         _: &CompletionDisplay,
         _: &ProgramContext,
         _: &mut ProgramStore,


### PR DESCRIPTION
This pulls in the latest changes to `modalkit` and `modalkit-ratatui`, and updates how its used in `iamb` to account for changes in the crates.
