### PR TITLE
Recognise URLs in plain text message bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ dependencies = [
  "image",
  "lazy_static 1.5.0",
  "libc",
+ "linkify",
  "markup5ever_rcdom",
  "matrix-sdk",
  "mime",
@@ -2829,6 +2830,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ unicode-width = "0.1.10"
 url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
 humansize = "2.0.0"
+linkify = "0.10.0"
 
 [dependencies.comrak]
 version = "0.22.0"

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -524,11 +524,11 @@ impl StyleTree {
 }
 
 pub struct TreeGenState {
-    link_num: u8,
+    pub link_num: u8,
 }
 
 impl TreeGenState {
-    fn next_link_char(&mut self) -> Option<char> {
+    pub fn next_link_char(&mut self) -> Option<char> {
         let num = self.link_num;
 
         if num < 62 {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -72,6 +72,7 @@ mod state;
 
 pub use self::compose::text_to_message;
 use self::state::{body_cow_state, html_state};
+pub use html::TreeGenState;
 
 type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 


### PR DESCRIPTION
This PR introduces the `linkify` dependency to gather links if no `"formated_body"` exits. Links are available in `:open` but are not visually changed. It only works for links that include the protocol but I believe this limitation comes from the `url` crate.

fixes #370