### PR TITLE
Fix most clippy warnigs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1003,7 +1003,7 @@ impl ApplicationSettings {
         Ok(())
     }
 
-    pub fn get_user_char_span(&self, user_id: &UserId) -> Span {
+    pub fn get_user_char_span(&self, user_id: &UserId) -> Span<'_> {
         let (color, c) = self
             .tunables
             .users

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -233,13 +233,13 @@ impl MessageTimeStamp {
         dt1.date_naive() == dt2.date_naive()
     }
 
-    fn show_date(&self) -> Option<Span> {
+    fn show_date(&self) -> Option<Span<'_>> {
         let time = self.as_datetime().format("%A, %B %d %Y").to_string();
 
         Span::styled(time, BOLD_STYLE).into()
     }
 
-    fn show_time(&self) -> Option<Span> {
+    fn show_time(&self) -> Option<Span<'_>> {
         match self {
             MessageTimeStamp::OriginServer(ms) => {
                 let time = millis_to_datetime(*ms).format("%T");

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -97,12 +97,12 @@ fn bold_style() -> Style {
 }
 
 #[inline]
-fn bold_span(s: &str) -> Span {
+fn bold_span(s: &str) -> Span<'_> {
     Span::styled(s, bold_style())
 }
 
 #[inline]
-fn bold_spans(s: &str) -> Line {
+fn bold_spans(s: &str) -> Line<'_> {
     bold_span(s).into()
 }
 
@@ -116,12 +116,12 @@ fn selected_style(selected: bool) -> Style {
 }
 
 #[inline]
-fn selected_span(s: &str, selected: bool) -> Span {
+fn selected_span(s: &str, selected: bool) -> Span<'_> {
     Span::styled(s, selected_style(selected))
 }
 
 #[inline]
-fn selected_text(s: &str, selected: bool) -> Text {
+fn selected_text(s: &str, selected: bool) -> Text<'_> {
     Text::from(selected_span(s, selected))
 }
 
@@ -743,7 +743,7 @@ impl Window<IambInfo> for IambWindow {
         }
     }
 
-    fn get_tab_title(&self, store: &mut ProgramStore) -> Line {
+    fn get_tab_title(&self, store: &mut ProgramStore) -> Line<'_> {
         match self {
             IambWindow::DirectList(_) => bold_spans("Direct Messages"),
             IambWindow::RoomList(_) => bold_spans("Rooms"),
@@ -771,7 +771,7 @@ impl Window<IambInfo> for IambWindow {
         }
     }
 
-    fn get_win_title(&self, store: &mut ProgramStore) -> Line {
+    fn get_win_title(&self, store: &mut ProgramStore) -> Line<'_> {
         match self {
             IambWindow::DirectList(_) => bold_spans("Direct Messages"),
             IambWindow::RoomList(_) => bold_spans("Rooms"),
@@ -959,7 +959,12 @@ impl Display for GenericChatItem {
 }
 
 impl ListItem<IambInfo> for GenericChatItem {
-    fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
+    fn show(
+        &self,
+        selected: bool,
+        _: &ViewportContext<ListCursor>,
+        _: &mut ProgramStore,
+    ) -> Text<'_> {
         let unread = self.unread.is_unread();
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, unread, style);
@@ -1073,7 +1078,12 @@ impl Display for RoomItem {
 }
 
 impl ListItem<IambInfo> for RoomItem {
-    fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
+    fn show(
+        &self,
+        selected: bool,
+        _: &ViewportContext<ListCursor>,
+        _: &mut ProgramStore,
+    ) -> Text<'_> {
         let unread = self.unread.is_unread();
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, unread, style);
@@ -1177,7 +1187,12 @@ impl Display for DirectItem {
 }
 
 impl ListItem<IambInfo> for DirectItem {
-    fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
+    fn show(
+        &self,
+        selected: bool,
+        _: &ViewportContext<ListCursor>,
+        _: &mut ProgramStore,
+    ) -> Text<'_> {
         let unread = self.unread.is_unread();
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, unread, style);
@@ -1280,7 +1295,12 @@ impl Display for SpaceItem {
 }
 
 impl ListItem<IambInfo> for SpaceItem {
-    fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
+    fn show(
+        &self,
+        selected: bool,
+        _: &ViewportContext<ListCursor>,
+        _: &mut ProgramStore,
+    ) -> Text<'_> {
         selected_text(self.name.as_str(), selected)
     }
 
@@ -1411,7 +1431,12 @@ impl Display for VerifyItem {
 }
 
 impl ListItem<IambInfo> for VerifyItem {
-    fn show(&self, selected: bool, _: &ViewportContext<ListCursor>, _: &mut ProgramStore) -> Text {
+    fn show(
+        &self,
+        selected: bool,
+        _: &ViewportContext<ListCursor>,
+        _: &mut ProgramStore,
+    ) -> Text<'_> {
         let mut lines = vec![];
 
         let bold = Style::default().add_modifier(StyleModifier::BOLD);
@@ -1521,7 +1546,7 @@ impl ListItem<IambInfo> for MemberItem {
         selected: bool,
         _: &ViewportContext<ListCursor>,
         store: &mut ProgramStore,
-    ) -> Text {
+    ) -> Text<'_> {
         let info = store.application.rooms.get_or_default(self.room_id.clone());
         let user_id = self.member.user_id();
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -610,8 +610,7 @@ impl ChatState {
                             let mut buff = std::io::Cursor::new(bytes);
                             dynimage.write_to(&mut buff, image::ImageFormat::Png)?;
                             Ok(buff.into_inner())
-                        })
-                        .map_err(IambError::from)?;
+                        })?;
                 let mime = mime::IMAGE_PNG;
 
                 let name = "Clipboard.png";

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -658,7 +658,7 @@ impl RoomState {
         }
     }
 
-    pub fn get_title(&self, store: &mut ProgramStore) -> Line {
+    pub fn get_title(&self, store: &mut ProgramStore) -> Line<'_> {
         let title = store.application.get_room_title(self.id());
         let style = Style::default().add_modifier(StyleModifier::BOLD);
         let mut spans = vec![];


### PR DESCRIPTION
run `cargo clippy --fix` to resolve warnings introduced in #500

The only remaining warnings are about enum size differences in `RoomState` and `IambWindow`. Both are because `RoomState::Chat` is too large. I'm not sure whether to wrap this in a `Box` or to add a `#[allow(clippy::large_enum_variant)]`.