### PR TITLE
Support generating shell-completions using `clap_complete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2270,7 @@ dependencies = [
  "bitflags 2.9.1",
  "chrono",
  "clap",
+ "clap_complete",
  "comrak",
  "css-color-parser",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0"
 bitflags = "^2.3"
 chrono = "0.4"
 clap = {version = "~4.3", features = ["derive"]}
+clap_complete = "~4.3"
 css-color-parser = "0.1.2"
 dirs = "4.0.0"
 emojis = "0.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,9 @@ const VERSION: &str = match option_env!("VERGEN_GIT_SHA") {
 #[clap(version = VERSION, about, long_about = None)]
 #[clap(propagate_version = true)]
 pub struct Iamb {
+    #[clap(long, value_parser)]
+    pub completions: Option<clap_complete::Shell>,
+
     #[clap(short = 'P', long, value_parser)]
     pub profile: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use matrix_sdk::crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
 use matrix_sdk::ruma::OwnedUserId;
@@ -1077,6 +1077,11 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
 fn main() -> IambResult<()> {
     // Parse command-line flags.
     let iamb = Iamb::parse();
+
+    if let Some(shell) = iamb.completions {
+        clap_complete::generate(shell, &mut Iamb::command(), "iamb", &mut std::io::stdout());
+        return Ok(());
+    }
 
     // Load configuration and set up the Matrix SDK.
     let settings = ApplicationSettings::load(iamb).unwrap_or_else(print_exit);


### PR DESCRIPTION
I know having shell-completions on `iamb` is *kinda* silly considering the CLI
*literally* just contains `--config-directory` and `--profile` (and the short
variants), but at this point I am just too used to having them **everywhere**.

Usually I would also have put it into a `completions` subcommand, but wasn't sure if that is *useful* considering that there aren't any other subcommands there at the moment.

When dynamic completions get stabilized in `clap`, they could probably also be
used to complete available profiles and such.

---

About the `cargo fmt`-commit: There might be some breackage with the formatting?
`fn_call_width` being set *anything* seems to prevent `rustfmt` from running at
all.

So I commented that part out and `cargo +nightly fmt --all`ed the repo.
Wasn't sure if it opening a separate PR for that was worth it.
But am totally happy to do that if wanted.