### PR TITLE
Fix image preview placeholder rendering

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -172,7 +172,8 @@ fn placeholder_frame(
     image_preview_size: &ImagePreviewSize,
 ) -> Option<String> {
     let ImagePreviewSize { width, height } = image_preview_size;
-    if outer_width < *width || (*width < 2 || *height < 2) {
+    let width = usize::min(*width, outer_width);
+    if width < 2 || *height < 2 {
         return None;
     }
     let mut placeholder = "\u{230c}".to_string();
@@ -1090,7 +1091,7 @@ impl Message {
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);
-                    placeholder_frame(Some("Cut off..."), width, &backend.area().into())
+                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
                 },
                 ImageStatus::Error(err) => Some(format!("[Image error: {err}]\n")),
             };
@@ -1348,7 +1349,17 @@ pub mod tests {
             )
         );
 
-        assert_eq!(placeholder_frame(None, 2, &ImagePreviewSize { width: 4, height: 4 }), None);
+        assert_eq!(
+            placeholder_frame(None, 2, &ImagePreviewSize { width: 4, height: 4 }),
+            pretty_frame_test(
+                r#"
+⌌⌍
+
+
+⌎⌏
+"#
+            )
+        );
         assert_eq!(placeholder_frame(None, 4, &ImagePreviewSize { width: 1, height: 4 }), None);
 
         assert_eq!(placeholder_frame(None, 4, &ImagePreviewSize { width: 4, height: 1 }), None);


### PR DESCRIPTION
When `settings.image_preview.size.width` is more than the available width, the preview placeholder is not rendered. When the image is small enough to be rendered, it is shown over the other messages.

This PR prevents that by limiting the preview to the available space.