### PR TITLE
Update Nix lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1736994333,
-        "narHash": "sha256-v4Jrok5yXsZ6dwj2+2uo5cSyUi9fBTurHqHvNHLT1XA=",
+        "lastModified": 1756089517,
+        "narHash": "sha256-KGinVKturJFPrRebgvyUB1BUNqf1y9FN+tSJaTPlnFE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "848db855cb9e88785996e961951659570fc58814",
+        "rev": "44774c8c83cd392c50914f86e1ff75ef8619f1cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Build fails due to recently bumped versions. A routine `nix flake update --commit-lock-file` fixes it.

---

Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/eb62e6aa39ea67e0b8018ba8ea077efe65807dc8?narHash=sha256-uQ%2BNQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140%3D' (2025-01-14)
  → 'github:nixos/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/848db855cb9e88785996e961951659570fc58814?narHash=sha256-v4Jrok5yXsZ6dwj2%2B2uo5cSyUi9fBTurHqHvNHLT1XA%3D' (2025-01-16)
  → 'github:oxalica/rust-overlay/44774c8c83cd392c50914f86e1ff75ef8619f1cd?narHash=sha256-KGinVKturJFPrRebgvyUB1BUNqf1y9FN%2BtSJaTPlnFE%3D' (2025-08-25)
• Updated input 'rust-overlay/nixpkgs':
    'github:NixOS/nixpkgs/4bc9c909d9ac828a039f288cf872d16d38185db8?narHash=sha256-nIYdTAiKIGnFNugbomgBJR%2BXv5F1ZQU%2BHfaBqJKroC0%3D' (2025-01-08)
  → 'github:NixOS/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38%3D' (2025-04-13)
