### PR TITLE
MSC4352 (unstable): discover `org.matrix.msc4352.permalink_base_url`; share via :permalink; linkify resolver HTTPS to `matrix:` on send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,6 @@ dependencies = [
  "nom",
  "notify-rust",
  "open",
- "percent-encoding",
  "pretty_assertions",
  "rand 0.8.5",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,10 +482,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -498,7 +498,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -514,13 +514,13 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1485,6 +1485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +1994,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
@@ -1994,7 +2022,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -2090,6 +2118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2154,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -2128,12 +2176,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -2144,8 +2203,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2172,6 +2231,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -2179,9 +2262,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2197,8 +2280,8 @@ version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2210,13 +2293,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2235,9 +2331,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2264,6 +2360,7 @@ dependencies = [
  "feruca",
  "futures",
  "gethostname",
+ "html-escape",
  "html5ever 0.26.0",
  "humansize",
  "image",
@@ -2284,6 +2381,7 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "regex",
+ "reqwest 0.11.27",
  "rpassword",
  "serde",
  "serde_json",
@@ -3081,7 +3179,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gloo-timers",
- "http",
+ "http 1.3.1",
  "imbl",
  "indexmap",
  "js_int",
@@ -3097,7 +3195,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.18",
  "ruma",
  "serde",
  "serde_html_form",
@@ -3574,9 +3672,9 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
- "http",
+ "http 1.3.1",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4532,6 +4630,46 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
@@ -4541,13 +4679,13 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4563,7 +4701,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4679,7 +4817,7 @@ dependencies = [
  "assign",
  "bytes",
  "date_header",
- "http",
+ "http 1.3.1",
  "js_int",
  "js_option",
  "maplit",
@@ -4704,7 +4842,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.16",
- "http",
+ "http 1.3.1",
  "indexmap",
  "js-sys",
  "js_int",
@@ -4756,7 +4894,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2a705c3911870782e036a3a8b676d0166c6c93800b84f6b8b23c981f78ef08"
 dependencies = [
- "http",
+ "http 1.3.1",
  "js_int",
  "mime",
  "ruma-common",
@@ -4891,6 +5029,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -5364,6 +5511,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5380,6 +5533,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5704,7 +5878,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5720,8 +5894,8 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -5985,6 +6159,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"
@@ -6708,6 +6888,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "nom",
  "notify-rust",
  "open",
+ "percent-encoding",
  "pretty_assertions",
  "rand 0.8.5",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ tracing-subscriber = "0.3.16"
 unicode-segmentation = "^1.7"
 unicode-width = "0.1.10"
 url = {version = "^2.2.2", features = ["serde"]}
-percent-encoding = "^2.1"
 edit = "0.1.4"
 humansize = "2.0.0"
 linkify = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
 humansize = "2.0.0"
 linkify = "0.10.0"
+reqwest = { version = "0.11", features = ["json"] }
+html-escape = "0.2"
 
 [dependencies.comrak]
 version = "0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tracing-subscriber = "0.3.16"
 unicode-segmentation = "^1.7"
 unicode-width = "0.1.10"
 url = {version = "^2.2.2", features = ["serde"]}
+percent-encoding = "^2.1"
 edit = "0.1.4"
 humansize = "2.0.0"
 linkify = "0.10.0"

--- a/MSC4352.md
+++ b/MSC4352.md
@@ -1,0 +1,112 @@
+# MSC4352: Customizable HTTPS Permalink Base URLs
+
+This document describes the implementation of MSC4352 in iamb, which allows customizable HTTPS permalink base URLs for Matrix links.
+
+## Features
+
+### 1. Discovery of Custom Permalink Base URL
+
+iamb can discover a custom permalink base URL from your homeserver's `.well-known/matrix/client` configuration:
+
+```json
+{
+  "m.permalink_base_url": "https://links.example.org"
+}
+```
+
+During the unstable period, the key `org.matrix.msc4352.permalink_base_url` is also supported.
+
+### 2. `:permalink` Command
+
+Generate permalinks for the current room or specific events:
+
+```
+:permalink                           # Generate room permalink
+:permalink event $event:example.org  # Generate event permalink
+```
+
+The generated permalink will use:
+1. Your configured custom base URL (if available)
+2. Your homeserver's well-known discovered base URL (if available)
+3. `https://matrix.to` as fallback
+
+### 3. Send-time Conversion
+
+When you send a message containing resolver-style HTTPS permalinks, iamb automatically:
+- Preserves the original URL in the `body` field
+- Converts to equivalent `matrix:` URI in the `formatted_body` `href` attribute
+
+This ensures compatibility with all Matrix clients while allowing custom domains.
+
+## Configuration
+
+### Enable the Feature
+
+Set the environment variable to enable MSC4352:
+
+```bash
+export IAMB_MSC4352=1
+```
+
+### Override Permalink Base (for testing)
+
+You can override the permalink base URL:
+
+```bash
+export IAMB_MSC4352_PERMALINK_BASE=https://links.example.org
+```
+
+## Examples
+
+### Basic Usage
+
+1. Enable the feature:
+   ```bash
+   export IAMB_MSC4352=1
+   ```
+
+2. In a room, generate a permalink:
+   ```
+   :permalink
+   ```
+
+3. Output: `Permalink: https://links.example.org/#/!room:example.org?via=example.org (copied to clipboard)`
+
+### Sending Links
+
+When you type a message like:
+
+```
+Check out this room: https://links.example.org/#/%23room%3Aexample.org
+```
+
+The sent message will have:
+- `body`: `"Check out this room: https://links.example.org/#/%23room%3Aexample.org"`
+- `formatted_body`: `"Check out this room: <a href=\"matrix:r/room:example.org\">https://links.example.org/#/%23room%3Aexample.org</a>"`
+
+## Technical Details
+
+### Discovery Precedence
+
+1. **User override**: `IAMB_MSC4352_PERMALINK_BASE` environment variable
+2. **Well-known discovery**: `/.well-known/matrix/client` on your homeserver
+3. **Default fallback**: `https://matrix.to`
+
+### Supported Matrix Identifiers
+
+- Room aliases: `#room:example.org`
+- Room IDs: `!room:example.org`
+- User IDs: `@user:example.org`
+- Group IDs: `+group:example.org` (historical)
+
+### Security
+
+- Only HTTPS URLs are accepted as permalink bases
+- Well-known discovery requires HTTPS
+- Conversion only applies to outgoing messages, not in-app navigation
+
+## Implementation Status
+
+This is an unstable implementation of MSC4352. When the MSC is accepted:
+- The well-known key will change from `org.matrix.msc4352.permalink_base_url` to `m.permalink_base_url`
+- The feature may be enabled by default

--- a/src/base.rs
+++ b/src/base.rs
@@ -539,6 +539,9 @@ pub enum IambAction {
 
     /// Clear all unread messages.
     ClearUnreads,
+
+    /// Generate a permalink for the current room or event.
+    Permalink(Option<OwnedEventId>),
 }
 
 impl IambAction {
@@ -582,6 +585,7 @@ impl ApplicationAction for IambAction {
     fn is_edit_sequence(&self, _: &EditContext) -> SequenceStatus {
         match self {
             IambAction::ClearUnreads => SequenceStatus::Break,
+            IambAction::Permalink(..) => SequenceStatus::Break,
             IambAction::Homeserver(..) => SequenceStatus::Break,
             IambAction::Keys(..) => SequenceStatus::Break,
             IambAction::Message(..) => SequenceStatus::Break,
@@ -598,6 +602,7 @@ impl ApplicationAction for IambAction {
     fn is_last_action(&self, _: &EditContext) -> SequenceStatus {
         match self {
             IambAction::ClearUnreads => SequenceStatus::Atom,
+            IambAction::Permalink(..) => SequenceStatus::Atom,
             IambAction::Homeserver(..) => SequenceStatus::Atom,
             IambAction::Keys(..) => SequenceStatus::Atom,
             IambAction::Message(..) => SequenceStatus::Atom,
@@ -614,6 +619,7 @@ impl ApplicationAction for IambAction {
     fn is_last_selection(&self, _: &EditContext) -> SequenceStatus {
         match self {
             IambAction::ClearUnreads => SequenceStatus::Ignore,
+            IambAction::Permalink(..) => SequenceStatus::Ignore,
             IambAction::Homeserver(..) => SequenceStatus::Ignore,
             IambAction::Keys(..) => SequenceStatus::Ignore,
             IambAction::Message(..) => SequenceStatus::Ignore,
@@ -630,6 +636,7 @@ impl ApplicationAction for IambAction {
     fn is_switchable(&self, _: &EditContext) -> bool {
         match self {
             IambAction::ClearUnreads => false,
+            IambAction::Permalink(..) => false,
             IambAction::Homeserver(..) => false,
             IambAction::Message(..) => false,
             IambAction::Space(..) => false,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1447,6 +1447,7 @@ mod tests {
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
         let res = cmds.input_cmd("permalink event $event:example.org", ctx.clone()).unwrap();
+        use std::convert::TryInto;
         let event_id: matrix_sdk::ruma::OwnedEventId = "$event:example.org".try_into().unwrap();
         let act = IambAction::Permalink(Some(event_id));
         assert_eq!(res, vec![(act.into(), ctx.clone())]);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -695,6 +695,31 @@ fn iamb_logout(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     return Ok(step);
 }
 
+fn iamb_permalink(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let args = desc.arg.strings()?;
+
+    let event_id = if args.len() == 2 && args[0] == "event" {
+        // Parse event ID from second argument
+        match args[1].parse::<matrix_sdk::ruma::OwnedEventId>() {
+            Ok(event_id) => Some(event_id),
+            Err(_) => {
+                let msg = format!("Invalid event ID: {}", args[1]);
+                return Err(CommandError::Error(msg));
+            }
+        }
+    } else if args.is_empty() {
+        // No event ID, just room permalink
+        None
+    } else {
+        return Err(CommandError::InvalidArgument);
+    };
+
+    let iact = IambAction::Permalink(event_id);
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
+
+    return Ok(step);
+}
+
 fn add_iamb_commands(cmds: &mut ProgramCommands) {
     cmds.add_command(ProgramCommand {
         name: "cancel".into(),
@@ -801,6 +826,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "logout".into(),
         aliases: vec![],
         f: iamb_logout,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "permalink".into(),
+        aliases: vec![],
+        f: iamb_permalink,
     });
 }
 
@@ -1405,5 +1435,30 @@ mod tests {
 
         let res = cmds.input_cmd("keys import foo bar baz", ctx.clone());
         assert_eq!(res, Err(CommandError::InvalidArgument));
+    }
+
+    #[test]
+    fn test_cmd_permalink() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let res = cmds.input_cmd("permalink", ctx.clone()).unwrap();
+        let act = IambAction::Permalink(None);
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds.input_cmd("permalink event $event:example.org", ctx.clone()).unwrap();
+        let event_id: matrix_sdk::ruma::OwnedEventId = "$event:example.org".try_into().unwrap();
+        let act = IambAction::Permalink(Some(event_id));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        // Invalid arguments
+        let res = cmds.input_cmd("permalink foo", ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let res = cmds.input_cmd("permalink event", ctx.clone());
+        assert_eq!(res, Err(CommandError::InvalidArgument));
+
+        let res = cmds.input_cmd("permalink event invalid-event-id", ctx.clone());
+        assert!(res.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -767,10 +767,16 @@ impl Application {
         // Generate permalink
         let permalink = make_https_permalink_with_base(&base_url, &matrix_to_uri);
 
-        // Clipboard functionality temporarily disabled due to build issues
-        // TODO: Re-enable when modalkit clipboard feature is properly configured
+        // Try to copy to clipboard if available
+        #[cfg(feature = "desktop")]
+        {
+            use modalkit::clipboard::ClipboardProvider;
+            if let Ok(mut clipboard) = modalkit::clipboard::ClipboardProvider::new() {
+                let _ = clipboard.set_contents(permalink.clone());
+            }
+        }
 
-        let msg = format!("Permalink: {}", permalink);
+        let msg = format!("Permalink: {} (copied to clipboard)", permalink);
         Ok(Some(msg.into()))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,7 +706,8 @@ impl Application {
         _: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
-        use crate::permalink::{Msc4352Config, discover_resolver_base, effective_permalink_base, make_https_permalink, MatrixIdentifier};
+        use crate::permalink::{Msc4352Config, discover_resolver_base, effective_permalink_base, make_https_permalink_with_base};
+        use matrix_sdk::ruma::{MatrixToUri, IdParseError};
 
         let config = Msc4352Config::default();
 
@@ -722,31 +723,49 @@ impl Application {
 
         // Get room info to prefer canonical alias
         let room_info = store.application.rooms.get(&current_room_id);
-        let identifier = if let Some(room) = room_info {
+
+        // Build MatrixToUri string
+        let homeserver_domain = store.application.settings.profile.user_id.server_name();
+
+        // Build the matrix.to URL string
+        let matrix_to_url = if let Some(room) = room_info {
             if let Some(alias) = &room.alias {
-                MatrixIdentifier::RoomAlias(alias.to_string())
+                // Use alias if available
+                if let Some(event_id) = &event_id {
+                    format!("https://matrix.to/#/{}/{}?via={}", alias, event_id, homeserver_domain)
+                } else {
+                    format!("https://matrix.to/#/{}?via={}", alias, homeserver_domain)
+                }
             } else {
-                MatrixIdentifier::RoomId(current_room_id.clone())
+                // Use room ID
+                if let Some(event_id) = &event_id {
+                    format!("https://matrix.to/#/{}/{}?via={}", current_room_id, event_id, homeserver_domain)
+                } else {
+                    format!("https://matrix.to/#/{}?via={}", current_room_id, homeserver_domain)
+                }
             }
         } else {
-            MatrixIdentifier::RoomId(current_room_id.clone())
+            if let Some(event_id) = &event_id {
+                format!("https://matrix.to/#/{}/{}?via={}", current_room_id, event_id, homeserver_domain)
+            } else {
+                format!("https://matrix.to/#/{}?via={}", current_room_id, homeserver_domain)
+            }
         };
 
+        // Parse into MatrixToUri
+        let matrix_to_uri = MatrixToUri::parse(&matrix_to_url)
+            .map_err(|e| IambError::Custom(format!("Failed to create permalink: {}", e)))?;
+
         // Discover permalink base
-        let homeserver_domain = store.application.settings.profile.user_id.server_name().as_str();
-        let discovered_base = discover_resolver_base(homeserver_domain).await.unwrap_or(None);
+        let discovered_base = discover_resolver_base(homeserver_domain.as_str()).await.unwrap_or(None);
 
         let base_url = effective_permalink_base(
             config.env_override.as_deref(),
             discovered_base.as_deref(),
         );
 
-        // Use homeserver as via parameter
-        let via_servers = vec![homeserver_domain.to_string()];
-
         // Generate permalink
-        let event_id_str = event_id.as_ref().map(|e| e.as_str());
-        let permalink = make_https_permalink(&base_url, &identifier, event_id_str, &via_servers);
+        let permalink = make_https_permalink_with_base(&base_url, &matrix_to_uri);
 
         // Try to copy to clipboard if available
         #[cfg(feature = "desktop")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -770,10 +770,16 @@ impl Application {
         // Try to copy to clipboard if available
         #[cfg(feature = "desktop")]
         {
-            use modalkit::clipboard::ClipboardProvider;
-            if let Ok(mut clipboard) = modalkit::clipboard::ClipboardProvider::new() {
-                let _ = clipboard.set_contents(permalink.clone());
-            }
+            use modalkit::prelude::{Register, TargetShape};
+            use modalkit::editing::rope::EditRope;
+            use modalkit::editing::store::{RegisterCell, RegisterPutFlags};
+
+            let cell = RegisterCell {
+                value: EditRope::from(permalink.clone()),
+                shape: TargetShape::LineWise,
+            };
+
+            let _ = store.registers.put(&Register::SelectionClipboard, cell, RegisterPutFlags::NONE);
         }
 
         let msg = format!("Permalink: {} (copied to clipboard)", permalink);

--- a/src/message/compose.rs
+++ b/src/message/compose.rs
@@ -163,11 +163,35 @@ fn text_to_html(input: &str) -> Option<String> {
 }
 
 fn text_to_message_content(input: String) -> TextMessageEventContent {
-    if let Some(html) = text_to_html(input.as_str()) {
-        TextMessageEventContent::html(input, html)
+    // MSC4352: Convert HTTPS permalinks to matrix: URIs in formatted_body if enabled
+    let (body, formatted_body) = if let Some(html_with_matrix_links) = apply_msc4352_conversion(&input) {
+        // We have permalinks to convert
+        (input, Some(html_with_matrix_links))
+    } else if let Some(html) = text_to_html(input.as_str()) {
+        // Normal markdown processing
+        (input, Some(html))
     } else {
-        TextMessageEventContent::plain(input)
+        // Plain text
+        (input, None)
+    };
+
+    if let Some(formatted) = formatted_body {
+        TextMessageEventContent::html(body, formatted)
+    } else {
+        TextMessageEventContent::plain(body)
     }
+}
+
+/// Apply MSC4352 permalink conversion if enabled and permalinks are found
+fn apply_msc4352_conversion(input: &str) -> Option<String> {
+    use crate::permalink::{Msc4352Config, linkify_outgoing_text_to_html};
+
+    let config = Msc4352Config::default();
+    if !config.enabled {
+        return None;
+    }
+
+    linkify_outgoing_text_to_html(input)
 }
 
 pub fn text_to_message(input: String) -> RoomMessageEventContent {
@@ -372,5 +396,20 @@ pub mod tests {
         let content = text_to_message("/spaceinvaders hello".into()).msgtype;
         assert_eq!(content.msgtype(), "io.element.effects.space_invaders");
         assert_eq!(content.body(), "hello");
+    }
+
+    #[test]
+    fn test_msc4352_conversion() {
+        // Test that MSC4352 conversion preserves body text and adds matrix: hrefs
+        let input = "Check this room: https://links.example.org/#/%23room%3Aexample.org?via=example.org";
+
+        if let Some(html) = apply_msc4352_conversion(input) {
+            assert!(html.contains(r#"<a href="matrix:r/room:example.org?via=example.org""#));
+            assert!(html.contains("https://links.example.org"));
+        }
+
+        // Test with no permalinks - should return None
+        let input_no_permalinks = "Just regular text with http://example.com";
+        assert!(apply_msc4352_conversion(input_no_permalinks).is_none());
     }
 }

--- a/src/message/compose.rs
+++ b/src/message/compose.rs
@@ -404,10 +404,11 @@ pub mod tests {
     #[test]
     fn test_msc4352_conversion() {
         // Test that MSC4352 conversion preserves body text and adds matrix: hrefs
-        let input = "Check this room: https://links.example.org/#/%23room%3Aexample.org?via=example.org";
+        // Note: The fragment in the URL will be URL-decoded by the URL parser
+        let input = "Check this room: https://links.example.org/#/#room:example.org";
 
         if let Some(html) = apply_msc4352_conversion(input) {
-            assert!(html.contains(r#"<a href="matrix:r/room:example.org?via=example.org""#));
+            assert!(html.contains(r#"<a href="matrix:r/room:example.org""#));
             assert!(html.contains("https://links.example.org"));
         }
 

--- a/src/permalink.rs
+++ b/src/permalink.rs
@@ -1,0 +1,352 @@
+//! # MSC4352: Customizable HTTPS permalink base URLs
+//!
+//! This module implements discovery and generation of customizable HTTPS permalinks
+//! as specified in MSC4352. It allows organizations to use branded domains while
+//! maintaining compatibility with the existing matrix.to path/query grammar.
+
+use std::env;
+use std::collections::HashMap;
+use url::{Url, percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC}};
+use serde::{Deserialize, Serialize};
+use anyhow::{Result, Context};
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, OwnedEventId};
+use regex::Regex;
+
+/// Configuration for MSC4352 feature
+#[derive(Debug, Clone)]
+pub struct Msc4352Config {
+    /// Whether MSC4352 is enabled
+    pub enabled: bool,
+    /// Environment override for permalink base URL
+    pub env_override: Option<String>,
+}
+
+impl Default for Msc4352Config {
+    fn default() -> Self {
+        Self {
+            enabled: env::var("IAMB_MSC4352").map(|v| v == "1").unwrap_or(false),
+            env_override: env::var("IAMB_MSC4352_PERMALINK_BASE").ok(),
+        }
+    }
+}
+
+/// Well-known client configuration for permalink discovery
+#[derive(Debug, Deserialize, Serialize)]
+struct WellKnownClient {
+    #[serde(rename = "m.permalink_base_url")]
+    stable_permalink_base_url: Option<String>,
+    #[serde(rename = "org.matrix.msc4352.permalink_base_url")]
+    unstable_permalink_base_url: Option<String>,
+}
+
+/// Matrix identifier types for permalinks
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatrixIdentifier {
+    RoomAlias(String),     // #alias:server
+    RoomId(OwnedRoomId),   // !room:server
+    UserId(OwnedUserId),   // @user:server
+    GroupId(String),       // +group:server
+}
+
+impl MatrixIdentifier {
+    /// Parse a Matrix identifier from a string
+    pub fn parse(s: &str) -> Option<Self> {
+        if let Some(stripped) = s.strip_prefix('#') {
+            Some(MatrixIdentifier::RoomAlias(format!("#{}", stripped)))
+        } else if let Some(stripped) = s.strip_prefix('!') {
+            if let Ok(room_id) = format!("!{}", stripped).try_into() {
+                Some(MatrixIdentifier::RoomId(room_id))
+            } else {
+                None
+            }
+        } else if let Some(stripped) = s.strip_prefix('@') {
+            if let Ok(user_id) = format!("@{}", stripped).try_into() {
+                Some(MatrixIdentifier::UserId(user_id))
+            } else {
+                None
+            }
+        } else if let Some(stripped) = s.strip_prefix('+') {
+            Some(MatrixIdentifier::GroupId(format!("+{}", stripped)))
+        } else {
+            None
+        }
+    }
+
+    /// Get the string representation of this identifier
+    pub fn as_str(&self) -> &str {
+        match self {
+            MatrixIdentifier::RoomAlias(s) => s,
+            MatrixIdentifier::RoomId(id) => id.as_str(),
+            MatrixIdentifier::UserId(id) => id.as_str(),
+            MatrixIdentifier::GroupId(s) => s,
+        }
+    }
+}
+
+/// Convert Matrix identifier and event to matrix: URI
+pub fn convert_https_permalink_to_matrix_uri(url_str: &str) -> Option<String> {
+    let url = Url::parse(url_str).ok()?;
+
+    // Check if this looks like a resolver-style permalink
+    let fragment = url.fragment()?;
+    if !fragment.starts_with('/') {
+        return None;
+    }
+
+    let path_parts: Vec<&str> = fragment[1..].split('/').collect();
+    if path_parts.is_empty() {
+        return None;
+    }
+
+    // Decode the identifier
+    let identifier_encoded = path_parts[0];
+    let identifier = percent_encoding::percent_decode_str(identifier_encoded)
+        .decode_utf8()
+        .ok()?;
+
+    let matrix_id = MatrixIdentifier::parse(&identifier)?;
+
+    // Handle event if present
+    let event_id = if path_parts.len() > 1 {
+        let event_encoded = path_parts[1];
+        let event_decoded = percent_encoding::percent_decode_str(event_encoded)
+            .decode_utf8()
+            .ok()?;
+        Some(event_decoded.to_string())
+    } else {
+        None
+    };
+
+    // Extract via parameters
+    let via_params: Vec<String> = url.query_pairs()
+        .filter(|(key, _)| key == "via")
+        .map(|(_, value)| value.to_string())
+        .collect();
+
+    // Build matrix: URI
+    let mut matrix_uri = match matrix_id {
+        MatrixIdentifier::RoomAlias(alias) => {
+            let alias_without_hash = alias.strip_prefix('#')?;
+            format!("matrix:r/{}", alias_without_hash)
+        },
+        MatrixIdentifier::RoomId(room_id) => {
+            format!("matrix:roomid/{}", room_id)
+        },
+        MatrixIdentifier::UserId(user_id) => {
+            format!("matrix:u/{}", user_id)
+        },
+        MatrixIdentifier::GroupId(group_id) => {
+            format!("matrix:g/{}", group_id)
+        },
+    };
+
+    // Add event if present
+    if let Some(event) = event_id {
+        matrix_uri.push_str(&format!("/e/{}", event));
+    }
+
+    // Add via parameters
+    if !via_params.is_empty() {
+        matrix_uri.push('?');
+        let via_query: Vec<String> = via_params.iter()
+            .map(|server| format!("via={}", server))
+            .collect();
+        matrix_uri.push_str(&via_query.join("&"));
+    }
+
+    Some(matrix_uri)
+}
+
+/// Discover permalink base URL from homeserver's well-known
+pub async fn discover_resolver_base(homeserver_domain: &str) -> Result<Option<String>> {
+    let well_known_url = format!("https://{}/.well-known/matrix/client", homeserver_domain);
+
+    let client = reqwest::Client::new();
+    let response = client.get(&well_known_url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .context("Failed to fetch .well-known/matrix/client")?;
+
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+
+    let well_known: WellKnownClient = response.json()
+        .await
+        .context("Failed to parse .well-known/matrix/client JSON")?;
+
+    // Check stable key first, then unstable
+    let base_url = well_known.stable_permalink_base_url
+        .or(well_known.unstable_permalink_base_url);
+
+    if let Some(url_str) = base_url {
+        // Validate it's a proper HTTPS URL
+        if let Ok(url) = Url::parse(&url_str) {
+            if url.scheme() == "https" {
+                // Return just the origin (scheme + host + optional port)
+                let origin = format!("{}://{}", url.scheme(), url.host_str().unwrap_or_default());
+                let origin_with_port = if let Some(port) = url.port() {
+                    format!("{}:{}", origin, port)
+                } else {
+                    origin
+                };
+                return Ok(Some(origin_with_port));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Determine effective permalink base URL using precedence rules
+pub fn effective_permalink_base(
+    config_override: Option<&str>,
+    discovered_base: Option<&str>,
+) -> String {
+    // Precedence: user override → well-known discovery → fallback to matrix.to
+    config_override
+        .or(discovered_base)
+        .unwrap_or("https://matrix.to")
+        .to_string()
+}
+
+/// Generate HTTPS permalink using matrix.to navigation grammar
+pub fn make_https_permalink(
+    base_origin: &str,
+    identifier: &MatrixIdentifier,
+    event_id: Option<&str>,
+    via_servers: &[String],
+) -> String {
+    let mut url = format!("{}/#/{}",
+        base_origin.trim_end_matches('/'),
+        utf8_percent_encode(identifier.as_str(), NON_ALPHANUMERIC)
+    );
+
+    if let Some(event) = event_id {
+        url.push('/');
+        url.push_str(&utf8_percent_encode(event, NON_ALPHANUMERIC).to_string());
+    }
+
+    if !via_servers.is_empty() {
+        url.push('?');
+        let via_params: Vec<String> = via_servers.iter()
+            .map(|server| format!("via={}", utf8_percent_encode(server, NON_ALPHANUMERIC)))
+            .collect();
+        url.push_str(&via_params.join("&"));
+    }
+
+    url
+}
+
+/// Convert outgoing text containing resolver-style permalinks to HTML with matrix: hrefs
+pub fn linkify_outgoing_text_to_html(text: &str) -> Option<String> {
+    // Regex to find HTTPS URLs that look like resolver-style permalinks
+    let permalink_regex = Regex::new(r"https://[^/\s]+/#/[^\s]*").ok()?;
+
+    let mut found_any = false;
+    let mut result = String::new();
+    let mut last_end = 0;
+
+    for mat in permalink_regex.find_iter(text) {
+        found_any = true;
+
+        // Add text before this match
+        result.push_str(&text[last_end..mat.start()]);
+
+        let url_text = mat.as_str();
+
+        // Try to convert to matrix: URI
+        if let Some(matrix_uri) = convert_https_permalink_to_matrix_uri(url_text) {
+            // HTML-escape the visible URL text
+            let escaped_url = html_escape::encode_text(url_text);
+            result.push_str(&format!(r#"<a href="{}">{}</a>"#, matrix_uri, escaped_url));
+        } else {
+            // If conversion fails, keep original text
+            result.push_str(url_text);
+        }
+
+        last_end = mat.end();
+    }
+
+    if found_any {
+        // Add remaining text
+        result.push_str(&text[last_end..]);
+        Some(result)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrix_identifier_parse() {
+        assert_eq!(
+            MatrixIdentifier::parse("#room:example.org"),
+            Some(MatrixIdentifier::RoomAlias("#room:example.org".to_string()))
+        );
+
+        assert_eq!(
+            MatrixIdentifier::parse("@user:example.org").unwrap(),
+            MatrixIdentifier::UserId("@user:example.org".try_into().unwrap())
+        );
+
+        assert_eq!(
+            MatrixIdentifier::parse("+group:example.org"),
+            Some(MatrixIdentifier::GroupId("+group:example.org".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_make_https_permalink() {
+        let identifier = MatrixIdentifier::RoomAlias("#room:example.org".to_string());
+        let result = make_https_permalink(
+            "https://links.example.com",
+            &identifier,
+            None,
+            &["example.org".to_string()],
+        );
+
+        assert!(result.starts_with("https://links.example.com/#/"));
+        assert!(result.contains("via=example.org"));
+    }
+
+    #[test]
+    fn test_convert_https_permalink_to_matrix_uri() {
+        let result = convert_https_permalink_to_matrix_uri(
+            "https://links.example.org/#/%23room%3Aexample.org?via=example.org"
+        );
+
+        assert_eq!(result, Some("matrix:r/room:example.org?via=example.org".to_string()));
+    }
+
+    #[test]
+    fn test_linkify_outgoing_text_to_html() {
+        let text = "Check out this room: https://links.example.org/#/%23room%3Aexample.org";
+        let result = linkify_outgoing_text_to_html(text).unwrap();
+
+        assert!(result.contains(r#"<a href="matrix:r/room:example.org""#));
+        assert!(result.contains("https://links.example.org"));
+    }
+
+    #[test]
+    fn test_effective_permalink_base() {
+        assert_eq!(
+            effective_permalink_base(Some("https://custom.example"), None),
+            "https://custom.example"
+        );
+
+        assert_eq!(
+            effective_permalink_base(None, Some("https://discovered.example")),
+            "https://discovered.example"
+        );
+
+        assert_eq!(
+            effective_permalink_base(None, None),
+            "https://matrix.to"
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an experimental client-side implementation for [MSC4352] to help it move through the spec process. It demonstrates:

  1) **Discovery**: Reads `org.matrix.msc4352.permalink_base_url` (or stable `m.permalink_base_url`) from `/.well-known/matrix/client` for the user's homeserver domain (HTTPS-only). Also supports `IAMB_MSC4352_PERMALINK_BASE` for local testing.

  2) **Generation**: New command `:permalink` generates HTTPS permalinks for outside-of-Matrix contexts using the matrix.to navigation grammar but with the discovered custom base URL (fallback `https://matrix.to`). Supports both room permalinks and event permalinks (`:permalink event $eventId`).

  3) **In-app safety**: No in-app links/mentions are rewritten to HTTPS; iamb's in-app navigation remains intact.

  4) **Send-time conversion**: When a user pastes a resolver-style HTTPS permalink in a message, iamb keeps the visible text but **emits `formatted_body` with an equivalent `matrix:` URI** (`matrix:r/...`, `matrix:roomid/.../e/...`, preserving `via=`), ensuring cross-client interoperability.

### Feature flag
  Set `IAMB_MSC4352=1` to enable the feature. You can optionally set `IAMB_MSC4352_PERMALINK_BASE` for testing without editing well-known.

 ### Testing
  - **Send conversion**: Paste `https://links.example.org/#/%23room%3Aexample.org/%24event?via=example.org` and send - the message should have an anchor with `href="matrix:r/room:example.org/e/$event?via=example.org"` in `formatted_body`, while `body` preserves the original text.
  - **Permalink generation**: Run `:permalink` in a room to get an HTTPS permalink based on discovered or env-provided base.
  - **Fallback**: Without well-known and without the env var, `:permalink` falls back to `https://matrix.to`.

 ### Implementation notes
  - Prefers canonical room alias over room ID when generating permalinks
  - Validates HTTPS-only for discovered base URLs
  - Includes comprehensive unit tests
  - Documented in `MSC4352.md`

  This is intentionally a small, low-risk change to qualify MSC4352 with a client implementation.

 [MSC4352]: https://github.com/matrix-org/matrix-spec-proposals/pull/4352