### PR TITLE
Update Nix flake and its lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1736994333,
-        "narHash": "sha256-v4Jrok5yXsZ6dwj2+2uo5cSyUi9fBTurHqHvNHLT1XA=",
+        "lastModified": 1756694554,
+        "narHash": "sha256-z/Iy4qvcMqzhA2IAAg71Sw4BrMwbBHvCS90ZoPLsnIk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "848db855cb9e88785996e961951659570fc58814",
+        "rev": "b29e5365120f344fe7161f14fc9e272fcc41ee56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,13 +8,21 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         # We only need the nightly overlay in the devShell because .rs files are formatted with nightly.
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        rustNightly = pkgs.rust-bin.nightly."2024-12-12".default;
+        rustNightly = pkgs.rust-bin.nightly."2025-08-31".default;
       in
       with pkgs;
       {
@@ -26,14 +34,27 @@
             lockFile = ./Cargo.lock;
           };
           nativeBuildInputs = [ pkg-config ];
-          buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin
-            (with darwin.apple_sdk.frameworks; [ AppKit Security Cocoa ]);
+          buildInputs =
+            [ openssl ]
+            ++ lib.optionals stdenv.isDarwin (
+              with darwin.apple_sdk.frameworks;
+              [
+                AppKit
+                Security
+                Cocoa
+              ]
+            );
         };
 
         devShell = mkShell {
           buildInputs = [
             (rustNightly.override {
-              extensions = [ "rust-src" "rust-analyzer-preview" "rustfmt" "clippy" ];
+              extensions = [
+                "rust-src"
+                "rust-analyzer-preview"
+                "rustfmt"
+                "clippy"
+              ];
             })
             pkg-config
             cargo-tarpaulin
@@ -41,5 +62,6 @@
             sqlite
           ];
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
Currently pulls in rust 1.83, which is too old to build iamb now.

I'm going to try to keep the nix stuff up to date from now on.