### PR TITLE
Treat unknown html tags as plain text

### DIFF
--- a/src/message/html.rs
+++ b/src/message/html.rs
@@ -820,7 +820,8 @@ fn h2t(hdl: &Handle, state: &mut TreeGenState) -> StyleTreeChildren {
                     *c2t(&node.children.borrow(), state)
                 },
 
-                _ => return vec![],
+                // Treat unknown tags as plain text.
+                _ => *c2t(&node.children.borrow(), state),
             }
         },
 


### PR DESCRIPTION
Although the [spec](https://spec.matrix.org/v1.15/client-server-api/#mroommessage-msgtypes) recommends not rendering unknown html tags, this breaks messages that refuse to implement the spec like mautrix/discord#196. I believe it is better to provide more compatibility than to adhere to the spec.

fixes #503