### PR TITLE
Implement basic reloading

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -57,6 +57,8 @@ View a list of direct messages.
 .It Sy ":logout [user id]"
 Log out of
 .Nm .
+.It Sy ":reload"
+Reload the config.
 .It Sy ":rooms"
 View a list of joined rooms.
 .It Sy ":spaces"

--- a/src/base.rs
+++ b/src/base.rs
@@ -539,6 +539,9 @@ pub enum IambAction {
 
     /// Clear all unread messages.
     ClearUnreads,
+
+    /// Reload the config.
+    ReloadConfig,
 }
 
 impl IambAction {
@@ -592,6 +595,7 @@ impl ApplicationAction for IambAction {
             IambAction::ToggleScrollbackFocus => SequenceStatus::Break,
             IambAction::Verify(..) => SequenceStatus::Break,
             IambAction::VerifyRequest(..) => SequenceStatus::Break,
+            IambAction::ReloadConfig => SequenceStatus::Break,
         }
     }
 
@@ -608,6 +612,7 @@ impl ApplicationAction for IambAction {
             IambAction::ToggleScrollbackFocus => SequenceStatus::Atom,
             IambAction::Verify(..) => SequenceStatus::Atom,
             IambAction::VerifyRequest(..) => SequenceStatus::Atom,
+            IambAction::ReloadConfig => SequenceStatus::Atom,
         }
     }
 
@@ -624,6 +629,7 @@ impl ApplicationAction for IambAction {
             IambAction::ToggleScrollbackFocus => SequenceStatus::Ignore,
             IambAction::Verify(..) => SequenceStatus::Ignore,
             IambAction::VerifyRequest(..) => SequenceStatus::Ignore,
+            IambAction::ReloadConfig => SequenceStatus::Ignore,
         }
     }
 
@@ -640,6 +646,7 @@ impl ApplicationAction for IambAction {
             IambAction::ToggleScrollbackFocus => false,
             IambAction::Verify(..) => false,
             IambAction::VerifyRequest(..) => false,
+            IambAction::ReloadConfig => false,
         }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -695,6 +695,17 @@ fn iamb_logout(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     return Ok(step);
 }
 
+fn iamb_reload(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    if !desc.arg.text.is_empty() {
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    let clear = IambAction::ReloadConfig;
+    let step = CommandStep::Continue(clear.into(), ctx.context.clone());
+
+    return Ok(step);
+}
+
 fn add_iamb_commands(cmds: &mut ProgramCommands) {
     cmds.add_command(ProgramCommand {
         name: "cancel".into(),
@@ -801,6 +812,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "logout".into(),
         aliases: vec![],
         f: iamb_logout,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "reload".into(),
+        aliases: vec![],
+        f: iamb_reload,
     });
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ const VERSION: &str = match option_env!("VERGEN_GIT_SHA") {
     Some(_) => concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")"),
 };
 
-#[derive(Parser)]
+#[derive(Parser, Debug, Clone, Default)]
 #[clap(version = VERSION, about, long_about = None)]
 #[clap(propagate_version = true)]
 pub struct Iamb {
@@ -841,6 +841,7 @@ pub struct ApplicationSettings {
     pub dirs: DirectoryValues,
     pub layout: Layout,
     pub macros: Macros,
+    pub cli: Iamb,
 }
 
 impl ApplicationSettings {
@@ -851,6 +852,7 @@ impl ApplicationSettings {
     pub fn load(cli: Iamb) -> Result<Self, Box<dyn std::error::Error>> {
         let mut config_dir = cli
             .config_directory
+            .clone()
             .or_else(Self::get_xdg_config_home)
             .or_else(dirs::config_dir)
             .unwrap_or_else(|| {
@@ -888,45 +890,46 @@ impl ApplicationSettings {
 
         validate_profile_names(&profiles);
 
-        let (profile_name, mut profile) = if let Some(profile) = cli.profile.or(default_profile) {
-            profiles.remove_entry(&profile).unwrap_or_else(|| {
-                usage!(
-                    "No configured profile with the name {:?} in {}",
-                    profile,
-                    config_json.display()
-                );
-            })
-        } else if profiles.len() == 1 {
-            profiles.into_iter().next().unwrap()
-        } else {
-            loop {
-                println!("\nNo profile specified. Available profiles:");
-                profiles
-                    .keys()
-                    .enumerate()
-                    .for_each(|(i, name)| println!("{}: {}", i, name));
-
-                print!("Select a number or 'q' to quit: ");
-                let _ = std::io::stdout().flush();
-
-                let mut input = String::new();
-                let _ = std::io::stdin().read_line(&mut input);
-
-                if input.trim() == "q" {
+        let (profile_name, mut profile) =
+            if let Some(profile) = cli.profile.clone().or(default_profile) {
+                profiles.remove_entry(&profile).unwrap_or_else(|| {
                     usage!(
-                        "No profile specified. \
+                        "No configured profile with the name {:?} in {}",
+                        profile,
+                        config_json.display()
+                    );
+                })
+            } else if profiles.len() == 1 {
+                profiles.into_iter().next().unwrap()
+            } else {
+                loop {
+                    println!("\nNo profile specified. Available profiles:");
+                    profiles
+                        .keys()
+                        .enumerate()
+                        .for_each(|(i, name)| println!("{}: {}", i, name));
+
+                    print!("Select a number or 'q' to quit: ");
+                    let _ = std::io::stdout().flush();
+
+                    let mut input = String::new();
+                    let _ = std::io::stdin().read_line(&mut input);
+
+                    if input.trim() == "q" {
+                        usage!(
+                            "No profile specified. \
                         Please use -P or add \"default_profile\" to your configuration.\n\n\
                         For more information try '--help'",
-                    );
-                }
-                if let Ok(i) = input.trim().parse::<usize>() {
-                    if i < profiles.len() {
-                        break profiles.into_iter().nth(i).unwrap();
+                        );
                     }
+                    if let Ok(i) = input.trim().parse::<usize>() {
+                        if i < profiles.len() {
+                            break profiles.into_iter().nth(i).unwrap();
+                        }
+                    }
+                    println!("\nInvalid index.");
                 }
-                println!("\nInvalid index.");
-            }
-        };
+            };
 
         let macros = merge_maps(profile.macros.take(), macros).unwrap_or_default();
         let layout = profile.layout.take().or(layout).unwrap_or_default();
@@ -983,6 +986,7 @@ impl ApplicationSettings {
             dirs,
             layout,
             macros,
+            cli,
         };
 
         Ok(settings)

--- a/src/main.rs
+++ b/src/main.rs
@@ -573,6 +573,18 @@ impl Application {
                 None
             },
 
+            IambAction::ReloadConfig => {
+                let settings =
+                    ApplicationSettings::load(store.application.settings.cli.clone()).unwrap();
+                let mut bindings = crate::keybindings::setup_keybindings();
+                settings.setup(&mut bindings);
+                self.bindings = KeyManager::new(bindings);
+
+                store.application.settings = settings;
+
+                None
+            },
+
             IambAction::ToggleScrollbackFocus => {
                 self.screen.current_window_mut()?.focus_toggle();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -225,6 +225,7 @@ pub fn mock_settings() -> ApplicationSettings {
         dirs: mock_dirs(),
         layout: Default::default(),
         macros: HashMap::default(),
+        cli: Default::default(),
     }
 }
 


### PR DESCRIPTION
This adds `:reload` to reload some config options.

Options not currently affected:
- `log_level`
- image previews
- notifications
- ...

Further testing is needed to see which options need to be handled in code.

fixes #505