### PR TITLE
Add config option for playing sound-hints with desktop notifications

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -483,6 +483,8 @@ pub struct Notifications {
     pub via: NotifyVia,
     #[serde(default = "default_true")]
     pub show_message: bool,
+    #[serde(default)]
+    pub play_sound: bool,
 }
 
 #[derive(Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -484,7 +484,7 @@ pub struct Notifications {
     #[serde(default = "default_true")]
     pub show_message: bool,
     #[serde(default)]
-    pub sound_hint: String,
+    pub sound_hint: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -484,7 +484,7 @@ pub struct Notifications {
     #[serde(default = "default_true")]
     pub show_message: bool,
     #[serde(default)]
-    pub play_sound: bool,
+    pub sound_hint: String,
 }
 
 #[derive(Clone)]

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -91,7 +91,7 @@ pub async fn register_notifications(
                                     body.as_deref(),
                                     room_id,
                                     &store,
-                                    sound_hint,
+                                    sound_hint.as_deref(),
                                 )
                                 .await;
                             },
@@ -116,7 +116,7 @@ async fn send_notification(
     body: Option<&str>,
     room_id: OwnedRoomId,
     store: &AsyncProgramStore,
-    sound_hint: String,
+    sound_hint: Option<&str>,
 ) {
     #[cfg(feature = "desktop")]
     if via.desktop {
@@ -143,7 +143,7 @@ async fn send_notification_desktop(
     body: Option<&str>,
     room_id: OwnedRoomId,
     _store: &AsyncProgramStore,
-    sound_hint: String,
+    sound_hint: Option<&str>,
 ) {
     let mut desktop_notification = notify_rust::Notification::new();
     desktop_notification
@@ -152,8 +152,8 @@ async fn send_notification_desktop(
         .icon(IAMB_XDG_NAME)
         .action("default", "default");
 
-    if !sound_hint.is_empty() {
-        desktop_notification.sound_name(sound_hint.as_str());
+    if let Some(sound_hint) = sound_hint {
+        desktop_notification.sound_name(sound_hint);
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,7 +196,7 @@ pub fn mock_tunables() -> TunableValues {
             enabled: false,
             via: NotifyVia::default(),
             show_message: true,
-            play_sound: false,
+            sound_hint: String::from(""),
         },
         image_preview: None,
         user_gutter_width: 30,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,7 +196,7 @@ pub fn mock_tunables() -> TunableValues {
             enabled: false,
             via: NotifyVia::default(),
             show_message: true,
-            sound_hint: String::from(""),
+            sound_hint: None,
         },
         image_preview: None,
         user_gutter_width: 30,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,6 +196,7 @@ pub fn mock_tunables() -> TunableValues {
             enabled: false,
             via: NotifyVia::default(),
             show_message: true,
+            play_sound: false,
         },
         image_preview: None,
         user_gutter_width: 30,


### PR DESCRIPTION
This patch adds a configuration element called `play_sound` (bool, false by default) that when set true, 
it will tell the notification to use sound hint called `message-new-instant` which then plays a sound, 
depending on the platform the app is running in.

(I haven't really used Rust before so bear with me :sweat_smile: )