### PR TITLE
Add `:forget` to forget all left rooms

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -67,6 +67,8 @@ View a list of unread rooms.
 Mark all rooms as read.
 .It Sy ":welcome"
 View the startup Welcome window.
+.It Sy ":forget"
+Remove all left rooms from the internal database.
 .El
 
 .Sh "E2EE COMMANDS"

--- a/src/base.rs
+++ b/src/base.rs
@@ -491,6 +491,8 @@ pub enum HomeserverAction {
     /// Create a new room with an optional localpart.
     CreateRoom(Option<String>, CreateRoomType, CreateRoomFlags),
     Logout(String, bool),
+    /// Forget all left rooms
+    Forget,
 }
 
 /// An action performed against the user's room keys.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -200,6 +200,17 @@ fn iamb_leave(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     return Ok(step);
 }
 
+fn iamb_forget(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    if !desc.arg.text.is_empty() {
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    let forget = IambAction::Homeserver(HomeserverAction::Forget);
+    let step = CommandStep::Continue(forget.into(), ctx.context.clone());
+
+    return Ok(step);
+}
+
 fn iamb_cancel(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     if !desc.arg.text.is_empty() {
         return Result::Err(CommandError::InvalidArgument);
@@ -730,6 +741,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "leave".into(),
         aliases: vec![],
         f: iamb_leave,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "forget".into(),
+        aliases: vec![],
+        f: iamb_forget,
     });
     cmds.add_command(ProgramCommand {
         name: "members".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,13 @@ impl Application {
 
                 Err(UIError::NeedConfirm(prompt))
             },
+            HomeserverAction::Forget => {
+                let client = &store.application.worker.client;
+                for room in client.left_rooms() {
+                    room.forget().await.map_err(IambError::from)?;
+                }
+                Ok(vec![])
+            },
         }
     }
 


### PR DESCRIPTION
Left rooms are still synced and in the database unless they are forgotten. Maybe `:leave` should forget rooms by default since we don't show left rooms.