### PR TITLE
Open Matrix URIs on the command line and support user mentions

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -5,7 +5,7 @@
 .\"
 .\" You can preview this file with:
 .\"     $ man ./docs/iamb.1
-.Dd Mar 24, 2024
+.Dd Sep 11, 2025
 .Dt IAMB 1
 .Os
 .Sh NAME
@@ -16,6 +16,7 @@
 .Op Fl hV
 .Op Fl P Ar profile
 .Op Fl C Ar dir
+.Op Ar URI
 .Sh DESCRIPTION
 .Nm
 is a client for the Matrix communication protocol.
@@ -46,6 +47,9 @@ Show the help text and quit.
 Show the current
 .Nm
 version and quit.
+.It Ar URI
+A matrix uri or matrix.to link to open on startup. Specified at
+.Lk https://spec.matrix.org/latest/appendices/#uris
 .El
 
 .Sh "GENERAL COMMANDS"

--- a/iamb.desktop
+++ b/iamb.desktop
@@ -1,7 +1,8 @@
 [Desktop Entry]
 Categories=Network;InstantMessaging;Chat;
 Comment=A Matrix client for Vim addicts
-Exec=iamb
+Exec=iamb %u
+MimeType=x-scheme-handler/matrix
 GenericName=Matrix Client
 Keywords=Matrix;matrix.org;chat;communications;talk;
 Name=iamb

--- a/src/base.rs
+++ b/src/base.rs
@@ -507,7 +507,7 @@ pub enum KeysAction {
     Import(String, String),
 }
 
-/// An action that the main program loop should.
+/// An action that the main program loop should execute.
 ///
 /// See [the commands module][super::commands] for where these are usually created.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -524,8 +524,8 @@ pub enum IambAction {
     /// Perform an action on the current space.
     Space(SpaceAction),
 
-    /// Open a URL.
-    OpenLink(String),
+    /// Open a URL (and specify whether to join linked matrix rooms).
+    OpenLink(String, bool),
 
     /// Perform an action on the currently focused room.
     Room(RoomAction),

--- a/src/base.rs
+++ b/src/base.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use emojis::Emoji;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
+use matrix_sdk::ruma::OwnedRoomAliasId;
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -920,7 +921,10 @@ pub struct RoomInfo {
     pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
 
     /// The display names for users in this room.
-    pub display_names: HashMap<OwnedUserId, String>,
+    pub display_names: CompletionMap<OwnedUserId, String>,
+
+    /// Tab completion for the display names in this room.
+    pub display_name_completion: CompletionMap<String, OwnedUserId>,
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
@@ -943,6 +947,7 @@ impl Default for RoomInfo {
             fetch_last: Default::default(),
             users_typing: Default::default(),
             display_names: Default::default(),
+            display_name_completion: Default::default(),
             draw_last: Default::default(),
         }
     }
@@ -1603,7 +1608,7 @@ pub struct ChatStore {
     pub rooms: CompletionMap<OwnedRoomId, RoomInfo>,
 
     /// Map of room names.
-    pub names: CompletionMap<String, OwnedRoomId>,
+    pub names: CompletionMap<OwnedRoomAliasId, OwnedRoomId>,
 
     /// Presence information for other users.
     pub presences: CompletionMap<OwnedUserId, PresenceState>,
@@ -2015,7 +2020,9 @@ impl Completer<IambInfo> for IambCompleter {
         match content {
             IambBufferId::Command(CommandType::Command) => complete_cmdbar(text, cursor, store),
             IambBufferId::Command(CommandType::Search) => vec![],
-            IambBufferId::Room(_, _, RoomFocus::MessageBar) => complete_msgbar(text, cursor, store),
+            IambBufferId::Room(room_id, _, RoomFocus::MessageBar) => {
+                complete_msgbar(text, cursor, store, room_id)
+            },
             IambBufferId::Room(_, _, RoomFocus::Scrollback) => vec![],
 
             IambBufferId::DirectList => vec![],
@@ -2046,26 +2053,38 @@ fn complete_users(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Ve
 }
 
 /// Tab completion within the message bar.
-fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
+fn complete_msgbar(
+    text: &EditRope,
+    cursor: &mut Cursor,
+    store: &mut ChatStore,
+    room_id: &RoomId,
+) -> Vec<String> {
     let id = text
         .get_prefix_word_mut(cursor, &MATRIX_ID_WORD)
         .unwrap_or_else(EditRope::empty);
     let id = Cow::from(&id);
 
+    let info = store.rooms.get_or_default(room_id.to_owned());
+
     match id.chars().next() {
         // Complete room aliases.
         Some('#') => {
-            return store.names.complete(id.as_ref());
+            store
+                .names
+                .complete(id.as_ref())
+                .into_iter()
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete room identifiers.
         Some('!') => {
-            return store
+            store
                 .rooms
                 .complete(id.as_ref())
                 .into_iter()
-                .map(|i| i.to_string())
-                .collect();
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete Emoji shortcodes.
@@ -2073,26 +2092,43 @@ fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
             let list = store.emojis.complete(&id[1..]);
             let iter = list.into_iter().take(200).map(|s| format!(":{s}:"));
 
-            return iter.collect();
+            iter.collect()
         },
 
         // Complete usernames for @ and empty strings.
         Some('@') | None => {
-            return store
-                .presences
-                .complete(id.as_ref())
+            // spec says to mention with display name in anchor text
+            let mut users: HashSet<_> = info
+                .display_name_completion
+                .complete(id.strip_prefix('@').unwrap_or(&id))
                 .into_iter()
-                .map(|i| i.to_string())
+                .map(|n| {
+                    format!(
+                        "[{}]({})",
+                        n,
+                        info.display_name_completion.get(&n).unwrap().matrix_to_uri()
+                    )
+                })
                 .collect();
+
+            users.extend(info.display_names.complete(id.as_ref()).into_iter().map(|i| {
+                format!(
+                    "[{}]({})",
+                    info.display_names.get(&i).unwrap_or(&i.to_string()),
+                    i.matrix_to_uri()
+                )
+            }));
+
+            users.into_iter().collect()
         },
 
         // Unknown sigil.
-        Some(_) => return vec![],
+        Some(_) => vec![],
     }
 }
 
-/// Tab completion for Matrix identifiers (usernames, room aliases, etc.)
-fn complete_matrix_names(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
+/// Tab completion for Matrix room aliases
+fn complete_matrix_aliases(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
     let id = text
         .get_prefix_word_mut(cursor, &MATRIX_ID_WORD)
         .unwrap_or_else(EditRope::empty);
@@ -2100,7 +2136,7 @@ fn complete_matrix_names(text: &EditRope, cursor: &mut Cursor, store: &ChatStore
 
     let list = store.names.complete(id.as_ref());
     if !list.is_empty() {
-        return list;
+        return list.into_iter().map(|i| i.to_string()).collect();
     }
 
     let list = store.presences.complete(id.as_ref());
@@ -2156,7 +2192,7 @@ fn complete_cmdarg(
         "react" | "unreact" => complete_emoji(text, cursor, store),
 
         "invite" => complete_users(text, cursor, store),
-        "join" | "split" | "vsplit" | "tabedit" => complete_matrix_names(text, cursor, store),
+        "join" | "split" | "vsplit" | "tabedit" => complete_matrix_aliases(text, cursor, store),
         "room" => vec![],
         "verify" => vec![],
         "vertical" | "horizontal" | "aboveleft" | "belowright" | "tab" => {
@@ -2364,24 +2400,25 @@ pub mod tests {
     #[tokio::test]
     async fn test_complete_msgbar() {
         let store = mock_store().await;
-        let store = store.application;
+        let mut store = store.application;
+        let room_id = TEST_ROOM1_ID.clone();
 
         let text = EditRope::from("going for a walk :walk ");
         let mut cursor = Cursor::new(0, 22);
-        let res = complete_msgbar(&text, &mut cursor, &store);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
         assert_eq!(res, vec![":walking:", ":walking_man:", ":walking_woman:"]);
         assert_eq!(cursor, Cursor::new(0, 17));
 
-        let text = EditRope::from("hello @user1 ");
+        let text = EditRope::from("hello @user2 ");
         let mut cursor = Cursor::new(0, 12);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["@user1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[User 2](https://matrix.to/#/@user2:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 6));
 
         let text = EditRope::from("see #room ");
         let mut cursor = Cursor::new(0, 9);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["#room1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[#room1:example.com](https://matrix.to/#/%23room1:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 4));
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -1023,12 +1023,34 @@ impl RoomInfo {
 
     /// Get an event for an identifier.
     pub fn get_event(&self, event_id: &EventId) -> Option<&Message> {
-        self.messages.get(self.get_message_key(event_id)?)
+        let (thread_root, key) = match self.keys.get(event_id)? {
+            EventLocation::Message(thread_root, key) => (thread_root, key),
+            EventLocation::State(key) => (&None, key),
+            _ => return None,
+        };
+
+        let messages = if let Some(root) = thread_root {
+            self.threads.get(root)?
+        } else {
+            &self.messages
+        };
+        messages.get(key)
     }
 
     /// Get an event for an identifier as mutable.
     pub fn get_event_mut(&mut self, event_id: &EventId) -> Option<&mut Message> {
-        self.messages.get_mut(self.keys.get(event_id)?.to_message_key()?)
+        let (thread_root, key) = match self.keys.get(event_id)? {
+            EventLocation::Message(thread_root, key) => (thread_root, key),
+            EventLocation::State(key) => (&None, key),
+            _ => return None,
+        };
+
+        let messages = if let Some(root) = thread_root {
+            self.threads.get_mut(root)?
+        } else {
+            &mut self.messages
+        };
+        messages.get_mut(key)
     }
 
     pub fn redact(&mut self, ev: OriginalSyncRoomRedactionEvent) {

--- a/src/base.rs
+++ b/src/base.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::OwnedRoomAliasId;
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -919,7 +920,10 @@ pub struct RoomInfo {
     pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
 
     /// The display names for users in this room.
-    pub display_names: HashMap<OwnedUserId, String>,
+    pub display_names: CompletionMap<OwnedUserId, String>,
+
+    /// Tab completion for the display names in this room.
+    pub display_name_completion: CompletionMap<String, OwnedUserId>,
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
@@ -942,6 +946,7 @@ impl Default for RoomInfo {
             fetch_last: Default::default(),
             users_typing: Default::default(),
             display_names: Default::default(),
+            display_name_completion: Default::default(),
             draw_last: Default::default(),
         }
     }
@@ -1602,7 +1607,7 @@ pub struct ChatStore {
     pub rooms: CompletionMap<OwnedRoomId, RoomInfo>,
 
     /// Map of room names.
-    pub names: CompletionMap<String, OwnedRoomId>,
+    pub names: CompletionMap<OwnedRoomAliasId, OwnedRoomId>,
 
     /// Presence information for other users.
     pub presences: CompletionMap<OwnedUserId, PresenceState>,
@@ -2014,7 +2019,9 @@ impl Completer<IambInfo> for IambCompleter {
         match content {
             IambBufferId::Command(CommandType::Command) => complete_cmdbar(text, cursor, store),
             IambBufferId::Command(CommandType::Search) => vec![],
-            IambBufferId::Room(_, _, RoomFocus::MessageBar) => complete_msgbar(text, cursor, store),
+            IambBufferId::Room(room_id, _, RoomFocus::MessageBar) => {
+                complete_msgbar(text, cursor, store, room_id)
+            },
             IambBufferId::Room(_, _, RoomFocus::Scrollback) => vec![],
 
             IambBufferId::DirectList => vec![],
@@ -2045,26 +2052,38 @@ fn complete_users(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Ve
 }
 
 /// Tab completion within the message bar.
-fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
+fn complete_msgbar(
+    text: &EditRope,
+    cursor: &mut Cursor,
+    store: &mut ChatStore,
+    room_id: &RoomId,
+) -> Vec<String> {
     let id = text
         .get_prefix_word_mut(cursor, &MATRIX_ID_WORD)
         .unwrap_or_else(EditRope::empty);
     let id = Cow::from(&id);
 
+    let info = store.rooms.get_or_default(room_id.to_owned());
+
     match id.chars().next() {
         // Complete room aliases.
         Some('#') => {
-            return store.names.complete(id.as_ref());
+            store
+                .names
+                .complete(id.as_ref())
+                .into_iter()
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete room identifiers.
         Some('!') => {
-            return store
+            store
                 .rooms
                 .complete(id.as_ref())
                 .into_iter()
-                .map(|i| i.to_string())
-                .collect();
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete Emoji shortcodes.
@@ -2072,26 +2091,43 @@ fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
             let list = store.emojis.complete(&id[1..]);
             let iter = list.into_iter().take(200).map(|s| format!(":{s}:"));
 
-            return iter.collect();
+            iter.collect()
         },
 
         // Complete usernames for @ and empty strings.
         Some('@') | None => {
-            return store
-                .presences
-                .complete(id.as_ref())
+            // spec says to mention with display name in anchor text
+            let mut users: HashSet<_> = info
+                .display_name_completion
+                .complete(id.strip_prefix('@').unwrap_or(&id))
                 .into_iter()
-                .map(|i| i.to_string())
+                .map(|n| {
+                    format!(
+                        "[{}]({})",
+                        n,
+                        info.display_name_completion.get(&n).unwrap().matrix_to_uri()
+                    )
+                })
                 .collect();
+
+            users.extend(info.display_names.complete(id.as_ref()).into_iter().map(|i| {
+                format!(
+                    "[{}]({})",
+                    info.display_names.get(&i).unwrap_or(&i.to_string()),
+                    i.matrix_to_uri()
+                )
+            }));
+
+            users.into_iter().collect()
         },
 
         // Unknown sigil.
-        Some(_) => return vec![],
+        Some(_) => vec![],
     }
 }
 
-/// Tab completion for Matrix identifiers (usernames, room aliases, etc.)
-fn complete_matrix_names(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
+/// Tab completion for Matrix room aliases
+fn complete_matrix_aliases(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
     let id = text
         .get_prefix_word_mut(cursor, &MATRIX_ID_WORD)
         .unwrap_or_else(EditRope::empty);
@@ -2099,7 +2135,7 @@ fn complete_matrix_names(text: &EditRope, cursor: &mut Cursor, store: &ChatStore
 
     let list = store.names.complete(id.as_ref());
     if !list.is_empty() {
-        return list;
+        return list.into_iter().map(|i| i.to_string()).collect();
     }
 
     let list = store.presences.complete(id.as_ref());
@@ -2155,7 +2191,7 @@ fn complete_cmdarg(
         "react" | "unreact" => complete_emoji(text, cursor, store),
 
         "invite" => complete_users(text, cursor, store),
-        "join" | "split" | "vsplit" | "tabedit" => complete_matrix_names(text, cursor, store),
+        "join" | "split" | "vsplit" | "tabedit" => complete_matrix_aliases(text, cursor, store),
         "room" => vec![],
         "verify" => vec![],
         "vertical" | "horizontal" | "aboveleft" | "belowright" | "tab" => {
@@ -2359,24 +2395,25 @@ pub mod tests {
     #[tokio::test]
     async fn test_complete_msgbar() {
         let store = mock_store().await;
-        let store = store.application;
+        let mut store = store.application;
+        let room_id = TEST_ROOM1_ID.clone();
 
         let text = EditRope::from("going for a walk :walk ");
         let mut cursor = Cursor::new(0, 22);
-        let res = complete_msgbar(&text, &mut cursor, &store);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
         assert_eq!(res, vec![":walking:", ":walking_man:", ":walking_woman:"]);
         assert_eq!(cursor, Cursor::new(0, 17));
 
-        let text = EditRope::from("hello @user1 ");
+        let text = EditRope::from("hello @user2 ");
         let mut cursor = Cursor::new(0, 12);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["@user1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[User 2](https://matrix.to/#/@user2:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 6));
 
         let text = EditRope::from("see #room ");
         let mut cursor = Cursor::new(0, 9);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["#room1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[#room1:example.com](https://matrix.to/#/%23room1:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 4));
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -506,7 +506,7 @@ pub enum KeysAction {
     Import(String, String),
 }
 
-/// An action that the main program loop should.
+/// An action that the main program loop should execute.
 ///
 /// See [the commands module][super::commands] for where these are usually created.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -523,8 +523,8 @@ pub enum IambAction {
     /// Perform an action on the current space.
     Space(SpaceAction),
 
-    /// Open a URL.
-    OpenLink(String),
+    /// Open a URL (and specify whether to join linked matrix rooms).
+    OpenLink(String, bool),
 
     /// Perform an action on the currently focused room.
     Room(RoomAction),

--- a/src/base.rs
+++ b/src/base.rs
@@ -2,7 +2,7 @@
 //!
 //! The types defined here get used throughout iamb.
 
-use std::collections::hash_map::{Entry, IntoIter};
+use std::collections::hash_map::IntoIter;
 use std::collections::{BTreeSet, HashSet};
 
 use emojis::Emoji;
@@ -566,7 +566,7 @@ pub enum KeysAction {
     Import(String, String),
 }
 
-/// An action that the main program loop should.
+/// An action that the main program loop should execute.
 ///
 /// See [the commands module][super::commands] for where these are usually created.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -583,8 +583,8 @@ pub enum IambAction {
     /// Perform an action on the current space.
     Space(SpaceAction),
 
-    /// Open a URL.
-    OpenLink(String),
+    /// Open a URL (and specify whether to join linked matrix rooms).
+    OpenLink(String, bool),
 
     /// Perform an action on the currently focused room.
     Room(RoomAction),
@@ -992,9 +992,9 @@ struct DisplayNameUsers {
 #[derive(Default)]
 pub struct DisplayNameStore {
     /// The boolean is the same `is_active` field as the argument to [`Self::set`].
-    by_ids: HashMap<OwnedUserId, (String, bool)>,
+    by_ids: CompletionMap<OwnedUserId, (Option<String>, bool)>,
 
-    by_names: HashMap<String, DisplayNameUsers>,
+    by_names: CompletionMap<String, DisplayNameUsers>,
 }
 
 impl DisplayNameStore {
@@ -1028,51 +1028,40 @@ impl DisplayNameStore {
             self.set_by_name(user_id.clone(), name, is_active);
         }
 
-        let previous = match (self.by_ids.entry(user_id), name) {
-            // Nothing to do!
-            (Entry::Vacant(_), None) => None,
+        if self
+            .by_ids
+            .get(&user_id)
+            .is_some_and(|(n, a)| *n == name && *a == is_active)
+        {
+            // nothing to do
+            return;
+        }
 
-            // Setting initial display name for user:
-            (Entry::Vacant(v), Some(name)) => {
-                v.insert((name, is_active));
-                None
-            },
+        let previous = self.by_ids.insert(user_id.to_owned(), (name, is_active));
 
-            // Unsetting display name:
-            (Entry::Occupied(o), None) => Some(o.remove_entry()),
-
-            // Replacing existing name:
-            (Entry::Occupied(mut o), Some(name)) => {
-                let key = (name, is_active);
-                if o.get() == &key {
-                    None
-                } else {
-                    Some((o.key().clone(), o.insert(key)))
-                }
-            },
-        };
-
-        let Some((user_id, previous)) = previous else {
+        let Some((Some(name), was_active)) = previous else {
+            // no previous entry in `self.by_names` to remove
             return;
         };
 
-        let Some(users) = self.by_names.get_mut(&previous.0) else {
+        let Some(users) = self.by_names.get_mut(&name) else {
             return;
         };
 
-        if previous.1 {
+        if was_active {
             users.active.remove(&user_id);
         } else {
             users.inactive.remove(&user_id);
         }
 
         if users.active.is_empty() && users.inactive.is_empty() {
-            self.by_names.remove(&previous.0);
+            self.by_names.remove(&name);
         }
     }
 
     pub fn get<'a>(&'a self, user_id: &UserId) -> Option<Cow<'a, str>> {
         let (displayname, is_active) = self.by_ids.get(user_id)?;
+        let displayname = displayname.as_ref()?;
         let users = self.by_names.get(displayname)?;
 
         if !users.active.contains(user_id) && !users.inactive.contains(user_id) {
@@ -1088,6 +1077,35 @@ impl DisplayNameStore {
 
         // Ambiguous username, so include unique user ID:
         Some(Cow::Owned(format!("{displayname} ({user_id})")))
+    }
+
+    pub fn complete_mention(&self, prefix: &str) -> Vec<String> {
+        // spec says to mention with display name in anchor text
+        let mut users: BTreeSet<_> = self
+            .by_names
+            .complete(prefix.strip_prefix('@').unwrap_or(prefix))
+            .into_iter()
+            .flat_map(|name| {
+                let users = self.by_names.get(&name).unwrap();
+                users
+                    .active
+                    .iter()
+                    .map(move |id| format!("[{name}]({})", id.matrix_to_uri()))
+            })
+            .collect();
+
+        users.extend(self.by_ids.complete(prefix).into_iter().map(|id| {
+            format!(
+                "[{}]({})",
+                self.by_ids
+                    .get(&id)
+                    .and_then(|(name, _)| name.as_deref())
+                    .unwrap_or(id.as_str()),
+                id.matrix_to_uri()
+            )
+        }));
+
+        users.into_iter().collect()
     }
 }
 
@@ -1859,7 +1877,7 @@ pub struct ChatStore {
     pub rooms: CompletionMap<OwnedRoomId, RoomInfo>,
 
     /// Map of room names.
-    pub names: CompletionMap<String, OwnedRoomId>,
+    pub names: CompletionMap<OwnedRoomAliasId, OwnedRoomId>,
 
     /// Presence information for other users.
     pub presences: CompletionMap<OwnedUserId, PresenceState>,

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,5 +1,6 @@
 //! Tab completions for iamb
 
+use matrix_sdk::ruma::RoomId;
 use modalkit::editing::completion::{Completer, complete_path};
 use modalkit::editing::cursor::Cursor;
 use modalkit::env::vim::command::CommandDescription;
@@ -264,7 +265,7 @@ fn complete_users(input: &str, store: &ChatStore) -> Vec<String> {
 fn complete_matrix_names(input: &str, store: &ChatStore) -> Vec<String> {
     let list = store.names.complete(input);
     if !list.is_empty() {
-        return list;
+        return list.into_iter().map(|i| i.to_string()).collect();
     }
 
     let list = store.presences.complete(input);
@@ -279,7 +280,7 @@ fn complete_matrix_names(input: &str, store: &ChatStore) -> Vec<String> {
 fn complete_room_alias_or_id(input: &str, store: &ChatStore) -> Vec<String> {
     let list = store.names.complete(input);
     if !list.is_empty() {
-        return list;
+        return list.into_iter().map(|i| i.to_string()).collect();
     }
 
     store.rooms.complete(input).into_iter().map(|i| i.to_string()).collect()
@@ -685,26 +686,38 @@ fn complete_cmdbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
 }
 
 /// Tab completion within the message bar.
-fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> Vec<String> {
+fn complete_msgbar(
+    text: &EditRope,
+    cursor: &mut Cursor,
+    store: &mut ChatStore,
+    room_id: &RoomId,
+) -> Vec<String> {
     let id = text
         .get_prefix_word_mut(cursor, &MATRIX_ID_WORD)
         .unwrap_or_else(EditRope::empty);
     let id = Cow::from(&id);
 
+    let info = store.rooms.get_or_default(room_id.to_owned());
+
     match id.chars().next() {
         // Complete room aliases.
         Some('#') => {
-            return store.names.complete(id.as_ref());
+            store
+                .names
+                .complete(id.as_ref())
+                .into_iter()
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete room identifiers.
         Some('!') => {
-            return store
+            store
                 .rooms
                 .complete(id.as_ref())
                 .into_iter()
-                .map(|i| i.to_string())
-                .collect();
+                .map(|i| format!("[{}]({})", i, i.matrix_to_uri()))
+                .collect()
         },
 
         // Complete Emoji shortcodes.
@@ -716,14 +729,7 @@ fn complete_msgbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
         },
 
         // Complete usernames for @ and empty strings.
-        Some('@') | None => {
-            return store
-                .presences
-                .complete(id.as_ref())
-                .into_iter()
-                .map(|i| i.to_string())
-                .collect();
-        },
+        Some('@') | None => info.display_names.complete_mention(&id),
 
         // Unknown sigil.
         Some(_) => return vec![],
@@ -743,7 +749,9 @@ impl Completer<IambInfo> for IambCompleter {
         match content {
             IambBufferId::Command(CommandType::Command) => complete_cmdbar(text, cursor, store),
             IambBufferId::Command(CommandType::Search) => vec![],
-            IambBufferId::Room(_, _, RoomFocus::MessageBar) => complete_msgbar(text, cursor, store),
+            IambBufferId::Room(room_id, _, RoomFocus::MessageBar) => {
+                complete_msgbar(text, cursor, store, room_id)
+            },
             IambBufferId::Room(_, _, RoomFocus::Scrollback) => vec![],
 
             IambBufferId::DirectList => vec![],
@@ -774,24 +782,25 @@ pub mod tests {
     #[tokio::test]
     async fn test_complete_msgbar() {
         let store = mock_store().await;
-        let store = store.application;
+        let mut store = store.application;
+        let room_id = TEST_ROOM1_ID.clone();
 
         let text = EditRope::from("going for a walk :walk ");
         let mut cursor = Cursor::new(0, 22);
-        let res = complete_msgbar(&text, &mut cursor, &store);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
         assert_eq!(res, vec![":walking:", ":walking_man:", ":walking_woman:"]);
         assert_eq!(cursor, Cursor::new(0, 17));
 
-        let text = EditRope::from("hello @user1 ");
+        let text = EditRope::from("hello @user2 ");
         let mut cursor = Cursor::new(0, 12);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["@user1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[User 2](https://matrix.to/#/@user2:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 6));
 
         let text = EditRope::from("see #room ");
         let mut cursor = Cursor::new(0, 9);
-        let res = complete_msgbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["#room1:example.com"]);
+        let res = complete_msgbar(&text, &mut cursor, &mut store, &room_id);
+        assert_eq!(res, vec!["[#room1:example.com](https://matrix.to/#/%23room1:example.com)"]);
         assert_eq!(cursor, Cursor::new(0, 4));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,6 +135,9 @@ pub struct Iamb {
 
     #[clap(short = 'C', long, value_parser)]
     pub config_directory: Option<PathBuf>,
+
+    /// `matrix:` uri or `https://matrix.to` link to open
+    pub uri: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1103,8 +1103,19 @@ impl ApplicationSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::*;
     use matrix_sdk::ruma::user_id;
     use std::convert::TryFrom;
+
+    #[test]
+    fn test_get_user_span_borrowed() {
+        // fix `StyleTreeNode::print` for `StyleTreeNode::UserId` if this breaks
+        let info = mock_room();
+        let settings = mock_settings();
+        let span = settings.get_user_span(&TEST_USER1, &info);
+
+        assert!(matches!(span.content, Cow::Borrowed(_)));
+    }
 
     #[test]
     fn test_profile_name_invalid() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,9 @@ pub struct Iamb {
 
     #[clap(short = 'C', long, value_parser)]
     pub config_directory: Option<PathBuf>,
+
+    /// `matrix:` uri or `https://matrix.to` link to open
+    pub uri: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1065,8 +1065,19 @@ impl ApplicationSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::*;
     use matrix_sdk::ruma::user_id;
     use std::convert::TryFrom;
+
+    #[test]
+    fn test_get_user_span_borrowed() {
+        // fix `StyleTreeNode::print` for `StyleTreeNode::UserId` if this breaks
+        let info = mock_room();
+        let settings = mock_settings();
+        let span = settings.get_user_span(&TEST_USER1, &info);
+
+        assert!(matches!(span.content, Cow::Borrowed(_)));
+    }
 
     #[test]
     fn test_profile_name_invalid() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,9 @@ pub struct Iamb {
 
     #[clap(short = 'C', long, value_parser)]
     pub config_directory: Option<PathBuf>,
+
+    /// `matrix:` uri or `https://matrix.to` link to open
+    pub uri: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1473,6 +1476,18 @@ mod tests {
     use std::convert::TryFrom;
 
     use matrix_sdk::ruma::user_id;
+
+    use crate::tests::{TEST_USER1, mock_room, mock_settings};
+
+    #[test]
+    fn test_get_user_span_borrowed() {
+        // fix `StyleTreeNode::print` for `StyleTreeNode::UserId` if this breaks
+        let info = mock_room();
+        let settings = mock_settings();
+        let span = settings.get_user_span(&TEST_USER1, &info);
+
+        assert!(matches!(span.content, Cow::Borrowed(_)));
+    }
 
     #[test]
     fn test_profile_name_invalid() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,8 +1072,13 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     }));
 
     // And finally, start running the terminal UI.
-    let mut application = Application::new(settings, store).await?;
-    application.run().await?;
+    let mut application = Application::new(settings, store)
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
+    application
+        .run()
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
 
     // Clean up the terminal on exit.
     restore_tty(enable_enhanced_keys, enable_mouse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,16 +151,13 @@ fn config_tab_to_desc(
 
             let window = match window {
                 config::WindowPath::UserId(user_id) => {
-                    let name = user_id.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(user_id.to_string())?;
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
-                    let name = alias.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(alias.to_string())?;
+                    names.insert(alias, room_id.clone());
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::Window(id) => id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,9 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
-use matrix_sdk::ruma::OwnedUserId;
+use matrix_sdk::ruma::matrix_uri::MatrixId;
 use matrix_sdk_crypto::encrypt_room_key_export;
+use matrix_sdk::ruma::{MatrixToUri, MatrixUri, OwnedUserId};
 use modalkit::keybindings::InputBindings;
 use rand::distr::Alphanumeric;
 use rand::RngExt as _;
@@ -194,13 +195,109 @@ fn restore_layout(
     tabs.to_layout(area.into(), store)
 }
 
+fn resolve_initial_room(
+    settings: &ApplicationSettings,
+    store: &mut ProgramStore,
+    id: MatrixId,
+) -> IambResult<Option<IambWindow>> {
+    let mut room_name = String::new();
+    let room_id = match id {
+        MatrixId::Room(id) => {
+            room_name = id.to_string();
+            id
+        },
+        MatrixId::RoomAlias(alias_id) => {
+            room_name = alias_id.to_string();
+            store.application.worker.resolve_alias(alias_id)?
+        },
+        MatrixId::User(user_id) => {
+            match store.application.worker.client.get_dm_room(&user_id) {
+                Some(room) => room.room_id().to_owned(),
+                None => {
+                    restore_tty(false, settings.tunables.mouse.enabled);
+
+                    let question = format!("No dm with {user_id} found. Create new DM? [y]es/[n]o");
+
+                    loop {
+                        match read_yesno(&question) {
+                            Some('y') => break,
+                            Some('n') => {
+                                setup_tty(settings, false)?;
+                                return Ok(None);
+                            },
+                            Some(_) | None => continue,
+                        }
+                    }
+
+                    setup_tty(settings, false)?;
+
+                    store.application.worker.join_room(user_id.to_string())?
+                },
+            }
+        },
+        MatrixId::Event(owned_room_or_alias_id, _event_id) => {
+            // ignore event id for now
+            room_name = owned_room_or_alias_id.to_string();
+            let room_or_alias_id: &matrix_sdk::ruma::RoomOrAliasId = &owned_room_or_alias_id;
+            if let Ok(alias_id) = <&matrix_sdk::ruma::RoomAliasId>::try_from(room_or_alias_id) {
+                store.application.worker.resolve_alias(alias_id.to_owned())?
+            } else {
+                matrix_sdk::ruma::OwnedRoomId::try_from(owned_room_or_alias_id).unwrap()
+            }
+        },
+        _ => {
+            tracing::error!("encountered unrecoginsed matrix id: {id:?}");
+            return Ok(None);
+        },
+    };
+
+    if !store
+        .application
+        .worker
+        .client
+        .joined_rooms()
+        .iter()
+        .any(|room| room.room_id() == room_id)
+    {
+        restore_tty(false, settings.tunables.mouse.enabled);
+
+        let question = format!("Join room {room_name:?}? [y]es/[n]o");
+
+        loop {
+            match read_yesno(&question) {
+                Some('y') => break,
+                Some('n') => {
+                    setup_tty(settings, false)?;
+                    return Ok(None);
+                },
+                Some(_) | None => continue,
+            }
+        }
+
+        setup_tty(settings, false)?;
+
+        store.application.worker.join_room(room_id.to_string())?;
+    }
+
+    let id = IambId::Room(room_id, None);
+    let win = IambWindow::open(id, store)?;
+    Ok(Some(win))
+}
+
 fn setup_screen(
     settings: ApplicationSettings,
     store: &mut ProgramStore,
+    initial_room: Option<MatrixId>,
 ) -> IambResult<ScreenState<IambWindow, IambInfo>> {
     let cmd = CommandBarState::new(store);
     let dims = crossterm::terminal::size()?;
     let area = Rect::new(0, 0, dims.0, dims.1);
+
+    if let Some(id) = initial_room {
+        if let Some(win) = resolve_initial_room(&settings, store, id)? {
+            return Ok(ScreenState::new(win, cmd));
+        }
+    }
 
     match settings.layout {
         config::Layout::Restore => {
@@ -272,6 +369,7 @@ impl Application {
     pub async fn new(
         settings: ApplicationSettings,
         store: AsyncProgramStore,
+        initial_room: Option<MatrixId>,
     ) -> IambResult<Application> {
         let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend)?;
@@ -281,7 +379,7 @@ impl Application {
         let bindings = KeyManager::new(bindings);
 
         let mut locked = store.lock().await;
-        let screen = setup_screen(settings, locked.deref_mut())?;
+        let screen = setup_screen(settings, locked.deref_mut(), initial_room)?;
 
         let worker = locked.application.worker.clone();
 
@@ -1016,7 +1114,7 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
     let _ = crossterm::terminal::disable_raw_mode();
 }
 
-async fn run(settings: ApplicationSettings) -> IambResult<()> {
+async fn run(settings: ApplicationSettings, initial_room: Option<MatrixId>) -> IambResult<()> {
     // Get old keys the first time we run w/ the upgraded SDK.
     let import_keys = check_import_keys(&settings).await?;
 
@@ -1071,7 +1169,7 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     }));
 
     // And finally, start running the terminal UI.
-    let mut application = Application::new(settings, store)
+    let mut application = Application::new(settings, store, initial_room)
         .await
         .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
     application
@@ -1127,6 +1225,15 @@ fn main() -> IambResult<()> {
     // Parse command-line flags.
     let iamb = Iamb::parse();
 
+    let initial_room = if let Some(uri) = &iamb.uri {
+        MatrixUri::parse(uri)
+            .map(|uri| uri.id().clone())
+            .or_else(|_| MatrixToUri::parse(uri).map(|uri| uri.id().clone()))
+            .ok()
+    } else {
+        None
+    };
+
     // Load configuration and set up the Matrix SDK.
     let settings = ApplicationSettings::load(iamb).unwrap_or_else(print_exit);
 
@@ -1149,7 +1256,7 @@ fn main() -> IambResult<()> {
         .build()
         .unwrap();
 
-    rt.block_on(async move { run(settings).await })?;
+    rt.block_on(async move { run(settings, initial_room).await })?;
 
     drop(guard);
     process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,16 +154,13 @@ fn config_tab_to_desc(
 
             let window = match window {
                 config::WindowPath::UserId(user_id) => {
-                    let name = user_id.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(user_id.to_string())?;
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
-                    let name = alias.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(alias.to_string())?;
+                    names.insert(alias, room_id.clone());
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::Window(id) => id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use matrix_sdk::ruma::api::client::error::ErrorKind;
 use matrix_sdk::ruma::matrix_uri::MatrixId;
 use matrix_sdk_crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::{MatrixToUri, MatrixUri, OwnedUserId};
+use matrix_sdk::OwnedServerName;
 use modalkit::keybindings::InputBindings;
 use rand::distr::Alphanumeric;
 use rand::RngExt as _;
@@ -154,12 +155,12 @@ fn config_tab_to_desc(
 
             let window = match window {
                 config::WindowPath::UserId(user_id) => {
-                    let room_id = worker.join_room(user_id.to_string())?;
+                    let room_id = worker.join_room(user_id.to_string(), vec![])?;
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
-                    let room_id = worker.join_room(alias.to_string())?;
+                    let room_id = worker.join_room(alias.to_string(), vec![])?;
                     names.insert(alias, room_id.clone());
                     IambId::Room(room_id, None)
                 },
@@ -197,6 +198,7 @@ fn restore_layout(
 fn resolve_mxid(
     store: &mut ProgramStore,
     id: MatrixId,
+    via: &[OwnedServerName],
     join_or_create: bool,
 ) -> IambResult<Result<IambId, String>> {
     let mut room_name = String::new();
@@ -213,7 +215,7 @@ fn resolve_mxid(
             match store.application.worker.client.get_dm_room(&user_id) {
                 Some(room) => room.room_id().to_owned(),
                 None if join_or_create => {
-                    store.application.worker.join_room(user_id.to_string())?
+                    store.application.worker.join_room(user_id.to_string(), via.to_owned())?
                 },
                 None => return Ok(Err(format!("No dm with {user_id} found. Create new DM?"))),
             }
@@ -243,7 +245,7 @@ fn resolve_mxid(
         .any(|room| room.room_id() == room_id)
     {
         if join_or_create {
-            store.application.worker.join_room(room_id.to_string())?;
+            store.application.worker.join_room(room_id.to_string(), via.to_owned())?;
         } else {
             return Ok(Err(format!("Join room {room_name:?}?")));
         }
@@ -255,14 +257,14 @@ fn resolve_mxid(
 fn setup_screen(
     settings: ApplicationSettings,
     store: &mut ProgramStore,
-    initial_room: Option<MatrixId>,
+    initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
 ) -> IambResult<ScreenState<IambWindow, IambInfo>> {
     let cmd = CommandBarState::new(store);
     let dims = crossterm::terminal::size()?;
     let area = Rect::new(0, 0, dims.0, dims.1);
 
-    if let Some(id) = initial_room {
-        match resolve_mxid(store, id.clone(), false)? {
+    if let Some((id, via)) = initial_room {
+        match resolve_mxid(store, id.clone(), &via, false)? {
             Ok(id) => {
                 return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
             },
@@ -278,7 +280,7 @@ fn setup_screen(
                 setup_tty(&settings, false)?;
 
                 if join_or_create {
-                    if let Ok(id) = resolve_mxid(store, id, true)? {
+                    if let Ok(id) = resolve_mxid(store, id, &via, true)? {
                         return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
                     }
                 }
@@ -356,7 +358,7 @@ impl Application {
     pub async fn new(
         settings: ApplicationSettings,
         store: AsyncProgramStore,
-        initial_room: Option<MatrixId>,
+        initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
     ) -> IambResult<Application> {
         let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend)?;
@@ -694,13 +696,16 @@ impl Application {
             },
 
             IambAction::OpenLink(url, join_or_create) => {
-                let matrix_id = MatrixUri::parse(&url)
-                    .map(|uri| uri.id().clone())
-                    .or_else(|_| MatrixToUri::parse(&url).map(|uri| uri.id().clone()))
-                    .ok();
+                let matrix_uri = MatrixUri::parse(&url).ok();
+                let matrix_to_uri = MatrixToUri::parse(&url).ok();
 
-                if let Some(id) = matrix_id {
-                    match resolve_mxid(store, id.clone(), join_or_create)? {
+                let matrix_id = matrix_uri
+                    .as_ref()
+                    .map(|uri| (uri.id(), uri.via()))
+                    .or(matrix_to_uri.as_ref().map(|uri| (uri.id(), uri.via())));
+
+                if let Some((id, via)) = matrix_id {
+                    match resolve_mxid(store, id.clone(), via, join_or_create)? {
                         Ok(room) => {
                             let target = OpenTarget::Application(room);
                             let action = WindowAction::Switch(target);
@@ -1122,7 +1127,10 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
     let _ = crossterm::terminal::disable_raw_mode();
 }
 
-async fn run(settings: ApplicationSettings, initial_room: Option<MatrixId>) -> IambResult<()> {
+async fn run(
+    settings: ApplicationSettings,
+    initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
+) -> IambResult<()> {
     // Get old keys the first time we run w/ the upgraded SDK.
     let import_keys = check_import_keys(&settings).await?;
 
@@ -1235,8 +1243,10 @@ fn main() -> IambResult<()> {
 
     let initial_room = if let Some(uri) = &iamb.uri {
         MatrixUri::parse(uri)
-            .map(|uri| uri.id().clone())
-            .or_else(|_| MatrixToUri::parse(uri).map(|uri| uri.id().clone()))
+            .map(|uri| (uri.id().clone(), uri.via().to_owned()))
+            .or_else(|_| {
+                MatrixToUri::parse(uri).map(|uri| (uri.id().clone(), uri.via().to_owned()))
+            })
             .ok()
     } else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use matrix_sdk::crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
 use matrix_sdk::ruma::matrix_uri::MatrixId;
 use matrix_sdk::ruma::{MatrixToUri, MatrixUri, OwnedUserId};
-use matrix_sdk::OwnedServerName;
+use matrix_sdk::{OwnedServerName, RoomState};
 use modalkit::keybindings::InputBindings;
 use rand::{distributions::Alphanumeric, Rng};
 use temp_dir::TempDir;
@@ -198,7 +198,7 @@ fn resolve_mxid(
     via: &[OwnedServerName],
     join_or_create: bool,
 ) -> IambResult<Result<IambId, String>> {
-    let mut room_name = String::new();
+    let room_name;
     let room_id = match id {
         MatrixId::Room(id) => {
             room_name = id.to_string();
@@ -209,13 +209,15 @@ fn resolve_mxid(
             store.application.worker.resolve_alias(alias_id)?
         },
         MatrixId::User(user_id) => {
-            match store.application.worker.client.get_dm_room(&user_id) {
+            let id = match store.application.worker.client.get_dm_room(&user_id) {
                 Some(room) => room.room_id().to_owned(),
                 None if join_or_create => {
                     store.application.worker.join_room(user_id.to_string(), via.to_owned())?
                 },
                 None => return Ok(Err(format!("No dm with {user_id} found. Create new DM?"))),
-            }
+            };
+            room_name = id.to_string();
+            id
         },
         MatrixId::Event(owned_room_or_alias_id, _event_id) => {
             // ignore event id for now
@@ -237,12 +239,11 @@ fn resolve_mxid(
         .application
         .worker
         .client
-        .joined_rooms()
-        .iter()
-        .any(|room| room.room_id() == room_id)
+        .get_room(&room_id)
+        .is_none_or(|room| room.state() != RoomState::Joined)
     {
         if join_or_create {
-            store.application.worker.join_room(room_id.to_string(), via.to_owned())?;
+            store.application.worker.join_room(room_name, via.to_owned())?;
         } else {
             return Ok(Err(format!("Join room {room_name:?}?")));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1071,8 +1071,13 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     }));
 
     // And finally, start running the terminal UI.
-    let mut application = Application::new(settings, store).await?;
-    application.run().await?;
+    let mut application = Application::new(settings, store)
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
+    application
+        .run()
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
 
     // Clean up the terminal on exit.
     restore_tty(enable_enhanced_keys, enable_mouse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,11 +195,13 @@ fn restore_layout(
     tabs.to_layout(area.into(), store)
 }
 
-fn resolve_initial_room(
-    settings: &ApplicationSettings,
+/// Returns the `IambId` for the new window or a string to query the user. If they answer `y` this
+/// function should be rerun with `join_or_create` set to `true`.
+fn resolve_mxid(
     store: &mut ProgramStore,
     id: MatrixId,
-) -> IambResult<Option<IambWindow>> {
+    join_or_create: bool,
+) -> IambResult<Result<IambId, String>> {
     let mut room_name = String::new();
     let room_id = match id {
         MatrixId::Room(id) => {
@@ -213,26 +215,10 @@ fn resolve_initial_room(
         MatrixId::User(user_id) => {
             match store.application.worker.client.get_dm_room(&user_id) {
                 Some(room) => room.room_id().to_owned(),
-                None => {
-                    restore_tty(false, settings.tunables.mouse.enabled);
-
-                    let question = format!("No dm with {user_id} found. Create new DM? [y]es/[n]o");
-
-                    loop {
-                        match read_yesno(&question) {
-                            Some('y') => break,
-                            Some('n') => {
-                                setup_tty(settings, false)?;
-                                return Ok(None);
-                            },
-                            Some(_) | None => continue,
-                        }
-                    }
-
-                    setup_tty(settings, false)?;
-
+                None if join_or_create => {
                     store.application.worker.join_room(user_id.to_string())?
                 },
+                None => return Ok(Err(format!("No dm with {user_id} found. Create new DM?"))),
             }
         },
         MatrixId::Event(owned_room_or_alias_id, _event_id) => {
@@ -247,7 +233,7 @@ fn resolve_initial_room(
         },
         _ => {
             tracing::error!("encountered unrecoginsed matrix id: {id:?}");
-            return Ok(None);
+            return Ok(Err("Matrix link cannot be opened. Press 'n' to continue.".to_owned()));
         },
     };
 
@@ -259,29 +245,14 @@ fn resolve_initial_room(
         .iter()
         .any(|room| room.room_id() == room_id)
     {
-        restore_tty(false, settings.tunables.mouse.enabled);
-
-        let question = format!("Join room {room_name:?}? [y]es/[n]o");
-
-        loop {
-            match read_yesno(&question) {
-                Some('y') => break,
-                Some('n') => {
-                    setup_tty(settings, false)?;
-                    return Ok(None);
-                },
-                Some(_) | None => continue,
-            }
+        if join_or_create {
+            store.application.worker.join_room(room_id.to_string())?;
+        } else {
+            return Ok(Err(format!("Join room {room_name:?}?")));
         }
-
-        setup_tty(settings, false)?;
-
-        store.application.worker.join_room(room_id.to_string())?;
     }
 
-    let id = IambId::Room(room_id, None);
-    let win = IambWindow::open(id, store)?;
-    Ok(Some(win))
+    Ok(Ok(IambId::Room(room_id, None)))
 }
 
 fn setup_screen(
@@ -294,8 +265,27 @@ fn setup_screen(
     let area = Rect::new(0, 0, dims.0, dims.1);
 
     if let Some(id) = initial_room {
-        if let Some(win) = resolve_initial_room(&settings, store, id)? {
-            return Ok(ScreenState::new(win, cmd));
+        match resolve_mxid(store, id.clone(), false)? {
+            Ok(id) => {
+                return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
+            },
+            Err(question) => {
+                restore_tty(false, settings.tunables.mouse.enabled);
+                let join_or_create = loop {
+                    match read_yesno(&format!("{question} [y]es/[n]o")) {
+                        Some('y') => break true,
+                        Some('n') => break false,
+                        Some(_) | None => continue,
+                    }
+                };
+                setup_tty(&settings, false)?;
+
+                if join_or_create {
+                    if let Ok(id) = resolve_mxid(store, id, true)? {
+                        return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
+                    }
+                }
+            },
         }
     }
 
@@ -706,12 +696,33 @@ impl Application {
                 self.screen.current_window_mut()?.send_command(act, ctx, store).await?
             },
 
-            IambAction::OpenLink(url) => {
-                tokio::task::spawn_blocking(move || {
-                    return open::that(url);
-                });
+            IambAction::OpenLink(url, join_or_create) => {
+                let matrix_id = MatrixUri::parse(&url)
+                    .map(|uri| uri.id().clone())
+                    .or_else(|_| MatrixToUri::parse(&url).map(|uri| uri.id().clone()))
+                    .ok();
 
-                None
+                if let Some(id) = matrix_id {
+                    match resolve_mxid(store, id.clone(), join_or_create)? {
+                        Ok(room) => {
+                            let target = OpenTarget::Application(room);
+                            let action = WindowAction::Switch(target);
+
+                            self.action_prepend(vec![(action.into(), ctx)]);
+                            None
+                        },
+                        Err(prompt) => {
+                            let act = IambAction::OpenLink(url, true).into();
+                            let dialog = PromptYesNo::new(prompt, vec![act]);
+                            let err = UIError::NeedConfirm(Box::new(dialog));
+                            return Err(err);
+                        },
+                    }
+                } else {
+                    tokio::task::spawn_blocking(move || open::that(url));
+
+                    None
+                }
             },
 
             IambAction::Verify(act, user_dev) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
 use matrix_sdk::ruma::matrix_uri::MatrixId;
-use matrix_sdk_crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::{MatrixToUri, MatrixUri, OwnedUserId};
-use matrix_sdk::OwnedServerName;
+use matrix_sdk::{OwnedServerName, RoomState};
+use matrix_sdk_crypto::encrypt_room_key_export;
 use modalkit::keybindings::InputBindings;
 use rand::distr::Alphanumeric;
 use rand::RngExt as _;
@@ -201,7 +201,7 @@ fn resolve_mxid(
     via: &[OwnedServerName],
     join_or_create: bool,
 ) -> IambResult<Result<IambId, String>> {
-    let mut room_name = String::new();
+    let room_name;
     let room_id = match id {
         MatrixId::Room(id) => {
             room_name = id.to_string();
@@ -212,13 +212,15 @@ fn resolve_mxid(
             store.application.worker.resolve_alias(alias_id)?
         },
         MatrixId::User(user_id) => {
-            match store.application.worker.client.get_dm_room(&user_id) {
+            let id = match store.application.worker.client.get_dm_room(&user_id) {
                 Some(room) => room.room_id().to_owned(),
                 None if join_or_create => {
                     store.application.worker.join_room(user_id.to_string(), via.to_owned())?
                 },
                 None => return Ok(Err(format!("No dm with {user_id} found. Create new DM?"))),
-            }
+            };
+            room_name = id.to_string();
+            id
         },
         MatrixId::Event(owned_room_or_alias_id, _event_id) => {
             // ignore event id for now
@@ -240,12 +242,11 @@ fn resolve_mxid(
         .application
         .worker
         .client
-        .joined_rooms()
-        .iter()
-        .any(|room| room.room_id() == room_id)
+        .get_room(&room_id)
+        .is_none_or(|room| room.state() != RoomState::Joined)
     {
         if join_or_create {
-            store.application.worker.join_room(room_id.to_string(), via.to_owned())?;
+            store.application.worker.join_room(room_name, via.to_owned())?;
         } else {
             return Ok(Err(format!("Join room {room_name:?}?")));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::AtomicUsize;
 
 use clap::{CommandFactory, Parser};
 use matrix_sdk::ruma::api::error::ErrorKind;
+use matrix_sdk::{OwnedServerName, RoomState};
 use matrix_sdk_crypto::encrypt_room_key_export;
 use modalkit::actions::{Commandable, TabAction, TabContainer, TabCount, WindowContainer};
 use modalkit::crossterm;
@@ -99,16 +100,13 @@ fn config_tab_to_desc(
 
             let window = match window {
                 config::WindowPath::UserId(user_id) => {
-                    let name = user_id.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(user_id.to_string(), vec![])?;
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
-                    let name = alias.to_string();
-                    let room_id = worker.join_room(name.clone())?;
-                    names.insert(name, room_id.clone());
+                    let room_id = worker.join_room(alias.to_string(), vec![])?;
+                    names.insert(alias, room_id.clone());
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::Window(id) => id,
@@ -140,13 +138,99 @@ fn restore_layout(
     tabs.to_layout(area.into(), store)
 }
 
+/// Returns the `IambId` for the new window or a string to query the user. If they answer `y` this
+/// function should be rerun with `join_or_create` set to `true`.
+fn resolve_mxid(
+    store: &mut ProgramStore,
+    id: MatrixId,
+    via: &[OwnedServerName],
+    join_or_create: bool,
+) -> IambResult<Result<IambId, String>> {
+    let room_name;
+    let room_id = match id {
+        MatrixId::Room(id) => {
+            room_name = id.to_string();
+            id
+        },
+        MatrixId::RoomAlias(alias_id) => {
+            room_name = alias_id.to_string();
+            store.application.worker.resolve_alias(alias_id)?
+        },
+        MatrixId::User(user_id) => {
+            let id = match store.application.worker.client.get_dm_room(&user_id) {
+                Some(room) => room.room_id().to_owned(),
+                None if join_or_create => {
+                    store.application.worker.join_room(user_id.to_string(), via.to_owned())?
+                },
+                None => return Ok(Err(format!("No dm with {user_id} found. Create new DM?"))),
+            };
+            room_name = id.to_string();
+            id
+        },
+        MatrixId::Event(owned_room_or_alias_id, _event_id) => {
+            // ignore event id for now
+            room_name = owned_room_or_alias_id.to_string();
+            let room_or_alias_id: &matrix_sdk::ruma::RoomOrAliasId = &owned_room_or_alias_id;
+            if let Ok(alias_id) = <&matrix_sdk::ruma::RoomAliasId>::try_from(room_or_alias_id) {
+                store.application.worker.resolve_alias(alias_id.to_owned())?
+            } else {
+                matrix_sdk::ruma::OwnedRoomId::try_from(owned_room_or_alias_id).unwrap()
+            }
+        },
+        _ => {
+            tracing::error!("encountered unrecoginsed matrix id: {id:?}");
+            return Ok(Err("Matrix link cannot be opened. Press 'n' to continue.".to_owned()));
+        },
+    };
+
+    if store
+        .application
+        .worker
+        .client
+        .get_room(&room_id)
+        .is_none_or(|room| room.state() != RoomState::Joined)
+    {
+        if join_or_create {
+            store.application.worker.join_room(room_name, via.to_owned())?;
+        } else {
+            return Ok(Err(format!("Join room {room_name:?}?")));
+        }
+    }
+
+    Ok(Ok(IambId::Room(room_id, None)))
+}
+
 fn setup_screen(
     settings: ApplicationSettings,
     store: &mut ProgramStore,
+    initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
 ) -> IambResult<ScreenState<IambWindow, IambInfo>> {
     let cmd = CommandBarState::new(store);
     let dims = crossterm::terminal::size()?;
     let area = Rect::new(0, 0, dims.0, dims.1);
+
+    if let Some((id, via)) = initial_room {
+        match resolve_mxid(store, id.clone(), &via, false)? {
+            Ok(id) => {
+                return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
+            },
+            Err(question) => {
+                restore_tty(false, settings.tunables.mouse.enabled);
+                let join_or_create = loop {
+                    match read_yesno(&format!("{question} [y]es/[n]o")) {
+                        Some('y') => break true,
+                        Some('n') => break false,
+                        Some(_) | None => continue,
+                    }
+                };
+                setup_tty(&settings, false)?;
+
+                if join_or_create && let Ok(id) = resolve_mxid(store, id, &via, true)? {
+                    return Ok(ScreenState::new(IambWindow::open(id, store)?, cmd));
+                }
+            },
+        }
+    }
 
     match settings.layout {
         config::Layout::Restore => {
@@ -218,6 +302,7 @@ impl Application {
     pub async fn new(
         settings: ApplicationSettings,
         store: AsyncProgramStore,
+        initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
     ) -> IambResult<Application> {
         let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend)?;
@@ -227,7 +312,7 @@ impl Application {
         let bindings = KeyManager::new(bindings);
 
         let mut locked = store.lock().await;
-        let screen = setup_screen(settings, locked.deref_mut())?;
+        let screen = setup_screen(settings, locked.deref_mut(), initial_room)?;
 
         let worker = locked.application.worker.clone();
 
@@ -566,12 +651,36 @@ impl Application {
                 self.screen.current_window_mut()?.send_command(act, ctx, store).await?
             },
 
-            IambAction::OpenLink(url) => {
-                tokio::task::spawn_blocking(move || {
-                    return open::that(url);
-                });
+            IambAction::OpenLink(url, join_or_create) => {
+                let matrix_uri = MatrixUri::parse(&url).ok();
+                let matrix_to_uri = MatrixToUri::parse(&url).ok();
 
-                None
+                let matrix_id = matrix_uri
+                    .as_ref()
+                    .map(|uri| (uri.id(), uri.via()))
+                    .or(matrix_to_uri.as_ref().map(|uri| (uri.id(), uri.via())));
+
+                if let Some((id, via)) = matrix_id {
+                    match resolve_mxid(store, id.clone(), via, join_or_create)? {
+                        Ok(room) => {
+                            let target = OpenTarget::Application(room);
+                            let action = WindowAction::Switch(target);
+
+                            self.action_prepend(vec![(action.into(), ctx)]);
+                            None
+                        },
+                        Err(prompt) => {
+                            let act = IambAction::OpenLink(url, true).into();
+                            let dialog = PromptYesNo::new(prompt, vec![act]);
+                            let err = UIError::NeedConfirm(Box::new(dialog));
+                            return Err(err);
+                        },
+                    }
+                } else {
+                    tokio::task::spawn_blocking(move || open::that(url));
+
+                    None
+                }
             },
 
             IambAction::Verify(act, flow_id) => {
@@ -1045,7 +1154,10 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
     let _ = crossterm::terminal::disable_raw_mode();
 }
 
-async fn run(settings: ApplicationSettings) -> IambResult<()> {
+async fn run(
+    settings: ApplicationSettings,
+    initial_room: Option<(MatrixId, Vec<OwnedServerName>)>,
+) -> IambResult<()> {
     // Get old keys the first time we run w/ the upgraded SDK.
     let import_keys = check_import_keys(&settings).await?;
 
@@ -1109,8 +1221,13 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     }));
 
     // And finally, start running the terminal UI.
-    let mut application = Application::new(settings, store).await?;
-    application.run().await?;
+    let mut application = Application::new(settings, store, initial_room)
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
+    application
+        .run()
+        .await
+        .inspect_err(|_| restore_tty(enable_enhanced_keys, enable_mouse))?;
 
     // Clean up the terminal on exit.
     restore_tty(enable_enhanced_keys, enable_mouse);
@@ -1165,6 +1282,17 @@ fn main() {
         return;
     }
 
+    let initial_room = if let Some(uri) = &iamb.uri {
+        MatrixUri::parse(uri)
+            .map(|uri| (uri.id().clone(), uri.via().to_owned()))
+            .or_else(|_| {
+                MatrixToUri::parse(uri).map(|uri| (uri.id().clone(), uri.via().to_owned()))
+            })
+            .ok()
+    } else {
+        None
+    };
+
     // Load configuration and set up the Matrix SDK.
     let settings = ApplicationSettings::load(iamb).unwrap_or_else(print_exit);
 
@@ -1187,7 +1315,7 @@ fn main() {
         .build()
         .unwrap();
 
-    if let Err(err) = rt.block_on(async move { run(settings).await }) {
+    if let Err(err) = rt.block_on(async move { run(settings, initial_room).await }) {
         eprintln!("\n{err}\n");
         process::exit(2);
     }

--- a/src/message/compose.rs
+++ b/src/message/compose.rs
@@ -67,7 +67,7 @@ impl SlashCommand {
                 MessageType::Text(msg)
             },
             SlashCommand::Markdown => {
-                let msg = text_to_message_content(input.to_string());
+                let msg = text_to_message_content(input.into());
                 MessageType::Text(msg)
             },
             SlashCommand::Confetti => {
@@ -170,17 +170,21 @@ fn text_to_html(input: &str) -> Option<String> {
     markdown_to_html(input, &options).into()
 }
 
-fn text_to_message_content(input: String) -> TextMessageEventContent {
-    if let Some(html) = text_to_html(input.as_str()) {
+fn text_to_message_content(input: Cow<'_, str>) -> TextMessageEventContent {
+    if let Some(html) = text_to_html(&input) {
         TextMessageEventContent::html(input, html)
     } else {
         TextMessageEventContent::plain(input)
     }
 }
 
-pub fn text_to_message(input: String, default_markup: MarkupFormat) -> RoomMessageEventContent {
-    let (rest, slash) = parse_slash_command(input.as_str())
+pub fn text_to_message(
+    input: Cow<'_, str>,
+    default_markup: MarkupFormat,
+) -> RoomMessageEventContent {
+    let (rest, slash) = parse_slash_command(&input)
         .unwrap_or_else(|_| (&input, SlashCommand::from(default_markup)));
+
     let msg = slash
         .to_message(rest)
         .unwrap_or_else(|_| MessageType::Text(text_to_message_content(input)));
@@ -193,19 +197,13 @@ pub fn text_to_text_message_event_content(
     input: String,
     default_markup: MarkupFormat,
 ) -> Option<TextMessageEventContent> {
-    let (body, cmd) = parse_slash_command(&input)
+    let (rest, slash) = parse_slash_command(&input)
         .unwrap_or_else(|_| (&input, SlashCommand::from(default_markup)));
 
-    let content = match cmd {
-        SlashCommand::Html => TextMessageEventContent::html(body, body),
-        SlashCommand::Plaintext => TextMessageEventContent::plain(body),
-        SlashCommand::Markdown => {
-            if let Some(html) = text_to_html(body) {
-                TextMessageEventContent::html(body, html)
-            } else {
-                TextMessageEventContent::plain(body)
-            }
-        },
+    let content = match slash {
+        SlashCommand::Html => TextMessageEventContent::html(rest, rest),
+        SlashCommand::Plaintext => TextMessageEventContent::plain(rest),
+        SlashCommand::Markdown => text_to_message_content(rest.into()),
         _ => return None,
     };
 

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -11,11 +11,19 @@
 //! This isn't as important for iamb, since it isn't a browser environment, but we do still map
 //! input onto an enum of the safe list of tags to keep it easy to understand and process.
 use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::ops::Deref;
 
 use css_color_parser::Color as CssColor;
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
-use matrix_sdk::ruma::{OwnedRoomAliasId, OwnedRoomId, OwnedUserId};
+use matrix_sdk::ruma::{
+    matrix_uri::MatrixId,
+    MatrixToUri,
+    MatrixUri,
+    OwnedRoomAliasId,
+    OwnedRoomId,
+    OwnedUserId,
+};
 use unicode_segmentation::UnicodeSegmentation;
 use url::Url;
 
@@ -96,12 +104,14 @@ impl ListStyle {
 pub type StyleTreeChildren = Vec<StyleTreeNode>;
 
 /// Type of contents in a table cell.
+#[derive(Debug, Clone, Copy)]
 pub enum CellType {
     Data,
     Header,
 }
 
 /// A collection of cells for a single row in a table.
+#[derive(Debug, Clone)]
 pub struct TableRow {
     cells: Vec<(CellType, StyleTreeNode)>,
 }
@@ -119,6 +129,7 @@ impl TableRow {
 }
 
 /// A collection of rows in a table.
+#[derive(Debug, Clone)]
 pub struct TableSection {
     rows: Vec<TableRow>,
 }
@@ -136,6 +147,7 @@ impl TableSection {
 }
 
 /// A table.
+#[derive(Debug, Clone)]
 pub struct Table {
     caption: Option<Box<StyleTreeNode>>,
     sections: Vec<TableSection>,
@@ -265,6 +277,7 @@ impl Table {
 }
 
 /// A processed HTML element that we can render to the terminal.
+#[derive(Debug, Clone)]
 pub enum StyleTreeNode {
     Anchor(Box<StyleTreeNode>, char, Url),
     Blockquote(Box<StyleTreeNode>),
@@ -713,6 +726,31 @@ fn attrs_to_style(attrs: &[Attribute]) -> Style {
     return style;
 }
 
+fn mxid2t(id: &MatrixId, n: Option<char>, c: &StyleTreeNode, h: &Url) -> StyleTreeNode {
+    match id {
+        MatrixId::Room(room_id) => StyleTreeNode::RoomId(room_id.to_owned(), n),
+        MatrixId::RoomAlias(alias) => StyleTreeNode::RoomAlias(alias.to_owned(), n),
+        MatrixId::User(user_id) => StyleTreeNode::UserId(user_id.to_owned(), n),
+        MatrixId::Event(room_or_alias_id, _) => {
+            let room_or_alias_id: &matrix_sdk::ruma::RoomOrAliasId = room_or_alias_id;
+            // ignore event id for now
+            if let Ok(alias_id) = <&matrix_sdk::ruma::RoomAliasId>::try_from(room_or_alias_id) {
+                StyleTreeNode::RoomAlias(alias_id.to_owned(), n)
+            } else {
+                let room_id = <&matrix_sdk::ruma::RoomId>::try_from(room_or_alias_id).unwrap();
+                StyleTreeNode::RoomId(room_id.to_owned(), n)
+            }
+        },
+        _ => {
+            if let Some(n) = n {
+                StyleTreeNode::Anchor(Box::new(c.to_owned()), n, h.to_owned())
+            } else {
+                c.clone()
+            }
+        },
+    }
+}
+
 fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
     let node = hdl.deref();
 
@@ -730,7 +768,13 @@ fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
                     let h = attrs_to_href(&attrs.borrow()).and_then(|u| Url::parse(&u).ok());
 
                     if let Some(h) = h {
-                        if let Some(n) = state.next_link_char() {
+                        let n = state.next_link_char();
+
+                        if let Ok(uri) = MatrixToUri::parse(h.as_str()) {
+                            mxid2t(uri.id(), n, &c, &h)
+                        } else if let Ok(uri) = MatrixUri::parse(h.as_str()) {
+                            mxid2t(uri.id(), n, &c, &h)
+                        } else if let Some(n) = n {
                             StyleTreeNode::Anchor(c, n, h)
                         } else {
                             *c

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -282,10 +282,10 @@ pub enum StyleTreeNode {
     Table(Table),
     Text(Cow<'static, str>),
     Sequence(StyleTreeChildren),
-    RoomAlias(OwnedRoomAliasId),
-    RoomId(OwnedRoomId),
-    UserId(OwnedUserId),
-    DisplayName(String, OwnedUserId),
+    RoomAlias(OwnedRoomAliasId, Option<char>),
+    RoomId(OwnedRoomId, Option<char>),
+    UserId(OwnedUserId, Option<char>),
+    DisplayName(String, OwnedUserId, Option<char>),
 }
 
 impl StyleTreeNode {
@@ -326,16 +326,29 @@ impl StyleTreeNode {
                 table.gather_links(urls);
             },
 
+            StyleTreeNode::DisplayName(_, user_id, c) | StyleTreeNode::UserId(user_id, c) => {
+                if let Some(c) = c {
+                    let to_url = Url::parse(&user_id.matrix_uri(false).to_string()).unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+            StyleTreeNode::RoomId(room_id, c) => {
+                if let Some(c) = c {
+                    let to_url = Url::parse(&room_id.matrix_uri(false).to_string()).unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+            StyleTreeNode::RoomAlias(alias, c) => {
+                if let Some(c) = c {
+                    let to_url = Url::parse(&alias.matrix_uri(false).to_string()).unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+
             StyleTreeNode::Image(_) => {},
             StyleTreeNode::Ruler => {},
             StyleTreeNode::Text(_) => {},
             StyleTreeNode::Break => {},
-
-            // TODO: eventually these should turn into internal links:
-            StyleTreeNode::UserId(_) => {},
-            StyleTreeNode::RoomId(_) => {},
-            StyleTreeNode::RoomAlias(_) => {},
-            StyleTreeNode::DisplayName(_, _) => {},
         }
     }
 
@@ -474,19 +487,19 @@ impl StyleTreeNode {
                 }
             },
 
-            StyleTreeNode::UserId(user_id) => {
+            StyleTreeNode::UserId(user_id, _) => {
                 let style = printer.settings().get_user_style(user_id);
                 printer.push_str(user_id.as_str(), style);
             },
-            StyleTreeNode::DisplayName(display_name, user_id) => {
+            StyleTreeNode::DisplayName(display_name, user_id, _) => {
                 let style = printer.settings().get_user_style(user_id);
                 printer.push_str(display_name.as_str(), style);
             },
-            StyleTreeNode::RoomId(room_id) => {
+            StyleTreeNode::RoomId(room_id, _) => {
                 let bold = style.add_modifier(StyleModifier::BOLD);
                 printer.push_str(room_id.as_str(), bold);
             },
-            StyleTreeNode::RoomAlias(alias) => {
+            StyleTreeNode::RoomAlias(alias, _) => {
                 let bold = style.add_modifier(StyleModifier::BOLD);
                 printer.push_str(alias.as_str(), bold);
             },

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -16,13 +16,16 @@ use std::ops::Deref;
 
 use css_color_parser::Color as CssColor;
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
-use matrix_sdk::ruma::{
-    matrix_uri::MatrixId,
-    MatrixToUri,
-    MatrixUri,
-    OwnedRoomAliasId,
-    OwnedRoomId,
-    OwnedUserId,
+use matrix_sdk::{
+    ruma::{
+        matrix_uri::MatrixId,
+        MatrixToUri,
+        MatrixUri,
+        OwnedRoomAliasId,
+        OwnedRoomId,
+        OwnedUserId,
+    },
+    OwnedServerName,
 };
 use unicode_segmentation::UnicodeSegmentation;
 use url::Url;
@@ -298,7 +301,7 @@ pub enum StyleTreeNode {
     Text(Cow<'static, str>),
     Sequence(StyleTreeChildren),
     RoomAlias(OwnedRoomAliasId, Option<char>),
-    RoomId(OwnedRoomId, Option<char>),
+    RoomId(OwnedRoomId, Vec<OwnedServerName>, Option<char>),
     UserId(OwnedUserId, Option<char>),
     DisplayName(String, OwnedUserId, Option<char>),
 }
@@ -348,9 +351,11 @@ impl StyleTreeNode {
                     urls.push((*c, to_url));
                 }
             },
-            StyleTreeNode::RoomId(room_id, c) => {
+            StyleTreeNode::RoomId(room_id, via, c) => {
                 if let Some(c) = c {
-                    let to_url = Url::parse(&room_id.matrix_uri(false).to_string()).unwrap();
+                    let to_url =
+                        Url::parse(&room_id.matrix_uri_via(via.iter().cloned(), false).to_string())
+                            .unwrap();
                     urls.push((*c, to_url));
                 }
             },
@@ -519,7 +524,7 @@ impl StyleTreeNode {
                 let style = printer.settings().get_user_style(user_id);
                 printer.push_str(display_name.as_str(), style);
             },
-            StyleTreeNode::RoomId(room_id, _) => {
+            StyleTreeNode::RoomId(room_id, _, _) => {
                 let bold = style.add_modifier(StyleModifier::BOLD);
                 printer.push_str(room_id.as_str(), bold);
             },
@@ -738,9 +743,15 @@ fn attrs_to_style(attrs: &[Attribute]) -> Style {
     return style;
 }
 
-fn mxid2t(id: &MatrixId, n: Option<char>, c: &StyleTreeNode, h: &Url) -> StyleTreeNode {
+fn mxid2t(
+    id: &MatrixId,
+    via: &[OwnedServerName],
+    n: Option<char>,
+    c: &StyleTreeNode,
+    h: &Url,
+) -> StyleTreeNode {
     match id {
-        MatrixId::Room(room_id) => StyleTreeNode::RoomId(room_id.to_owned(), n),
+        MatrixId::Room(room_id) => StyleTreeNode::RoomId(room_id.to_owned(), via.to_owned(), n),
         MatrixId::RoomAlias(alias) => StyleTreeNode::RoomAlias(alias.to_owned(), n),
         MatrixId::User(user_id) => StyleTreeNode::UserId(user_id.to_owned(), n),
         MatrixId::Event(room_or_alias_id, _) => {
@@ -750,7 +761,7 @@ fn mxid2t(id: &MatrixId, n: Option<char>, c: &StyleTreeNode, h: &Url) -> StyleTr
                 StyleTreeNode::RoomAlias(alias_id.to_owned(), n)
             } else {
                 let room_id = <&matrix_sdk::ruma::RoomId>::try_from(room_or_alias_id).unwrap();
-                StyleTreeNode::RoomId(room_id.to_owned(), n)
+                StyleTreeNode::RoomId(room_id.to_owned(), via.to_owned(), n)
             }
         },
         _ => {
@@ -783,9 +794,9 @@ fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
                         let n = state.next_link_char();
 
                         if let Ok(uri) = MatrixToUri::parse(h.as_str()) {
-                            mxid2t(uri.id(), n, &c, &h)
+                            mxid2t(uri.id(), uri.via(), n, &c, &h)
                         } else if let Ok(uri) = MatrixUri::parse(h.as_str()) {
-                            mxid2t(uri.id(), n, &c, &h)
+                            mxid2t(uri.id(), uri.via(), n, &c, &h)
                         } else if let Some(n) = n {
                             StyleTreeNode::Anchor(c, n, h)
                         } else {

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -43,6 +43,7 @@ use ratatui::{
 };
 
 use crate::{
+    base::RoomInfo,
     config::ApplicationSettings,
     message::printer::TextPrinter,
     util::{join_cell_text, space_text},
@@ -169,6 +170,7 @@ impl Table {
         width: usize,
         style: Style,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
         let mut text = Text::default();
         let columns = self.columns();
@@ -188,7 +190,7 @@ impl Table {
         if let Some(caption) = &self.caption {
             let subw = width.saturating_sub(6);
             let mut printer =
-                TextPrinter::new(subw, style, true, settings).align(Alignment::Center);
+                TextPrinter::new(subw, style, true, settings, info).align(Alignment::Center);
             caption.print(&mut printer, style);
 
             for mut line in printer.finish().lines {
@@ -235,7 +237,7 @@ impl Table {
                                 CellType::Data => style,
                             };
 
-                            cell.to_text(*w, style, settings)
+                            cell.to_text(*w, style, settings, info)
                         } else {
                             space_text(*w, style)
                         };
@@ -307,8 +309,9 @@ impl StyleTreeNode {
         width: usize,
         style: Style,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
-        let mut printer = TextPrinter::new(width, style, true, settings);
+        let mut printer = TextPrinter::new(width, style, true, settings, info);
         self.print(&mut printer, style);
         printer.finish()
     }
@@ -483,7 +486,7 @@ impl StyleTreeNode {
                 }
             },
             StyleTreeNode::Table(table) => {
-                let text = table.to_text(width, style, printer.settings);
+                let text = table.to_text(width, style, printer.settings, printer.info);
                 printer.push_text(text);
             },
             StyleTreeNode::Break => {
@@ -501,8 +504,16 @@ impl StyleTreeNode {
             },
 
             StyleTreeNode::UserId(user_id, _) => {
-                let style = printer.settings().get_user_style(user_id);
-                printer.push_str(user_id.as_str(), style);
+                let span: Span<'a> = printer.settings().get_user_span(user_id, printer.info);
+                let style = span.style;
+
+                let Cow::Borrowed(name) = span.content else {
+                    unreachable!()
+                };
+                if !name.starts_with('@') {
+                    printer.push_str("@", style);
+                }
+                printer.push_str(name, style);
             },
             StyleTreeNode::DisplayName(display_name, user_id, _) => {
                 let style = printer.settings().get_user_style(user_id);
@@ -542,8 +553,9 @@ impl StyleTree {
         style: Style,
         hide_reply: bool,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
-        let mut printer = TextPrinter::new(width, style, hide_reply, settings);
+        let mut printer = TextPrinter::new(width, style, hide_reply, settings, info);
 
         for child in self.children.iter() {
             child.print(&mut printer, style);
@@ -914,19 +926,20 @@ pub fn parse_matrix_html(s: &str) -> StyleTree {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::tests::mock_settings;
+    use crate::tests::{mock_room, mock_settings};
     use crate::util::space_span;
     use pretty_assertions::assert_eq;
     use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn test_header() {
+        let info = mock_room();
         let settings = mock_settings();
         let bold = Style::default().add_modifier(StyleModifier::BOLD);
 
         let s = "<h1>Header 1</h1>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled(" ", bold),
@@ -938,7 +951,7 @@ pub mod tests {
 
         let s = "<h2>Header 2</h2>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -951,7 +964,7 @@ pub mod tests {
 
         let s = "<h3>Header 3</h3>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -965,7 +978,7 @@ pub mod tests {
 
         let s = "<h4>Header 4</h4>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -980,7 +993,7 @@ pub mod tests {
 
         let s = "<h5>Header 5</h5>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -996,7 +1009,7 @@ pub mod tests {
 
         let s = "<h6>Header 6</h6>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -1014,6 +1027,7 @@ pub mod tests {
 
     #[test]
     fn test_style() {
+        let info = mock_room();
         let settings = mock_settings();
         let def = Style::default();
         let bold = def.add_modifier(StyleModifier::BOLD);
@@ -1024,7 +1038,7 @@ pub mod tests {
 
         let s = "<b>Bold!</b>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Bold", bold),
             Span::styled("!", bold),
@@ -1033,7 +1047,7 @@ pub mod tests {
 
         let s = "<strong>Bold!</strong>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Bold", bold),
             Span::styled("!", bold),
@@ -1042,7 +1056,7 @@ pub mod tests {
 
         let s = "<i>Italic!</i>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Italic", italic),
             Span::styled("!", italic),
@@ -1051,7 +1065,7 @@ pub mod tests {
 
         let s = "<em>Italic!</em>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Italic", italic),
             Span::styled("!", italic),
@@ -1060,7 +1074,7 @@ pub mod tests {
 
         let s = "<del>Strikethrough!</del>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Strikethrough", strike),
             Span::styled("!", strike),
@@ -1069,7 +1083,7 @@ pub mod tests {
 
         let s = "<strike>Strikethrough!</strike>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Strikethrough", strike),
             Span::styled("!", strike),
@@ -1078,7 +1092,7 @@ pub mod tests {
 
         let s = "<u>Underline!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Underline", underl),
             Span::styled("!", underl),
@@ -1087,7 +1101,7 @@ pub mod tests {
 
         let s = "<font color=\"#ff0000\">Red!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Red", red),
             Span::styled("!", red),
@@ -1096,7 +1110,7 @@ pub mod tests {
 
         let s = "<font color=\"red\">Red!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), false, &settings);
+        let text = tree.to_text(20, Style::default(), false, &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Red", red),
             Span::styled("!", red),
@@ -1106,10 +1120,11 @@ pub mod tests {
 
     #[test]
     fn test_paragraph() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<p>Hello world!</p><p>Content</p><p>Goodbye world!</p>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), false, &settings);
+        let text = tree.to_text(10, Style::default(), false, &settings, &info);
         assert_eq!(text.lines.len(), 7);
         assert_eq!(
             text.lines[0],
@@ -1134,10 +1149,11 @@ pub mod tests {
 
     #[test]
     fn test_blockquote() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<blockquote>Hello world!</blockquote>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), false, &settings);
+        let text = tree.to_text(10, Style::default(), false, &settings, &info);
         let style = Style::new().fg(QUOTE_COLOR);
         assert_eq!(text.lines.len(), 2);
         assert_eq!(
@@ -1166,10 +1182,11 @@ pub mod tests {
 
     #[test]
     fn test_list_unordered() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<ul><li>List Item 1</li><li>List Item 2</li><li>List Item 3</li></ul>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(8, Style::default(), false, &settings);
+        let text = tree.to_text(8, Style::default(), false, &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1229,10 +1246,11 @@ pub mod tests {
 
     #[test]
     fn test_list_ordered() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<ol><li>List Item 1</li><li>List Item 2</li><li>List Item 3</li></ol>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(9, Style::default(), false, &settings);
+        let text = tree.to_text(9, Style::default(), false, &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1292,6 +1310,7 @@ pub mod tests {
 
     #[test]
     fn test_table() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<table>\
                  <thead>\
@@ -1303,7 +1322,7 @@ pub mod tests {
                  <tr><td>a</td><td>b</td><td>c</td></tr>\
                  </tbody></table>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(15, Style::default(), false, &settings);
+        let text = tree.to_text(15, Style::default(), false, &settings, &info);
         let bold = Style::default().add_modifier(StyleModifier::BOLD);
         assert_eq!(text.lines.len(), 11);
 
@@ -1393,11 +1412,12 @@ pub mod tests {
 
     #[test]
     fn test_matrix_reply() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<mx-reply>This was replied to</mx-reply>This is the reply";
 
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), false, &settings);
+        let text = tree.to_text(10, Style::default(), false, &settings, &info);
         assert_eq!(text.lines.len(), 4);
         assert_eq!(
             text.lines[0],
@@ -1434,7 +1454,7 @@ pub mod tests {
         );
 
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), true, &settings);
+        let text = tree.to_text(10, Style::default(), true, &settings, &info);
         assert_eq!(text.lines.len(), 2);
         assert_eq!(
             text.lines[0],
@@ -1459,10 +1479,11 @@ pub mod tests {
 
     #[test]
     fn test_self_closing() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "Hello<br>World<br>Goodbye";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(7, Style::default(), true, &settings);
+        let text = tree.to_text(7, Style::default(), true, &settings, &info);
         assert_eq!(text.lines.len(), 3);
         assert_eq!(text.lines[0], Line::from(vec![Span::raw("Hello"), Span::raw("  "),]));
         assert_eq!(text.lines[1], Line::from(vec![Span::raw("World"), Span::raw("  "),]));
@@ -1471,10 +1492,11 @@ pub mod tests {
 
     #[test]
     fn test_embedded_newline() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<p>Hello\nWorld</p>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(15, Style::default(), true, &settings);
+        let text = tree.to_text(15, Style::default(), true, &settings, &info);
         assert_eq!(text.lines.len(), 1);
         assert_eq!(
             text.lines[0],
@@ -1489,6 +1511,7 @@ pub mod tests {
 
     #[test]
     fn test_pre_tag() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = concat!(
             "<pre><code class=\"language-rust\">",
@@ -1499,7 +1522,7 @@ pub mod tests {
             "</code></pre>\n"
         );
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(25, Style::default(), true, &settings);
+        let text = tree.to_text(25, Style::default(), true, &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1577,6 +1600,7 @@ pub mod tests {
 
     #[test]
     fn test_emoji_shortcodes() {
+        let info = mock_room();
         let mut enabled = mock_settings();
         enabled.tunables.message_shortcode_display = true;
         let mut disabled = mock_settings();
@@ -1590,13 +1614,13 @@ pub mod tests {
             let s = format!("<p>{emoji}</p>");
             let tree = parse_matrix_html(s.as_str());
             // Test with emojis_shortcodes set to false
-            let text = tree.to_text(20, Style::default(), false, &disabled);
+            let text = tree.to_text(20, Style::default(), false, &disabled, &info);
             assert_eq!(text.lines, vec![Line::from(vec![
                 Span::raw(emoji),
                 space_span(20 - emoji_width, Style::default()),
             ]),]);
             // Test with emojis_shortcodes set to true
-            let text = tree.to_text(20, Style::default(), false, &enabled);
+            let text = tree.to_text(20, Style::default(), false, &enabled, &info);
             assert_eq!(text.lines, vec![Line::from(vec![
                 Span::raw(replacement.as_str()),
                 space_span(20 - replacement_width, Style::default()),

--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -17,6 +17,7 @@ use html5ever::interface::{Attribute, QualName};
 use html5ever::tendril::{StrTendril, TendrilSink};
 use html5ever::{local_name, ns};
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
+use matrix_sdk::OwnedServerName;
 use ratatui::symbols::line;
 
 use crate::message::printer::TextPrinter;
@@ -79,12 +80,14 @@ impl ListStyle {
 pub type StyleTreeChildren = Vec<StyleTreeNode>;
 
 /// Type of contents in a table cell.
+#[derive(Debug, Clone, Copy)]
 pub enum CellType {
     Data,
     Header,
 }
 
 /// A collection of cells for a single row in a table.
+#[derive(Debug, Clone)]
 pub struct TableRow {
     cells: Vec<(CellType, StyleTreeNode)>,
 }
@@ -102,6 +105,7 @@ impl TableRow {
 }
 
 /// A collection of rows in a table.
+#[derive(Debug, Clone)]
 pub struct TableSection {
     rows: Vec<TableRow>,
 }
@@ -119,6 +123,7 @@ impl TableSection {
 }
 
 /// A table.
+#[derive(Debug, Clone)]
 pub struct Table {
     caption: Option<Box<StyleTreeNode>>,
     sections: Vec<TableSection>,
@@ -140,6 +145,7 @@ impl Table {
         width: usize,
         style: Style,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
         let mut text = Text::default();
         let columns = self.columns();
@@ -158,7 +164,8 @@ impl Table {
 
         if let Some(caption) = &self.caption {
             let subw = width.saturating_sub(6);
-            let mut printer = TextPrinter::new(subw, style, settings).align(Alignment::Center);
+            let mut printer =
+                TextPrinter::new(subw, style, settings, info).align(Alignment::Center);
             caption.print(&mut printer, style);
 
             for mut line in printer.finish().lines {
@@ -205,7 +212,7 @@ impl Table {
                                 CellType::Data => style,
                             };
 
-                            cell.to_text(*w, style, settings)
+                            cell.to_text(*w, style, settings, info)
                         } else {
                             space_text(*w, style)
                         };
@@ -247,6 +254,7 @@ impl Table {
 }
 
 /// A processed HTML element that we can render to the terminal.
+#[derive(Debug, Clone)]
 pub enum StyleTreeNode {
     Anchor(Box<StyleTreeNode>, char, Url),
     Blockquote(Box<StyleTreeNode>),
@@ -263,10 +271,10 @@ pub enum StyleTreeNode {
     Table(Table),
     Text(Cow<'static, str>),
     Sequence(StyleTreeChildren),
-    RoomAlias(OwnedRoomAliasId),
-    RoomId(OwnedRoomId),
-    UserId(OwnedUserId),
-    DisplayName(String, OwnedUserId),
+    RoomAlias(OwnedRoomAliasId, Option<char>),
+    RoomId(OwnedRoomId, Vec<OwnedServerName>, Option<char>),
+    UserId(OwnedUserId, Option<char>),
+    DisplayName(String, OwnedUserId, Option<char>),
 }
 
 impl StyleTreeNode {
@@ -275,8 +283,9 @@ impl StyleTreeNode {
         width: usize,
         style: Style,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
-        let mut printer = TextPrinter::new(width, style, settings);
+        let mut printer = TextPrinter::new(width, style, settings, info);
         self.print(&mut printer, style);
         printer.finish()
     }
@@ -306,16 +315,31 @@ impl StyleTreeNode {
                 table.gather_links(urls);
             },
 
+            StyleTreeNode::DisplayName(_, user_id, c) | StyleTreeNode::UserId(user_id, c) => {
+                if let Some(c) = c {
+                    let to_url = Url::parse(&user_id.matrix_uri(false).to_string()).unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+            StyleTreeNode::RoomId(room_id, via, c) => {
+                if let Some(c) = c {
+                    let to_url =
+                        Url::parse(&room_id.matrix_uri_via(via.iter().cloned(), false).to_string())
+                            .unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+            StyleTreeNode::RoomAlias(alias, c) => {
+                if let Some(c) = c {
+                    let to_url = Url::parse(&alias.matrix_uri(false).to_string()).unwrap();
+                    urls.push((*c, to_url));
+                }
+            },
+
             StyleTreeNode::Image(_) => {},
             StyleTreeNode::Ruler => {},
             StyleTreeNode::Text(_) => {},
             StyleTreeNode::Break => {},
-
-            // TODO: eventually these should turn into internal links:
-            StyleTreeNode::UserId(_) => {},
-            StyleTreeNode::RoomId(_) => {},
-            StyleTreeNode::RoomAlias(_) => {},
-            StyleTreeNode::DisplayName(_, _) => {},
         }
     }
 
@@ -428,7 +452,7 @@ impl StyleTreeNode {
                 }
             },
             StyleTreeNode::Table(table) => {
-                let text = table.to_text(width, style, printer.settings);
+                let text = table.to_text(width, style, printer.settings, printer.info);
                 printer.push_text(text);
             },
             StyleTreeNode::Break => {
@@ -445,19 +469,25 @@ impl StyleTreeNode {
                 }
             },
 
-            StyleTreeNode::UserId(user_id) => {
-                let style = printer.settings().get_user_style(user_id);
-                printer.push_str(user_id.as_str(), style);
+            StyleTreeNode::UserId(user_id, _) => {
+                let mut span: Span<'a> = printer.settings().get_user_span(user_id, printer.info);
+                let style = style.patch(span.style);
+                span.style = style;
+
+                if !span.content.starts_with('@') {
+                    printer.push_str("@", style);
+                }
+                printer.push_span_nobreak(span);
             },
-            StyleTreeNode::DisplayName(display_name, user_id) => {
+            StyleTreeNode::DisplayName(display_name, user_id, _) => {
                 let style = printer.settings().get_user_style(user_id);
                 printer.push_str(display_name.as_str(), style);
             },
-            StyleTreeNode::RoomId(room_id) => {
+            StyleTreeNode::RoomId(room_id, _, _) => {
                 let bold = style.add_modifier(StyleModifier::BOLD);
                 printer.push_str(room_id.as_str(), bold);
             },
-            StyleTreeNode::RoomAlias(alias) => {
+            StyleTreeNode::RoomAlias(alias, _) => {
                 let bold = style.add_modifier(StyleModifier::BOLD);
                 printer.push_str(alias.as_str(), bold);
             },
@@ -486,8 +516,9 @@ impl StyleTree {
         width: usize,
         style: Style,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Text<'a> {
-        let mut printer = TextPrinter::new(width, style, settings);
+        let mut printer = TextPrinter::new(width, style, settings, info);
 
         for child in self.children.iter() {
             child.print(&mut printer, style);
@@ -670,6 +701,37 @@ fn attrs_to_style(attrs: &[Attribute]) -> Style {
     return style;
 }
 
+fn mxid2t(
+    id: &MatrixId,
+    via: &[OwnedServerName],
+    n: Option<char>,
+    c: &StyleTreeNode,
+    h: &Url,
+) -> StyleTreeNode {
+    match id {
+        MatrixId::Room(room_id) => StyleTreeNode::RoomId(room_id.to_owned(), via.to_owned(), n),
+        MatrixId::RoomAlias(alias) => StyleTreeNode::RoomAlias(alias.to_owned(), n),
+        MatrixId::User(user_id) => StyleTreeNode::UserId(user_id.to_owned(), n),
+        MatrixId::Event(room_or_alias_id, _) => {
+            let room_or_alias_id: &matrix_sdk::ruma::RoomOrAliasId = room_or_alias_id;
+            // ignore event id for now
+            if let Ok(alias_id) = <&matrix_sdk::ruma::RoomAliasId>::try_from(room_or_alias_id) {
+                StyleTreeNode::RoomAlias(alias_id.to_owned(), n)
+            } else {
+                let room_id = <&matrix_sdk::ruma::RoomId>::try_from(room_or_alias_id).unwrap();
+                StyleTreeNode::RoomId(room_id.to_owned(), via.to_owned(), n)
+            }
+        },
+        _ => {
+            if let Some(n) = n {
+                StyleTreeNode::Anchor(Box::new(c.to_owned()), n, h.to_owned())
+            } else {
+                c.clone()
+            }
+        },
+    }
+}
+
 fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
     let node = hdl.deref();
 
@@ -684,7 +746,13 @@ fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
                     let h = attrs_to_href(&attrs.borrow()).and_then(|u| Url::parse(&u).ok());
 
                     if let Some(h) = h {
-                        if let Some(n) = state.next_link_char() {
+                        let n = state.next_link_char();
+
+                        if let Ok(uri) = MatrixToUri::parse(h.as_str()) {
+                            mxid2t(uri.id(), uri.via(), n, &c, &h)
+                        } else if let Ok(uri) = MatrixUri::parse(h.as_str()) {
+                            mxid2t(uri.id(), uri.via(), n, &c, &h)
+                        } else if let Some(n) = n {
                             StyleTreeNode::Anchor(c, n, h)
                         } else {
                             *c
@@ -827,21 +895,21 @@ pub fn parse_matrix_html(s: &str) -> StyleTree {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-
     use pretty_assertions::assert_eq;
     use unicode_width::UnicodeWidthStr;
 
-    use crate::tests::mock_settings;
+    use crate::tests::{mock_room, mock_settings};
     use crate::util::space_span;
 
     #[test]
     fn test_header() {
+        let info = mock_room();
         let settings = mock_settings();
         let bold = Style::default().add_modifier(StyleModifier::BOLD);
 
         let s = "<h1>Header 1</h1>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled(" ", bold),
@@ -853,7 +921,7 @@ pub mod tests {
 
         let s = "<h2>Header 2</h2>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -866,7 +934,7 @@ pub mod tests {
 
         let s = "<h3>Header 3</h3>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -880,7 +948,7 @@ pub mod tests {
 
         let s = "<h4>Header 4</h4>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -895,7 +963,7 @@ pub mod tests {
 
         let s = "<h5>Header 5</h5>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -911,7 +979,7 @@ pub mod tests {
 
         let s = "<h6>Header 6</h6>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("#", bold),
             Span::styled("#", bold),
@@ -929,6 +997,7 @@ pub mod tests {
 
     #[test]
     fn test_style() {
+        let info = mock_room();
         let settings = mock_settings();
         let def = Style::default();
         let bold = def.add_modifier(StyleModifier::BOLD);
@@ -939,7 +1008,7 @@ pub mod tests {
 
         let s = "<b>Bold!</b>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Bold", bold),
             Span::styled("!", bold),
@@ -948,7 +1017,7 @@ pub mod tests {
 
         let s = "<strong>Bold!</strong>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Bold", bold),
             Span::styled("!", bold),
@@ -957,7 +1026,7 @@ pub mod tests {
 
         let s = "<i>Italic!</i>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Italic", italic),
             Span::styled("!", italic),
@@ -966,7 +1035,7 @@ pub mod tests {
 
         let s = "<em>Italic!</em>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Italic", italic),
             Span::styled("!", italic),
@@ -975,7 +1044,7 @@ pub mod tests {
 
         let s = "<del>Strikethrough!</del>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Strikethrough", strike),
             Span::styled("!", strike),
@@ -984,7 +1053,7 @@ pub mod tests {
 
         let s = "<strike>Strikethrough!</strike>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Strikethrough", strike),
             Span::styled("!", strike),
@@ -993,7 +1062,7 @@ pub mod tests {
 
         let s = "<u>Underline!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Underline", underl),
             Span::styled("!", underl),
@@ -1002,7 +1071,7 @@ pub mod tests {
 
         let s = "<font color=\"#ff0000\">Red!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Red", red),
             Span::styled("!", red),
@@ -1011,7 +1080,7 @@ pub mod tests {
 
         let s = "<font color=\"red\">Red!</u>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(20, Style::default(), &settings);
+        let text = tree.to_text(20, Style::default(), &settings, &info);
         assert_eq!(text.lines, vec![Line::from(vec![
             Span::styled("Red", red),
             Span::styled("!", red),
@@ -1021,10 +1090,11 @@ pub mod tests {
 
     #[test]
     fn test_paragraph() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<p>Hello world!</p><p>Content</p><p>Goodbye world!</p>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), &settings);
+        let text = tree.to_text(10, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 7);
         assert_eq!(
             text.lines[0],
@@ -1049,10 +1119,11 @@ pub mod tests {
 
     #[test]
     fn test_blockquote() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<blockquote>Hello world!</blockquote>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), &settings);
+        let text = tree.to_text(10, Style::default(), &settings, &info);
         let style = Style::new().fg(QUOTE_COLOR);
         assert_eq!(text.lines.len(), 2);
         assert_eq!(
@@ -1081,10 +1152,11 @@ pub mod tests {
 
     #[test]
     fn test_list_unordered() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<ul><li>List Item 1</li><li>List Item 2</li><li>List Item 3</li></ul>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(8, Style::default(), &settings);
+        let text = tree.to_text(8, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1144,10 +1216,11 @@ pub mod tests {
 
     #[test]
     fn test_list_ordered() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<ol><li>List Item 1</li><li>List Item 2</li><li>List Item 3</li></ol>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(9, Style::default(), &settings);
+        let text = tree.to_text(9, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1207,6 +1280,7 @@ pub mod tests {
 
     #[test]
     fn test_table() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<table>\
                  <thead>\
@@ -1218,7 +1292,7 @@ pub mod tests {
                  <tr><td>a</td><td>b</td><td>c</td></tr>\
                  </tbody></table>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(15, Style::default(), &settings);
+        let text = tree.to_text(15, Style::default(), &settings, &info);
         let bold = Style::default().add_modifier(StyleModifier::BOLD);
         assert_eq!(text.lines.len(), 11);
 
@@ -1308,11 +1382,12 @@ pub mod tests {
 
     #[test]
     fn test_matrix_reply_stripped() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<mx-reply>This was replied to</mx-reply>This is the reply";
 
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(10, Style::default(), &settings);
+        let text = tree.to_text(10, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 2);
         assert_eq!(
             text.lines[0],
@@ -1337,10 +1412,11 @@ pub mod tests {
 
     #[test]
     fn test_self_closing() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "Hello<br>World<br>Goodbye";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(7, Style::default(), &settings);
+        let text = tree.to_text(7, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 3);
         assert_eq!(text.lines[0], Line::from(vec![Span::raw("Hello"), Span::raw("  "),]));
         assert_eq!(text.lines[1], Line::from(vec![Span::raw("World"), Span::raw("  "),]));
@@ -1349,10 +1425,11 @@ pub mod tests {
 
     #[test]
     fn test_embedded_newline() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = "<p>Hello\nWorld</p>";
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(15, Style::default(), &settings);
+        let text = tree.to_text(15, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 1);
         assert_eq!(
             text.lines[0],
@@ -1367,6 +1444,7 @@ pub mod tests {
 
     #[test]
     fn test_pre_tag() {
+        let info = mock_room();
         let settings = mock_settings();
         let s = concat!(
             "<pre><code class=\"language-rust\">",
@@ -1377,7 +1455,7 @@ pub mod tests {
             "</code></pre>\n"
         );
         let tree = parse_matrix_html(s);
-        let text = tree.to_text(25, Style::default(), &settings);
+        let text = tree.to_text(25, Style::default(), &settings, &info);
         assert_eq!(text.lines.len(), 6);
         assert_eq!(
             text.lines[0],
@@ -1455,6 +1533,7 @@ pub mod tests {
 
     #[test]
     fn test_emoji_shortcodes() {
+        let info = mock_room();
         let mut enabled = mock_settings();
         enabled.tunables.message_shortcode_display = true;
         let mut disabled = mock_settings();
@@ -1468,13 +1547,13 @@ pub mod tests {
             let s = format!("<p>{emoji}</p>");
             let tree = parse_matrix_html(s.as_str());
             // Test with emojis_shortcodes set to false
-            let text = tree.to_text(20, Style::default(), &disabled);
+            let text = tree.to_text(20, Style::default(), &disabled, &info);
             assert_eq!(text.lines, vec![Line::from(vec![
                 Span::raw(emoji),
                 space_span(20 - emoji_width, Style::default()),
             ]),]);
             // Test with emojis_shortcodes set to true
-            let text = tree.to_text(20, Style::default(), &enabled);
+            let text = tree.to_text(20, Style::default(), &enabled, &info);
             assert_eq!(text.lines, vec![Line::from(vec![
                 Span::raw(replacement.as_str()),
                 space_span(20 - replacement_width, Style::default()),

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -601,6 +601,7 @@ impl MessageColumns {
 
 struct MessageFormatter<'a> {
     settings: &'a ApplicationSettings,
+    info: &'a RoomInfo,
 
     /// How many columns to print.
     cols: MessageColumns,
@@ -721,7 +722,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, info);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -759,7 +760,8 @@ impl<'a> MessageFormatter<'a> {
     }
 
     fn push_reactions(&mut self, counts: Vec<(&'a str, usize)>, style: Style, text: &mut Text<'a>) {
-        let mut emojis = printer::TextPrinter::new(self.width(), style, false, self.settings);
+        let mut emojis =
+            printer::TextPrinter::new(self.width(), style, false, self.settings, self.info);
         let mut reactions = 0;
 
         for (key, count) in counts {
@@ -808,7 +810,8 @@ impl<'a> MessageFormatter<'a> {
         let plural = len != 1;
         let style = Style::default();
         let mut threaded =
-            printer::TextPrinter::new(self.width(), style, false, self.settings).literal(true);
+            printer::TextPrinter::new(self.width(), style, false, self.settings, self.info)
+                .literal(true);
         let len = Span::styled(len.to_string(), style.add_modifier(StyleModifier::BOLD));
         threaded.push_str(" \u{2937} ", style);
         threaded.push_span_nobreak(len);
@@ -943,7 +946,17 @@ impl Message {
                 .map(|user_id| user_id.to_owned())
                 .collect();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else if user_gutter + TIME_GUTTER + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
@@ -951,7 +964,17 @@ impl Message {
             let time = self.timestamp.show_time();
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else if user_gutter + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Two;
             let fill = width - user_gutter;
@@ -959,7 +982,17 @@ impl Message {
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else {
             let cols = MessageColumns::One;
             let fill = width.saturating_sub(2);
@@ -967,7 +1000,17 @@ impl Message {
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         }
     }
 
@@ -1000,7 +1043,7 @@ impl Message {
         });
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings);
+        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, info);
 
         // Given our text so far, determine the image offset.
         let proto_main = proto.map(|p| {
@@ -1048,9 +1091,10 @@ impl Message {
         style: Style,
         hide_reply: bool,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> (Text<'a>, Option<&'a Protocol>) {
         if let Some(html) = &self.html {
-            (html.to_text(width, style, hide_reply, settings), None)
+            (html.to_text(width, style, hide_reply, settings, info), None)
         } else {
             let mut msg = self.event.body();
             if settings.tunables.message_shortcode_display {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -644,6 +644,7 @@ enum SenderSpan<'a> {
 
 struct MessageFormatter<'a> {
     settings: &'a ApplicationSettings,
+    info: &'a RoomInfo,
 
     /// How many columns to print.
     cols: MessageColumns,
@@ -781,7 +782,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, settings, previews);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, settings, previews, info);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -826,7 +827,7 @@ impl<'a> MessageFormatter<'a> {
         settings: &ApplicationSettings,
         previews: &'a PreviewManager,
     ) -> Vec<ProtocolPreview<'a>> {
-        let mut emojis = printer::TextPrinter::new(self.width(), style, self.settings);
+        let mut emojis = printer::TextPrinter::new(self.width(), style, self.settings, self.info);
         let mut reactions = 0;
         let mut protos = Vec::new();
 
@@ -898,7 +899,7 @@ impl<'a> MessageFormatter<'a> {
         let plural = len != 1;
         let style = Style::default();
         let mut threaded =
-            printer::TextPrinter::new(self.width(), style, self.settings).literal(true);
+            printer::TextPrinter::new(self.width(), style, self.settings, self.info).literal(true);
         let len = Span::styled(len.to_string(), style.add_modifier(StyleModifier::BOLD));
         threaded.push_str(" \u{2937} ", style);
         threaded.push_span_nobreak(len);
@@ -1064,7 +1065,17 @@ impl Message {
                 .map(|user_id| user_id.to_owned())
                 .collect();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else if user_gutter + TIME_GUTTER + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
@@ -1072,7 +1083,17 @@ impl Message {
             let time = Some(self.timestamp.show_time());
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else if user_gutter + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Two;
             let fill = width - user_gutter;
@@ -1080,7 +1101,17 @@ impl Message {
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         } else {
             let cols = MessageColumns::One;
             let fill = width.saturating_sub(2);
@@ -1088,7 +1119,17 @@ impl Message {
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter {
+                settings,
+                cols,
+                orig,
+                fill,
+                user,
+                date,
+                time,
+                read,
+                info,
+            }
         }
     }
 
@@ -1137,7 +1178,7 @@ impl Message {
         }
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, settings, previews);
+        let (msg, proto) = self.show_msg(width, style, settings, previews, info);
 
         // Given our text so far, determine the image offset.
         if let Some(p) = proto {
@@ -1199,6 +1240,7 @@ impl Message {
         style: Style,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
+        info: &'a RoomInfo,
     ) -> (Text<'a>, Option<&'a SlicedProtocol>) {
         let mut proto = None;
         let placeholder = match self
@@ -1234,7 +1276,7 @@ impl Message {
         }
 
         if let Some(html) = &self.html {
-            text += html.to_text(width, style, settings);
+            text += html.to_text(width, style, settings, info);
         } else {
             let mut msg = self.event.body();
             if settings.tunables.message_shortcode_display {

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -11,6 +11,7 @@ use ratatui::text::{Line, Span, Text};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+use crate::base::RoomInfo;
 use crate::config::{ApplicationSettings, TunableValues};
 use crate::util::{
     replace_emojis_in_line,
@@ -33,6 +34,7 @@ pub struct TextPrinter<'a> {
     literal: bool,
 
     pub(super) settings: &'a ApplicationSettings,
+    pub(super) info: &'a RoomInfo,
 }
 
 impl<'a> TextPrinter<'a> {
@@ -42,6 +44,7 @@ impl<'a> TextPrinter<'a> {
         base_style: Style,
         hide_reply: bool,
         settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
     ) -> Self {
         TextPrinter {
             text: Text::default(),
@@ -54,6 +57,7 @@ impl<'a> TextPrinter<'a> {
             curr_width: 0,
             literal: false,
             settings,
+            info,
         }
     }
 
@@ -105,6 +109,7 @@ impl<'a> TextPrinter<'a> {
             curr_width: 0,
             literal: self.literal,
             settings: self.settings,
+            info: self.info,
         }
     }
 
@@ -303,12 +308,13 @@ impl<'a> TextPrinter<'a> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::tests::mock_settings;
+    use crate::tests::{mock_room, mock_settings};
 
     #[test]
     fn test_push_nobreak() {
         let settings = mock_settings();
-        let mut printer = TextPrinter::new(5, Style::default(), false, &settings);
+        let info = mock_room();
+        let mut printer = TextPrinter::new(5, Style::default(), false, &settings, &info);
         printer.push_span_nobreak("hello world".into());
         let text = printer.finish();
         assert_eq!(text.lines.len(), 1);

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -4,6 +4,7 @@
 //! lines to make concatenation work right (e.g., combining table cells after wrapping their
 //! contents).
 
+use crate::base::RoomInfo;
 use crate::config::TunableValues;
 use crate::prelude::*;
 use crate::util::{
@@ -26,11 +27,17 @@ pub struct TextPrinter<'a> {
     literal: bool,
 
     pub(super) settings: &'a ApplicationSettings,
+    pub(super) info: &'a RoomInfo,
 }
 
 impl<'a> TextPrinter<'a> {
     /// Create a new printer.
-    pub fn new(width: usize, base_style: Style, settings: &'a ApplicationSettings) -> Self {
+    pub fn new(
+        width: usize,
+        base_style: Style,
+        settings: &'a ApplicationSettings,
+        info: &'a RoomInfo,
+    ) -> Self {
         TextPrinter {
             text: Text::default(),
             width,
@@ -41,6 +48,7 @@ impl<'a> TextPrinter<'a> {
             curr_width: 0,
             literal: false,
             settings,
+            info,
         }
     }
 
@@ -91,6 +99,7 @@ impl<'a> TextPrinter<'a> {
             curr_width: 0,
             literal: self.literal,
             settings: self.settings,
+            info: self.info,
         }
     }
 
@@ -290,12 +299,13 @@ impl<'a> TextPrinter<'a> {
 pub mod tests {
     use super::*;
 
-    use crate::tests::mock_settings;
+    use crate::tests::{mock_room, mock_settings};
 
     #[test]
     fn test_push_nobreak() {
         let settings = mock_settings();
-        let mut printer = TextPrinter::new(5, Style::default(), &settings);
+        let info = mock_room();
+        let mut printer = TextPrinter::new(5, Style::default(), &settings, &info);
         printer.push_span_nobreak("hello world".into());
         let text = printer.finish();
         assert_eq!(text.lines.len(), 1);

--- a/src/message/state.rs
+++ b/src/message/state.rs
@@ -779,7 +779,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             ..
         }) => {
             let prefix = StyleTreeNode::Text("* upgraded the room; replacement room is ".into());
-            let room = StyleTreeNode::RoomId(content.replacement_room.clone(), Some('0'));
+            let room = StyleTreeNode::RoomId(content.replacement_room.clone(), vec![], Some('0'));
             vec![prefix, room]
         },
         AnyFullStateEventContent::RoomTopic(FullStateEventContent::Original {
@@ -793,7 +793,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let prefix = StyleTreeNode::Text("* added a space child: ".into());
 
             let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
-                StyleTreeNode::RoomId(room_id, Some('0'))
+                StyleTreeNode::RoomId(room_id, vec![], Some('0'))
             } else {
                 bold(ev.state_key().to_string())
             };
@@ -810,7 +810,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             };
 
             let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
-                StyleTreeNode::RoomId(room_id, Some('0'))
+                StyleTreeNode::RoomId(room_id, vec![], Some('0'))
             } else {
                 bold(ev.state_key().to_string())
             };

--- a/src/message/state.rs
+++ b/src/message/state.rs
@@ -3,6 +3,7 @@
 use matrix_sdk::ruma::events::room::member::MembershipChange;
 use matrix_sdk::ruma::events::{AnyStateEventContentChange, StateEventContentChange};
 
+use crate::message::TreeGenState;
 use crate::message::html::{StyleTree, StyleTreeNode};
 use crate::prelude::*;
 
@@ -510,7 +511,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             ..
         }) => {
             if let Some(canon) = content.alias.as_ref() {
-                let canon = StyleTreeNode::RoomAlias(canon.to_owned());
+                let canon = StyleTreeNode::RoomAlias(canon.to_owned(), Some('0'));
                 let prefix =
                     StyleTreeNode::Text("* updated the canonical alias for the room to: ".into());
                 vec![prefix, canon]
@@ -577,7 +578,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             let prev_details = prev_content.as_ref().map(|p| p.details());
             let change = content.membership_change(prev_details, ev.sender(), &state_key);
-            let user_id = StyleTreeNode::UserId(state_key.clone());
+            let user_id = StyleTreeNode::UserId(state_key.clone(), Some('0'));
 
             match change {
                 MembershipChange::None => {
@@ -656,7 +657,11 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
                                 (None, Some(new)) => {
                                     vec![
                                         StyleTreeNode::Text("* set their display name to ".into()),
-                                        StyleTreeNode::DisplayName(new.into(), state_key),
+                                        StyleTreeNode::DisplayName(
+                                            new.into(),
+                                            state_key,
+                                            Some('0'),
+                                        ),
                                     ]
                                 },
                                 (Some(old), Some(new)) => {
@@ -664,9 +669,13 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
                                         StyleTreeNode::Text(
                                             "* changed their display name from ".into(),
                                         ),
-                                        StyleTreeNode::DisplayName(old.into(), state_key.clone()),
+                                        StyleTreeNode::DisplayName(
+                                            old.into(),
+                                            state_key.clone(),
+                                            Some('0'),
+                                        ),
                                         StyleTreeNode::Text(" to ".into()),
-                                        StyleTreeNode::DisplayName(new.into(), state_key),
+                                        StyleTreeNode::DisplayName(new.into(), state_key, None),
                                     ]
                                 },
                                 (Some(_), None) => {
@@ -759,7 +768,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             ..
         }) => {
             let prefix = StyleTreeNode::Text("* upgraded the room; replacement room is ".into());
-            let room = StyleTreeNode::RoomId(content.replacement_room.clone());
+            let room = StyleTreeNode::RoomId(content.replacement_room.clone(), vec![], Some('0'));
             vec![prefix, room]
         },
         AnyStateEventContentChange::RoomTopic(StateEventContentChange::Original {
@@ -774,7 +783,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let prefix = StyleTreeNode::Text("* added a space child: ".into());
 
             let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
-                StyleTreeNode::RoomId(room_id)
+                StyleTreeNode::RoomId(room_id, vec![], Some('0'))
             } else {
                 bold(ev.state_key().to_string())
             };
@@ -792,7 +801,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             };
 
             let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
-                StyleTreeNode::RoomId(room_id)
+                StyleTreeNode::RoomId(room_id, vec![], Some('0'))
             } else {
                 bold(ev.state_key().to_string())
             };
@@ -816,12 +825,16 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             );
             let mut cs = vec![prefix];
 
+            let mut state = TreeGenState { link_num: 0 };
+
             for (i, member) in content.service_members.iter().enumerate() {
                 if i != 0 {
                     cs.push(StyleTreeNode::Text(", ".into()));
                 }
 
-                cs.push(StyleTreeNode::UserId(member.clone()));
+                let c = state.next_link_char();
+
+                cs.push(StyleTreeNode::UserId(member.clone(), c));
             }
 
             cs

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,8 +20,11 @@ pub use matrix_sdk::ruma::events::room::message::{
     RoomMessageEventContent,
 };
 pub use matrix_sdk::ruma::events::tag::{TagName, Tags};
+pub use matrix_sdk::ruma::matrix_uri::MatrixId;
 pub use matrix_sdk::ruma::{
     EventId,
+    MatrixToUri,
+    MatrixUri,
     MilliSecondsSinceUnixEpoch,
     OwnedEventId,
     OwnedRoomAliasId,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,10 +4,12 @@ use std::path::PathBuf;
 use matrix_sdk::ruma::{
     event_id,
     events::room::message::{OriginalRoomMessageEvent, RoomMessageEventContent},
+    owned_room_alias_id,
     server_name,
     user_id,
     EventId,
     OwnedEventId,
+    OwnedRoomAliasId,
     OwnedRoomId,
     OwnedUserId,
     RoomId,
@@ -46,9 +48,8 @@ use crate::{
     worker::Requester,
 };
 
-const TEST_ROOM1_ALIAS: &str = "#room1:example.com";
-
 lazy_static! {
+    pub static ref TEST_ROOM1_ALIAS: OwnedRoomAliasId = owned_room_alias_id!("#room1:example.com");
     pub static ref TEST_ROOM1_ID: OwnedRoomId =
         RoomId::new_v1(server_name!("example.com")).to_owned();
     pub static ref TEST_USER1: OwnedUserId = user_id!("@user1:example.com").to_owned();
@@ -154,6 +155,12 @@ pub fn mock_room() -> RoomInfo {
     room.name = Some("Watercooler Discussion".into());
     room.keys = mock_keys();
     *room.get_thread_mut(None) = mock_messages();
+
+    let user_id = TEST_USER2.clone();
+    let name = "User 2";
+    room.display_names.insert(user_id.clone(), name.to_string());
+    room.display_name_completion.insert(name.to_string(), user_id.clone());
+
     room
 }
 
@@ -248,7 +255,7 @@ pub async fn mock_store() -> ProgramStore {
     let info = mock_room();
 
     store.rooms.insert(room_id.clone(), info);
-    store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
+    store.names.insert(TEST_ROOM1_ALIAS.clone(), room_id);
 
     ProgramStore::new(store)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,10 +4,12 @@ use std::{collections::HashMap, iter::FromIterator as _};
 use matrix_sdk::ruma::{
     event_id,
     events::room::message::RoomMessageEventContent,
+    owned_room_alias_id,
     server_name,
     user_id,
     EventId,
     OwnedEventId,
+    OwnedRoomAliasId,
     OwnedRoomId,
     OwnedUserId,
     RoomId,
@@ -46,9 +48,8 @@ use crate::{
     worker::Requester,
 };
 
-const TEST_ROOM1_ALIAS: &str = "#room1:example.com";
-
 lazy_static! {
+    pub static ref TEST_ROOM1_ALIAS: OwnedRoomAliasId = owned_room_alias_id!("#room1:example.com");
     pub static ref TEST_ROOM1_ID: OwnedRoomId =
         RoomId::new_v1(server_name!("example.com")).to_owned();
     pub static ref TEST_USER1: OwnedUserId = user_id!("@user1:example.com").to_owned();
@@ -155,6 +156,12 @@ pub fn mock_room() -> RoomInfo {
     room.name = Some("Watercooler Discussion".into());
     room.keys = mock_keys();
     *room.get_thread_mut(None) = mock_messages();
+
+    let user_id = TEST_USER2.clone();
+    let name = "User 2";
+    room.display_names.insert(user_id.clone(), name.to_string());
+    room.display_name_completion.insert(name.to_string(), user_id.clone());
+
     room
 }
 
@@ -250,7 +257,7 @@ pub async fn mock_store() -> ProgramStore {
     let info = mock_room();
 
     store.rooms.insert(room_id.clone(), info);
-    store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
+    store.names.insert(TEST_ROOM1_ALIAS.clone(), room_id);
 
     ProgramStore::new(store)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,9 @@
 use std::iter::FromIterator as _;
 
 use lazy_static::lazy_static;
-use matrix_sdk::ruma::assign;
+use matrix_sdk::ruma::events::room::message::RoomMessageEventContent;
 use matrix_sdk::ruma::{UInt, event_id, server_name, user_id};
+use matrix_sdk::ruma::{assign, owned_room_alias_id};
 use serde_json::{Map, Value};
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -10,9 +11,8 @@ use crate::base::EventLocation;
 use crate::config::*;
 use crate::prelude::*;
 
-const TEST_ROOM1_ALIAS: &str = "#room1:example.com";
-
 lazy_static! {
+    pub static ref TEST_ROOM1_ALIAS: OwnedRoomAliasId = owned_room_alias_id!("#room1:example.com");
     pub static ref TEST_ROOM1_ID: OwnedRoomId =
         RoomId::new_v1(server_name!("example.com")).to_owned();
     pub static ref TEST_USER1: OwnedUserId = user_id!("@user1:example.com").to_owned();
@@ -134,6 +134,11 @@ pub fn mock_room() -> RoomInfo {
     room.name = Some("Watercooler Discussion".into());
     room.keys = mock_keys();
     *room.get_thread_mut(None) = mock_messages();
+
+    let user_id = TEST_USER2.clone();
+    let name = "User 2";
+    room.display_names.set(user_id.clone(), Some(name.to_string()), true);
+
     room
 }
 
@@ -247,7 +252,7 @@ pub async fn mock_store() -> ProgramStore {
     let info = mock_room();
 
     store.rooms.insert(room_id.clone(), info);
-    store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
+    store.names.insert(TEST_ROOM1_ALIAS.clone(), room_id);
 
     ProgramStore::new(store)
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -857,7 +857,7 @@ impl Window<IambInfo> for IambWindow {
 
             IambWindow::open(id, store)
         } else {
-            let room_id = worker.join_room(name.clone())?;
+            let room_id = worker.join_room(name.clone(), vec![])?;
 
             if let Ok(alias) = OwnedRoomAliasId::from_str(&name) {
                 names.insert(alias, room_id.clone());

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -9,6 +9,7 @@
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::fmt::{self, Display};
 use std::ops::Deref;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -857,7 +858,10 @@ impl Window<IambInfo> for IambWindow {
             IambWindow::open(id, store)
         } else {
             let room_id = worker.join_room(name.clone())?;
-            names.insert(name, room_id.clone());
+
+            if let Ok(alias) = OwnedRoomAliasId::from_str(&name) {
+                names.insert(alias, room_id.clone());
+            }
 
             let (room, name, tags) = store.application.worker.get_room(room_id)?;
             let room = RoomState::new(room, None, name, tags, store);
@@ -900,7 +904,7 @@ impl GenericChatItem {
         info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         GenericChatItem { room_info, name, alias, is_dm, unread }
@@ -1019,7 +1023,7 @@ impl RoomItem {
         info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         RoomItem { room_info, name, alias, unread }
@@ -1241,7 +1245,7 @@ impl SpaceItem {
         let alias = room_info.0.canonical_alias();
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         SpaceItem { room_info, name, alias }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -912,8 +912,11 @@ impl Window<IambInfo> for IambWindow {
 
             IambWindow::open(id, store)
         } else {
-            let room_id = worker.join_room(name.clone())?;
-            names.insert(name, room_id.clone());
+            let room_id = worker.join_room(name.clone(), vec![])?;
+
+            if let Ok(alias) = OwnedRoomAliasId::from_str(&name) {
+                names.insert(alias, room_id.clone());
+            }
 
             let (room, name, tags) = store.application.worker.get_room(room_id)?;
             let room = RoomState::new(room, None, name, tags, store);
@@ -956,7 +959,7 @@ impl GenericChatItem {
         info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         GenericChatItem { room_info, name, alias, is_dm, unread }
@@ -1079,7 +1082,7 @@ impl RoomItem {
         info.tags.clone_from(&room_info.deref().1);
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         RoomItem { room_info, name, alias, unread }
@@ -1300,7 +1303,7 @@ impl SpaceItem {
         let alias = room_info.0.canonical_alias();
 
         if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
+            store.application.names.insert(alias.to_owned(), room_id.to_owned());
         }
 
         SpaceItem { room_info, name, alias }

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -251,7 +251,7 @@ impl ChatState {
                                 .into_iter()
                                 .map(|l| {
                                     let url = l.1.to_string();
-                                    let act = IambAction::OpenLink(url.clone()).into();
+                                    let act = IambAction::OpenLink(url.clone(), false).into();
                                     MultiChoiceItem::new(l.0, url, vec![act])
                                 })
                                 .collect();

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -581,14 +581,14 @@ impl ChatState {
                     show_echo = false;
                 } else if let Some(thread_root) = self.scrollback.thread() {
                     if let Some(m) = self.get_reply_to(info) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::Yes, AddMentions::No);
+                        msg = msg.make_for_thread(m, ReplyWithinThread::Yes, AddMentions::Yes);
                     } else if let Some(m) = info.get_thread_last(thread_root) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::No, AddMentions::No);
+                        msg = msg.make_for_thread(m, ReplyWithinThread::No, AddMentions::Yes);
                     } else {
                         // Internal state is wonky?
                     }
                 } else if let Some(m) = self.get_reply_to(info) {
-                    msg = msg.make_reply_to(m, ForwardThread::Yes, AddMentions::No);
+                    msg = msg.make_reply_to(m, ForwardThread::Yes, AddMentions::Yes);
                 }
 
                 // XXX: second parameter can be a locally unique transaction id.

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -19,6 +19,7 @@ use matrix_sdk::ruma::events::room::message::{
     ForwardThread,
     MessageFormat,
     ReplyWithinThread,
+    TextMessageEventContent,
 };
 use matrix_sdk::send_queue::RoomSendQueueError;
 use modalkit::editing::history::{self, HistoryList};
@@ -518,6 +519,14 @@ impl ChatState {
             .filter(|c| !c.is_blank())
             .map(|c| c.trim_end().to_string())
             .and_then(|c| text_to_text_message_event_content(c, settings.tunables.default_markup));
+
+        let mentions = if let Some(content) = &config.caption {
+            extract_mentions(content)
+        } else {
+            Mentions::new()
+        };
+        config.mentions = Some(mentions);
+
         config.reply = self.generate_reply_info(info, add_caption);
         config
     }
@@ -555,30 +564,13 @@ impl ChatState {
                     msg.trim_end().to_string()
                 };
 
-                let mut msg = text_to_message(msg, tunables.default_markup);
+                let mut msg = text_to_message(msg.into(), tunables.default_markup);
 
-                // extract mentions from matrix links
-                let mut mentions = Mentions::new();
-                if let MessageType::Text(content) = &msg.msgtype &&
-                    let Some(formatted) = &content.formatted &&
-                    matches!(&formatted.format, MessageFormat::Html)
-                {
-                    let html = formatted.body.as_str();
-
-                    let re =
-                        Regex::new(r#"<a href="(https://matrix.to/#/@[^"]*:[^"]*)">"#).unwrap();
-
-                    let user_ids = re.captures_iter(html).map(|capture| {
-                        let link = capture.get(1).unwrap().as_str();
-                        let uri = MatrixToUri::parse(link).unwrap();
-                        let MatrixId::User(user_id) = uri.id() else {
-                            unreachable!()
-                        };
-                        user_id.to_owned()
-                    });
-
-                    mentions = Mentions::with_user_ids(user_ids);
-                }
+                let mentions = if let MessageType::Text(content) = &msg.msgtype {
+                    extract_mentions(content)
+                } else {
+                    Mentions::new()
+                };
                 msg = msg.add_mentions(mentions);
 
                 if let Some(key) = &self.editing {
@@ -1191,6 +1183,31 @@ fn open_command(open_command: Option<&Vec<String>>, target: OsString) -> IambRes
         });
         return Ok(());
     }
+}
+
+/// Extract mentions from `https://matrix.to` html links
+fn extract_mentions(content: &TextMessageEventContent) -> Mentions {
+    let Some(formatted) = content.formatted.as_ref() else {
+        return Mentions::new();
+    };
+    if !matches!(formatted.format, MessageFormat::Html) {
+        return Mentions::new();
+    }
+    let html = formatted.body.as_str();
+
+    let re = Regex::new(r#"<a href="(https://matrix.to/#/@[^"]*:[^"]*)">"#).unwrap();
+
+    let user_ids = re.captures_iter(html).map(|capture| {
+        let link = capture.get(1).unwrap().as_str();
+        let uri = MatrixToUri::parse(link).unwrap();
+        let MatrixId::User(user_id) = uri.id() else {
+            // we only matched user links (starting with `@`)
+            unreachable!()
+        };
+        user_id.to_owned()
+    });
+
+    Mentions::with_user_ids(user_ids)
 }
 
 fn cmd(open_command: &Vec<String>) -> Option<Command> {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -11,9 +11,15 @@ use matrix_sdk::attachment::AttachmentConfig;
 use matrix_sdk::attachment::{AttachmentInfo, BaseImageInfo};
 use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
 use matrix_sdk::room::reply::{EnforceThread, Reply};
+use matrix_sdk::ruma::events::Mentions;
 use matrix_sdk::ruma::events::reaction::ReactionEventContent;
-use matrix_sdk::ruma::events::relation::{Annotation, Replacement};
-use matrix_sdk::ruma::events::room::message::{AddMentions, ForwardThread, ReplyWithinThread};
+use matrix_sdk::ruma::events::relation::Annotation;
+use matrix_sdk::ruma::events::room::message::{
+    AddMentions,
+    ForwardThread,
+    MessageFormat,
+    ReplyWithinThread,
+};
 use matrix_sdk::send_queue::RoomSendQueueError;
 use modalkit::editing::history::{self, HistoryList};
 use modalkit::editing::store::RegisterError;
@@ -21,6 +27,7 @@ use modalkit::keybindings::dialog::{Dialog, MultiChoice, MultiChoiceItem};
 use modalkit_ratatui::PromptActions;
 use modalkit_ratatui::textbox::{TextBox, TextBoxState};
 use ratatui::prelude::Stylize;
+use regex::Regex;
 
 use crate::base::{DownloadFlags, EchoLocation};
 use crate::config::EncryptionIndicatorLocation;
@@ -145,15 +152,18 @@ impl ChatState {
                 Err(UIError::NeedConfirm(prompt))
             },
             MessageAction::Download(filename, flags) => {
+                if let MessageEvent::State(_) = &msg.event {
+                    let err = open_links(msg);
+                    return Err(err);
+                }
+
                 if let Some(msgtype) = msg.event.msgtype() {
                     let media = client.media();
-
                     let mut filename = match (filename, &settings.dirs.downloads) {
                         (Some(f), _) => PathBuf::from(f),
                         (None, Some(downloads)) => downloads.clone(),
                         (None, None) => return Err(IambError::NoDownloadDir.into()),
                     };
-
                     let (source, msg_filename) = match msgtype {
                         MessageType::Audio(c) => (c.source.clone(), c.filename()),
                         MessageType::File(c) => (c.source.clone(), c.filename()),
@@ -163,46 +173,13 @@ impl ChatState {
                             if !flags.contains(DownloadFlags::OPEN) {
                                 return Err(IambError::NoAttachment.into());
                             }
-
-                            let mut links = if let Some(html) = &msg.html {
-                                html.get_links()
-                            } else {
-                                vec![]
-                            };
-
-                            if links.is_empty() {
-                                links = linkify::LinkFinder::new()
-                                    .links(&msg.event.body())
-                                    .filter_map(|u| Url::parse(u.as_str()).ok())
-                                    .scan(TreeGenState { link_num: 0 }, |state, u| {
-                                        state.next_link_char().map(|c| (c, u))
-                                    })
-                                    .collect();
-                            }
-
-                            if links.is_empty() {
-                                return Err(IambError::NoAttachment.into());
-                            }
-
-                            let choices = links
-                                .into_iter()
-                                .map(|l| {
-                                    let url = l.1.to_string();
-                                    let act = IambAction::OpenLink(url.clone()).into();
-                                    MultiChoiceItem::new(l.0, url, vec![act])
-                                })
-                                .collect();
-                            let dialog = MultiChoice::new(choices);
-                            let err = UIError::NeedConfirm(Box::new(dialog));
-
+                            let err = open_links(msg);
                             return Err(err);
                         },
                     };
-
                     if filename.is_dir() {
                         filename.push(msg_filename.replace(std::path::MAIN_SEPARATOR_STR, "_"));
                     }
-
                     if filename.exists() && !flags.contains(DownloadFlags::FORCE) {
                         // Find an incrementally suffixed filename, e.g. image-2.jpg -> image-3.jpg
                         if let Some(stem) = filename.file_stem().and_then(OsStr::to_str) {
@@ -222,7 +199,6 @@ impl ChatState {
                             }
                         }
                     }
-
                     if !filename.exists() || flags.contains(DownloadFlags::FORCE) {
                         let req = MediaRequestParameters { source, format: MediaFormat::File };
 
@@ -241,7 +217,6 @@ impl ChatState {
 
                         return Err(err);
                     }
-
                     let info = if flags.contains(DownloadFlags::OPEN) {
                         let target = filename.clone().into_os_string();
                         match open_command(
@@ -264,7 +239,6 @@ impl ChatState {
                             filename.display()
                         ))
                     };
-
                     return Ok(info.into());
                 }
 
@@ -583,6 +557,30 @@ impl ChatState {
 
                 let mut msg = text_to_message(msg, tunables.default_markup);
 
+                // extract mentions from matrix links
+                let mut mentions = Mentions::new();
+                if let MessageType::Text(content) = &msg.msgtype &&
+                    let Some(formatted) = &content.formatted &&
+                    matches!(&formatted.format, MessageFormat::Html)
+                {
+                    let html = formatted.body.as_str();
+
+                    let re =
+                        Regex::new(r#"<a href="(https://matrix.to/#/@[^"]*:[^"]*)">"#).unwrap();
+
+                    let user_ids = re.captures_iter(html).map(|capture| {
+                        let link = capture.get(1).unwrap().as_str();
+                        let uri = MatrixToUri::parse(link).unwrap();
+                        let MatrixId::User(user_id) = uri.id() else {
+                            unreachable!()
+                        };
+                        user_id.to_owned()
+                    });
+
+                    mentions = Mentions::with_user_ids(user_ids);
+                }
+                msg = msg.add_mentions(mentions);
+
                 if let Some(key) = &self.editing {
                     let id = match &key.id {
                         MessageId::Origin(id) => id,
@@ -621,20 +619,27 @@ impl ChatState {
                         },
                     };
 
-                    msg.relates_to = Some(Relation::Replacement(Replacement::new(
-                        id.to_owned(),
-                        msg.msgtype.clone().into(),
-                    )));
+                    let Some(edited_msg) = info.get_event(id) else {
+                        let msg = "edited message not found in store";
+                        return Err(UIError::Failure(msg.into()));
+                    };
+
+                    let MessageEvent::Original(edited_msg, _) = &edited_msg.event else {
+                        let msg = "you can only edit normal messages";
+                        return Err(UIError::Failure(msg.into()));
+                    };
+
+                    msg = msg.make_replacement(edited_msg.as_ref());
                 } else if let Some(thread_root) = self.scrollback.thread() {
                     if let Some(m) = self.get_reply_to(info) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::Yes, AddMentions::No);
+                        msg = msg.make_for_thread(m, ReplyWithinThread::Yes, AddMentions::Yes);
                     } else if let Some(m) = info.get_thread_last(thread_root) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::No, AddMentions::No);
+                        msg = msg.make_for_thread(m, ReplyWithinThread::No, AddMentions::Yes);
                     } else {
                         // Internal state is wonky?
                     }
                 } else if let Some(m) = self.get_reply_to(info) {
-                    msg = msg.make_reply_to(m, ForwardThread::Yes, AddMentions::No);
+                    msg = msg.make_reply_to(m, ForwardThread::Yes, AddMentions::Yes);
                 }
 
                 room.send_queue().send(msg.into()).await.map_err(IambError::from)?;
@@ -766,6 +771,37 @@ impl ChatState {
 
         store.application.worker.typing_notice(self.room_id.clone());
     }
+}
+
+fn open_links(msg: &Message) -> UIError<IambInfo> {
+    let mut links = if let Some(html) = &msg.html {
+        html.get_links()
+    } else {
+        vec![]
+    };
+
+    if links.is_empty() {
+        links = linkify::LinkFinder::new()
+            .links(&msg.event.body())
+            .filter_map(|u| Url::parse(u.as_str()).ok())
+            .scan(TreeGenState { link_num: 0 }, |state, u| state.next_link_char().map(|c| (c, u)))
+            .collect();
+    }
+
+    if links.is_empty() {
+        return IambError::NoAttachment.into();
+    }
+
+    let choices = links
+        .into_iter()
+        .map(|l| {
+            let url = l.1.to_string();
+            let act = IambAction::OpenLink(url.clone(), false).into();
+            MultiChoiceItem::new(l.0, url, vec![act])
+        })
+        .collect();
+    let dialog = MultiChoice::new(choices);
+    UIError::NeedConfirm(Box::new(dialog))
 }
 
 macro_rules! delegate {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1356,8 +1356,8 @@ impl ClientWorker {
     }
 
     async fn direct_message(&mut self, user: OwnedUserId) -> IambResult<OwnedRoomId> {
-        for room in self.client.rooms() {
-            if !is_direct(&room).await {
+        for room in self.client.joined_rooms().iter().chain(self.client.invited_rooms().iter()) {
+            if !is_direct(room).await {
                 continue;
             }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -434,7 +434,11 @@ fn members_insert(
             let user_id = member.user_id();
             let display_name =
                 member.display_name().map_or(user_id.to_string(), |str| str.to_string());
-            info.display_names.insert(user_id.to_owned(), display_name);
+            let old_name = info.display_names.insert(user_id.to_owned(), display_name.clone());
+            if let Some(old_name) = old_name {
+                info.display_name_completion.remove(&old_name);
+            }
+            info.display_name_completion.insert(display_name, user_id.to_owned());
         }
     }
     // else ???
@@ -1144,11 +1148,21 @@ impl ClientWorker {
                     let info = locked.application.get_room_info(room_id.to_owned());
 
                     if ambiguous {
-                        info.display_names.remove(&user_id);
+                        let old_name = info.display_names.remove(&user_id);
+                        if let Some(old_name) = old_name {
+                            info.display_name_completion.remove(&old_name);
+                        }
                     } else if let Some(display) = ev.content.displayname {
-                        info.display_names.insert(user_id, display);
+                        let old_name = info.display_names.insert(user_id.clone(), display.clone());
+                        if let Some(old_name) = old_name {
+                            info.display_name_completion.remove(&old_name);
+                        }
+                        info.display_name_completion.insert(display, user_id);
                     } else {
-                        info.display_names.remove(&user_id);
+                        let old_name = info.display_names.remove(&user_id);
+                        if let Some(old_name) = old_name {
+                            info.display_name_completion.remove(&old_name);
+                        }
                     }
                 }
             },

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
+use matrix_sdk::ruma::OwnedRoomAliasId;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -629,6 +630,7 @@ pub enum WorkerTask {
     Logout(String, ClientReply<IambResult<EditInfo>>),
     GetInviter(MatrixRoom, ClientReply<IambResult<Option<RoomMember>>>),
     GetRoom(OwnedRoomId, ClientReply<IambResult<FetchedRoom>>),
+    ResolveAlias(OwnedRoomAliasId, ClientReply<IambResult<OwnedRoomId>>),
     JoinRoom(String, ClientReply<IambResult<OwnedRoomId>>),
     Members(OwnedRoomId, ClientReply<IambResult<Vec<RoomMember>>>),
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
@@ -661,6 +663,12 @@ impl Debug for WorkerTask {
             WorkerTask::GetRoom(room_id, _) => {
                 f.debug_tuple("WorkerTask::GetRoom")
                     .field(room_id)
+                    .field(&format_args!("_"))
+                    .finish()
+            },
+            WorkerTask::ResolveAlias(s, _) => {
+                f.debug_tuple("WorkerTask::ResolveAlias")
+                    .field(s)
                     .field(&format_args!("_"))
                     .finish()
             },
@@ -800,6 +808,14 @@ impl Requester {
         return response.recv();
     }
 
+    pub fn resolve_alias(&self, alias_id: OwnedRoomAliasId) -> IambResult<OwnedRoomId> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::ResolveAlias(alias_id, reply)).unwrap();
+
+        return response.recv();
+    }
+
     pub fn join_room(&self, name: String) -> IambResult<OwnedRoomId> {
         let (reply, response) = oneshot();
 
@@ -895,6 +911,10 @@ impl ClientWorker {
                 assert_eq!(self.initialized, false);
                 self.init(store).await;
                 reply.send(());
+            },
+            WorkerTask::ResolveAlias(alias_id, reply) => {
+                assert!(self.initialized);
+                reply.send(self.resolve_alias(alias_id).await);
             },
             WorkerTask::JoinRoom(room_id, reply) => {
                 assert!(self.initialized);
@@ -1381,12 +1401,28 @@ impl ClientWorker {
 
     async fn get_room(&mut self, room_id: OwnedRoomId) -> IambResult<FetchedRoom> {
         if let Some(room) = self.client.get_room(&room_id) {
-            let name = room.cached_display_name().ok_or_else(|| IambError::UnknownRoom(room_id))?;
+            let name = if let Some(name) = room.cached_display_name() {
+                name
+            } else {
+                room.display_name().await.map_err(IambError::from)?
+            };
             let tags = room.tags().await.map_err(IambError::from)?;
 
             Ok((room, name, tags))
         } else {
             Err(IambError::UnknownRoom(room_id).into())
+        }
+    }
+
+    async fn resolve_alias(&mut self, alias_id: OwnedRoomAliasId) -> IambResult<OwnedRoomId> {
+        match self.client.resolve_room_alias(&alias_id).await {
+            Ok(resp) => Ok(resp.room_id),
+            Err(e) => {
+                let msg = e.to_string();
+                let err = UIError::Failure(msg);
+
+                return Err(err);
+            },
         }
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1348,8 +1348,8 @@ impl ClientWorker {
     }
 
     async fn direct_message(&mut self, user: OwnedUserId) -> IambResult<OwnedRoomId> {
-        for room in self.client.rooms() {
-            if !is_direct(&room).await {
+        for room in self.client.joined_rooms().iter().chain(self.client.invited_rooms().iter()) {
+            if !is_direct(room).await {
                 continue;
             }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
 use matrix_sdk::ruma::OwnedRoomAliasId;
+use matrix_sdk::OwnedServerName;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -635,7 +636,7 @@ pub enum WorkerTask {
     GetInviter(MatrixRoom, ClientReply<IambResult<Option<RoomMember>>>),
     GetRoom(OwnedRoomId, ClientReply<IambResult<FetchedRoom>>),
     ResolveAlias(OwnedRoomAliasId, ClientReply<IambResult<OwnedRoomId>>),
-    JoinRoom(String, ClientReply<IambResult<OwnedRoomId>>),
+    JoinRoom(String, Vec<OwnedServerName>, ClientReply<IambResult<OwnedRoomId>>),
     Members(OwnedRoomId, ClientReply<IambResult<Vec<RoomMember>>>),
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
     TypingNotice(OwnedRoomId),
@@ -676,9 +677,10 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::JoinRoom(s, _) => {
+            WorkerTask::JoinRoom(s, via, _) => {
                 f.debug_tuple("WorkerTask::JoinRoom")
                     .field(s)
+                    .field(via)
                     .field(&format_args!("_"))
                     .finish()
             },
@@ -820,10 +822,10 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn join_room(&self, name: String) -> IambResult<OwnedRoomId> {
+    pub fn join_room(&self, name: String, via: Vec<OwnedServerName>) -> IambResult<OwnedRoomId> {
         let (reply, response) = oneshot();
 
-        self.tx.send(WorkerTask::JoinRoom(name, reply)).unwrap();
+        self.tx.send(WorkerTask::JoinRoom(name, via, reply)).unwrap();
 
         return response.recv();
     }
@@ -920,9 +922,9 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.resolve_alias(alias_id).await);
             },
-            WorkerTask::JoinRoom(room_id, reply) => {
+            WorkerTask::JoinRoom(name, via, reply) => {
                 assert!(self.initialized);
-                reply.send(self.join_room(room_id).await);
+                reply.send(self.join_room(name, via).await);
             },
             WorkerTask::GetInviter(invited, reply) => {
                 assert!(self.initialized);
@@ -1440,9 +1442,13 @@ impl ClientWorker {
         }
     }
 
-    async fn join_room(&mut self, name: String) -> IambResult<OwnedRoomId> {
+    async fn join_room(
+        &mut self,
+        name: String,
+        via: Vec<OwnedServerName>,
+    ) -> IambResult<OwnedRoomId> {
         if let Ok(alias_id) = OwnedRoomOrAliasId::from_str(name.as_str()) {
-            match self.client.join_room_by_id_or_alias(&alias_id, &[]).await {
+            match self.client.join_room_by_id_or_alias(&alias_id, &via).await {
                 Ok(resp) => Ok(resp.room_id().to_owned()),
                 Err(e) => {
                     let msg = e.to_string();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,11 +9,13 @@ use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use gethostname::gethostname;
+use matrix_sdk::OwnedServerName;
 use matrix_sdk::authentication::matrix::MatrixSession;
 use matrix_sdk::config::{RequestConfig, SyncSettings};
 use matrix_sdk::encryption::{BackupDownloadStrategy, EncryptionSettings};
 use matrix_sdk::event_handler::Ctx;
 use matrix_sdk::room::{Messages as MatrixMessages, MessagesOptions, RoomMember};
+use matrix_sdk::ruma::OwnedRoomAliasId;
 use matrix_sdk::ruma::api::client::filter::{
     FilterDefinition,
     LazyLoadOptions,
@@ -705,7 +707,8 @@ pub enum WorkerTask {
     Logout(String, ClientReply<IambResult<EditInfo>>),
     GetInviter(MatrixRoom, ClientReply<IambResult<Option<RoomMember>>>),
     GetRoom(OwnedRoomId, ClientReply<IambResult<FetchedRoom>>),
-    JoinRoom(String, ClientReply<IambResult<OwnedRoomId>>),
+    ResolveAlias(OwnedRoomAliasId, ClientReply<IambResult<OwnedRoomId>>),
+    JoinRoom(String, Vec<OwnedServerName>, ClientReply<IambResult<OwnedRoomId>>),
     Members(OwnedRoomId, ClientReply<IambResult<Vec<RoomMember>>>),
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
     TypingNotice(OwnedRoomId),
@@ -739,9 +742,16 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::JoinRoom(s, _) => {
+            WorkerTask::ResolveAlias(s, _) => {
+                f.debug_tuple("WorkerTask::ResolveAlias")
+                    .field(s)
+                    .field(&format_args!("_"))
+                    .finish()
+            },
+            WorkerTask::JoinRoom(s, via, _) => {
                 f.debug_tuple("WorkerTask::JoinRoom")
                     .field(s)
+                    .field(via)
                     .field(&format_args!("_"))
                     .finish()
             },
@@ -915,10 +925,18 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn join_room(&self, name: String) -> IambResult<OwnedRoomId> {
+    pub fn resolve_alias(&self, alias_id: OwnedRoomAliasId) -> IambResult<OwnedRoomId> {
         let (reply, response) = oneshot();
 
-        self.tx.send(WorkerTask::JoinRoom(name, reply)).unwrap();
+        self.tx.send(WorkerTask::ResolveAlias(alias_id, reply)).unwrap();
+
+        return response.recv();
+    }
+
+    pub fn join_room(&self, name: String, via: Vec<OwnedServerName>) -> IambResult<OwnedRoomId> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::JoinRoom(name, via, reply)).unwrap();
 
         return response.recv();
     }
@@ -1012,9 +1030,13 @@ impl ClientWorker {
                 self.init(store).await;
                 reply.send(());
             },
-            WorkerTask::JoinRoom(room_id, reply) => {
+            WorkerTask::ResolveAlias(alias_id, reply) => {
                 assert!(self.initialized);
-                reply.send(self.join_room(room_id).await);
+                reply.send(self.resolve_alias(alias_id).await);
+            },
+            WorkerTask::JoinRoom(name, via, reply) => {
+                assert!(self.initialized);
+                reply.send(self.join_room(name, via).await);
             },
             WorkerTask::GetInviter(invited, reply) => {
                 assert!(self.initialized);
@@ -1487,7 +1509,11 @@ impl ClientWorker {
 
     async fn get_room(&mut self, room_id: OwnedRoomId) -> IambResult<FetchedRoom> {
         if let Some(room) = self.client.get_room(&room_id) {
-            let name = room.cached_display_name().ok_or_else(|| IambError::UnknownRoom(room_id))?;
+            let name = if let Some(name) = room.cached_display_name() {
+                name
+            } else {
+                room.display_name().await.map_err(IambError::from)?
+            };
             let tags = room.tags().await.map_err(IambError::from)?;
 
             Ok((room, name, tags))
@@ -1496,9 +1522,25 @@ impl ClientWorker {
         }
     }
 
-    async fn join_room(&mut self, name: String) -> IambResult<OwnedRoomId> {
+    async fn resolve_alias(&mut self, alias_id: OwnedRoomAliasId) -> IambResult<OwnedRoomId> {
+        match self.client.resolve_room_alias(&alias_id).await {
+            Ok(resp) => Ok(resp.room_id),
+            Err(e) => {
+                let msg = e.to_string();
+                let err = UIError::Failure(msg);
+
+                return Err(err);
+            },
+        }
+    }
+
+    async fn join_room(
+        &mut self,
+        name: String,
+        via: Vec<OwnedServerName>,
+    ) -> IambResult<OwnedRoomId> {
         if let Ok(alias_id) = OwnedRoomOrAliasId::from_str(name.as_str()) {
-            match self.client.join_room_by_id_or_alias(&alias_id, &[]).await {
+            match self.client.join_room_by_id_or_alias(&alias_id, &via).await {
                 Ok(resp) => Ok(resp.room_id().to_owned()),
                 Err(e) => {
                     let msg = e.to_string();


### PR DESCRIPTION
This changes completion of matrix ids to be a matrix.to link. I don't think there is a better solution because we need a link for mentions to work.

To mention a user complete either an empty word or an `@` and the start of the username or displayname. This will complete a markdown formatted `matrix.to` link for the user. When sending the message, all `matrix.to` links are added as intentional mentions. It is not possible to mention a room.

I'm not sure where to add the documentation for mentioning a user. `iamb.1`? [iamb.chat](https://iamb.chat)?

fixes #506
fixes #418
fixes #393
fixes #249