### PR TITLE
Handle ambiguous display names conforming to spec

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -918,8 +918,8 @@ pub struct RoomInfo {
     /// Users currently typing in this room, and when we received notification of them doing so.
     pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
 
-    /// The display names for users in this room.
-    pub display_names: HashMap<OwnedUserId, String>,
+    /// The display names for users in this room with a flag whether they are ambiguous.
+    pub display_names: HashMap<OwnedUserId, (String, bool)>,
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,

--- a/src/base.rs
+++ b/src/base.rs
@@ -2,7 +2,7 @@
 //!
 //! The types defined here get used throughout iamb.
 use std::borrow::Cow;
-use std::collections::hash_map::IntoIter;
+use std::collections::hash_map::{Entry, IntoIter};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt::{self, Display};
@@ -878,6 +878,91 @@ impl UnreadInfo {
     }
 }
 
+/// Track the display names for users and render any needed disambiguation for
+/// those with overlapping names.
+#[derive(Default)]
+pub struct DisplayNameStore {
+    by_ids: HashMap<OwnedUserId, String>,
+    by_names: HashMap<String, HashSet<OwnedUserId>>,
+}
+
+impl DisplayNameStore {
+    /// Update the `HashSet` associated with a given displayname.
+    ///
+    /// Note that this *could* be done more elegantly using the Entry API, but
+    /// is intentionally written in a way to avoid cloning conflicting display
+    /// names.
+    fn set_by_name(&mut self, user_id: OwnedUserId, name: &str) {
+        if let Some(existing) = self.by_names.get_mut(name) {
+            existing.insert(user_id);
+        } else {
+            self.by_names.insert(name.to_owned(), HashSet::from([user_id]));
+        }
+    }
+
+    /// Track a new user ID to displayname mapping, or unset any existing ones.
+    pub fn set(&mut self, user_id: OwnedUserId, name: Option<String>) {
+        if let Some(name) = name.as_deref() {
+            self.set_by_name(user_id.clone(), name);
+        }
+
+        let previous = match (self.by_ids.entry(user_id), name) {
+            // Nothing to do!
+            (Entry::Vacant(_), None) => None,
+
+            // Setting initial display name for user:
+            (Entry::Vacant(v), Some(name)) => {
+                v.insert(name);
+                None
+            },
+
+            // Unsetting display name:
+            (Entry::Occupied(o), None) => Some(o.remove_entry()),
+
+            // Replacing existing name:
+            (Entry::Occupied(mut o), Some(name)) => {
+                if o.get() == &name {
+                    None
+                } else {
+                    Some((o.key().clone(), o.insert(name)))
+                }
+            },
+        };
+
+        let Some((user_id, previous)) = previous else {
+            return;
+        };
+
+        let Some(users) = self.by_names.get_mut(&previous) else {
+            return;
+        };
+
+        users.remove(&user_id);
+
+        if users.is_empty() {
+            self.by_names.remove(&previous);
+        }
+    }
+
+    pub fn get<'a>(&'a self, user_id: &UserId) -> Option<Cow<'a, str>> {
+        let displayname = self.by_ids.get(user_id)?;
+        let users = self.by_names.get(displayname)?;
+
+        if !users.contains(user_id) {
+            // Internal consistency error? Assume no display name:
+            return None;
+        }
+
+        if users.len() == 1 {
+            // Unambiguous!
+            return Some(Cow::Borrowed(displayname.as_str()));
+        }
+
+        // Ambiguous username, so include unique user ID:
+        Some(Cow::Owned(format!("{displayname} ({user_id})")))
+    }
+}
+
 /// Information about room's the user's joined.
 pub struct RoomInfo {
     /// The display name for this room.
@@ -918,8 +1003,8 @@ pub struct RoomInfo {
     /// Users currently typing in this room, and when we received notification of them doing so.
     pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
 
-    /// The display names for users in this room with a flag whether they are ambiguous.
-    pub display_names: HashMap<OwnedUserId, (String, bool)>,
+    /// The display names for users in this room.
+    pub display_names: DisplayNameStore,
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
@@ -2407,5 +2492,61 @@ pub mod tests {
         let mut cursor = Cursor::new(0, 15);
         let res = complete_cmdbar(&text, &mut cursor, &store);
         assert_eq!(res, users);
+    }
+
+    #[test]
+    fn test_ambiguous_displaynames() {
+        let mut store = DisplayNameStore::default();
+
+        store.set(TEST_USER1.clone(), Some("John".into()));
+        store.set(TEST_USER2.clone(), Some("John".into()));
+        store.set(TEST_USER3.clone(), Some("Jane".into()));
+        store.set(TEST_USER4.clone(), Some("Alice".into()));
+        store.set(TEST_USER5.clone(), Some("Bob".into()));
+
+        // TEST_USER1 and TEST_USER2 are both ambiguous, while the other are unambiguous:
+        assert_eq!(store.get(&TEST_USER1).unwrap().as_ref(), "John (@user1:example.com)");
+        assert_eq!(store.get(&TEST_USER2).unwrap().as_ref(), "John (@user2:example.com)");
+        assert_eq!(store.get(&TEST_USER3).unwrap().as_ref(), "Jane");
+        assert_eq!(store.get(&TEST_USER4).unwrap().as_ref(), "Alice");
+        assert_eq!(store.get(&TEST_USER5).unwrap().as_ref(), "Bob");
+
+        // TEST_USER1 becomes unambiguous when TEST_USER2 changes:
+        store.set(TEST_USER2.clone(), Some("Eve".into()));
+        assert_eq!(store.get(&TEST_USER1).unwrap().as_ref(), "John");
+        assert_eq!(store.get(&TEST_USER2).unwrap().as_ref(), "Eve");
+        assert_eq!(store.get(&TEST_USER3).unwrap().as_ref(), "Jane");
+        assert_eq!(store.get(&TEST_USER4).unwrap().as_ref(), "Alice");
+        assert_eq!(store.get(&TEST_USER5).unwrap().as_ref(), "Bob");
+
+        // TEST_USER5 becomes ambiguous when TEST_USER2 once again changes their name to match:
+        store.set(TEST_USER2.clone(), Some("Bob".into()));
+        assert_eq!(store.get(&TEST_USER1).unwrap().as_ref(), "John");
+        assert_eq!(store.get(&TEST_USER2).unwrap().as_ref(), "Bob (@user2:example.com)");
+        assert_eq!(store.get(&TEST_USER3).unwrap().as_ref(), "Jane");
+        assert_eq!(store.get(&TEST_USER4).unwrap().as_ref(), "Alice");
+        assert_eq!(store.get(&TEST_USER5).unwrap().as_ref(), "Bob (@user5:example.com)");
+
+        // Now "Everyone is John":
+        store.set(TEST_USER2.clone(), Some("John".into()));
+        store.set(TEST_USER3.clone(), Some("John".into()));
+        store.set(TEST_USER4.clone(), Some("John".into()));
+        store.set(TEST_USER5.clone(), Some("John".into()));
+        assert_eq!(store.get(&TEST_USER1).unwrap().as_ref(), "John (@user1:example.com)");
+        assert_eq!(store.get(&TEST_USER2).unwrap().as_ref(), "John (@user2:example.com)");
+        assert_eq!(store.get(&TEST_USER3).unwrap().as_ref(), "John (@user3:example.com)");
+        assert_eq!(store.get(&TEST_USER4).unwrap().as_ref(), "John (@user4:example.com)");
+        assert_eq!(store.get(&TEST_USER5).unwrap().as_ref(), "John (@user5:example.com)");
+
+        // 2-5 unset their displayname:
+        store.set(TEST_USER2.clone(), None);
+        store.set(TEST_USER3.clone(), None);
+        store.set(TEST_USER4.clone(), None);
+        store.set(TEST_USER5.clone(), None);
+        assert_eq!(store.get(&TEST_USER1).unwrap().as_ref(), "John");
+        assert_eq!(store.get(&TEST_USER2), None);
+        assert_eq!(store.get(&TEST_USER3), None);
+        assert_eq!(store.get(&TEST_USER4), None);
+        assert_eq!(store.get(&TEST_USER5), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1047,8 +1047,12 @@ impl ApplicationSettings {
             (None, UserDisplayStyle::Username) => Cow::Borrowed(user_id.as_str()),
             (None, UserDisplayStyle::LocalPart) => Cow::Borrowed(user_id.localpart()),
             (None, UserDisplayStyle::DisplayName) => {
-                if let Some(display) = info.display_names.get(user_id) {
-                    Cow::Borrowed(display.as_str())
+                if let Some((name, ambiguous)) = info.display_names.get(user_id) {
+                    if *ambiguous {
+                        Cow::Owned(format!("{}({})", name, user_id))
+                    } else {
+                        Cow::Borrowed(name.as_str())
+                    }
                 } else {
                     Cow::Borrowed(user_id.as_str())
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1047,12 +1047,8 @@ impl ApplicationSettings {
             (None, UserDisplayStyle::Username) => Cow::Borrowed(user_id.as_str()),
             (None, UserDisplayStyle::LocalPart) => Cow::Borrowed(user_id.localpart()),
             (None, UserDisplayStyle::DisplayName) => {
-                if let Some((name, ambiguous)) = info.display_names.get(user_id) {
-                    if *ambiguous {
-                        Cow::Owned(format!("{}({})", name, user_id))
-                    } else {
-                        Cow::Borrowed(name.as_str())
-                    }
+                if let Some(name) = info.display_names.get(user_id) {
+                    name
                 } else {
                     Cow::Borrowed(user_id.as_str())
                 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1563,7 +1563,7 @@ impl ListItem<IambInfo> for MemberItem {
         if let Some(name) = name {
             spans.push(Span::styled(name, style));
             parens = true;
-        } else if let Some(display) = info.display_names.get(user_id) {
+        } else if let Some((display, _)) = info.display_names.get(user_id) {
             spans.push(Span::styled(display.clone(), style));
             parens = true;
         }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1563,8 +1563,8 @@ impl ListItem<IambInfo> for MemberItem {
         if let Some(name) = name {
             spans.push(Span::styled(name, style));
             parens = true;
-        } else if let Some((display, _)) = info.display_names.get(user_id) {
-            spans.push(Span::styled(display.clone(), style));
+        } else if let Some(display) = info.display_names.get(user_id) {
+            spans.push(Span::styled(display.into_owned(), style));
             parens = true;
         }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -22,7 +22,6 @@ use url::Url;
 use matrix_sdk::{
     authentication::matrix::MatrixSession,
     config::{RequestConfig, SyncSettings},
-    deserialized_responses::DisplayName,
     encryption::{
         verification::{SasVerification, Verification},
         BackupDownloadStrategy,
@@ -430,13 +429,47 @@ fn members_insert(
         let info = rooms.get_or_default(room_id);
 
         for member in members {
-            let user_id = member.user_id();
-            let display_name =
-                member.display_name().map_or(user_id.to_string(), |str| str.to_string());
-            info.display_names.insert(user_id.to_owned(), display_name);
+            let user_id = member.user_id().to_owned();
+            let name = member.display_name().map(|s| s.to_owned());
+            member_set_display_name(info, user_id, name);
         }
     }
     // else ???
+}
+
+fn member_set_display_name(info: &mut RoomInfo, user_id: OwnedUserId, name: Option<String>) {
+    let to_remove;
+    if let Some(display_name) = name {
+        let ambiguous = info.display_names.iter_mut().any(|(_, (name, is_ambiguous))| {
+            if name == &display_name {
+                *is_ambiguous = true;
+                true
+            } else {
+                false
+            }
+        });
+
+        to_remove = info.display_names.insert(user_id, (display_name, ambiguous));
+    } else {
+        to_remove = info.display_names.remove(&user_id);
+    }
+    if let Some((display_name, _)) = to_remove {
+        let mut names: Vec<_> = info
+            .display_names
+            .iter_mut()
+            .filter_map(|(_, (name, is_ambiguous))| {
+                if name == &display_name {
+                    Some(is_ambiguous)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if names.len() == 1 {
+            *names[0] = false;
+        }
+    }
 }
 
 async fn load_older_forever(client: &Client, store: &AsyncProgramStore) {
@@ -1102,34 +1135,15 @@ impl ClientWorker {
         );
 
         let _ = self.client.add_event_handler(
-            |ev: OriginalSyncRoomMemberEvent,
-             room: MatrixRoom,
-             client: Client,
-             store: Ctx<AsyncProgramStore>| {
+            |ev: OriginalSyncRoomMemberEvent, room: MatrixRoom, store: Ctx<AsyncProgramStore>| {
                 async move {
                     let room_id = room.room_id();
                     let user_id = ev.state_key;
 
-                    let ambiguous_name = DisplayName::new(
-                        ev.content.displayname.as_deref().unwrap_or_else(|| user_id.as_str()),
-                    );
-                    let ambiguous = client
-                        .state_store()
-                        .get_users_with_display_name(room_id, &ambiguous_name)
-                        .await
-                        .map(|users| users.len() > 1)
-                        .unwrap_or_default();
-
                     let mut locked = store.lock().await;
                     let info = locked.application.get_room_info(room_id.to_owned());
 
-                    if ambiguous {
-                        info.display_names.remove(&user_id);
-                    } else if let Some(display) = ev.content.displayname {
-                        info.display_names.insert(user_id, display);
-                    } else {
-                        info.display_names.remove(&user_id);
-                    }
+                    member_set_display_name(info, user_id, ev.content.displayname);
                 }
             },
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -431,45 +431,10 @@ fn members_insert(
         for member in members {
             let user_id = member.user_id().to_owned();
             let name = member.display_name().map(|s| s.to_owned());
-            member_set_display_name(info, user_id, name);
+            info.display_names.set(user_id, name);
         }
     }
     // else ???
-}
-
-fn member_set_display_name(info: &mut RoomInfo, user_id: OwnedUserId, name: Option<String>) {
-    let to_remove;
-    if let Some(display_name) = name {
-        let ambiguous = info.display_names.iter_mut().any(|(_, (name, is_ambiguous))| {
-            if name == &display_name {
-                *is_ambiguous = true;
-                true
-            } else {
-                false
-            }
-        });
-
-        to_remove = info.display_names.insert(user_id, (display_name, ambiguous));
-    } else {
-        to_remove = info.display_names.remove(&user_id);
-    }
-    if let Some((display_name, _)) = to_remove {
-        let mut names: Vec<_> = info
-            .display_names
-            .iter_mut()
-            .filter_map(|(_, (name, is_ambiguous))| {
-                if name == &display_name {
-                    Some(is_ambiguous)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if names.len() == 1 {
-            *names[0] = false;
-        }
-    }
 }
 
 async fn load_older_forever(client: &Client, store: &AsyncProgramStore) {
@@ -1142,8 +1107,7 @@ impl ClientWorker {
 
                     let mut locked = store.lock().await;
                     let info = locked.application.get_room_info(room_id.to_owned());
-
-                    member_set_display_name(info, user_id, ev.content.displayname);
+                    info.display_names.set(user_id, ev.content.displayname);
                 }
             },
         );


### PR DESCRIPTION
The [spec](https://spec.matrix.org/v1.16/client-server-api/#calculating-the-display-name-for-a-user) says that ambiguous display names should be displayed and disambiguated by user id.