### PR TITLE
Add MSC4357 live messaging support

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -178,6 +178,7 @@ pub enum MessageAction {
     /// and error when it doesn't recognize it. The second [bool] argument forces it to be
     /// interpreted literally when it is `true`.
     Unreact(Option<String>, bool),
+
 }
 
 /// An action taken in the currently selected space.
@@ -898,6 +899,9 @@ pub struct RoomInfo {
     /// A map of message identifiers to thread replies.
     threads: HashMap<OwnedEventId, Messages>,
 
+    /// Set of event IDs for messages that are live (being typed)
+    pub live_message_ids: HashSet<OwnedEventId>,
+
     /// Whether the scrollback for this room is currently being fetched.
     pub fetching: bool,
 
@@ -929,6 +933,7 @@ impl Default for RoomInfo {
             user_receipts: Default::default(),
             reactions: Default::default(),
             threads: Default::default(),
+            live_message_ids: Default::default(),
             fetching: Default::default(),
             fetch_id: Default::default(),
             fetch_last: Default::default(),
@@ -1087,6 +1092,7 @@ impl RoomInfo {
         let event_id = msg.event_id;
         let new_msgtype = msg.new_content;
 
+
         let Some(EventLocation::Message(thread, key)) = self.keys.get(&event_id) else {
             return;
         };
@@ -1103,9 +1109,12 @@ impl RoomInfo {
             return;
         };
 
+        // Update live status based on live_message_ids
+        msg.is_live = self.live_message_ids.contains(&event_id);
+
         match &mut msg.event {
             MessageEvent::Original(orig) => {
-                orig.content.apply_replacement(new_msgtype);
+                orig.content.apply_replacement(new_msgtype.clone());
             },
             MessageEvent::Local(_, content) => {
                 content.apply_replacement(new_msgtype);
@@ -1165,22 +1174,37 @@ impl RoomInfo {
         let event_id = msg.event_id().to_owned();
         let key = (msg.origin_server_ts().into(), event_id.clone());
 
+        // Check if this is a live message
+        let is_live = self.live_message_ids.contains(&event_id);
+
         let loc = EventLocation::Message(None, key.clone());
-        self.keys.insert(event_id, loc);
-        self.messages.insert_message(key, msg);
+        self.keys.insert(event_id.clone(), loc);
+
+        // Convert to Message and set is_live flag if needed
+        let mut message: Message = msg.into();
+        message.is_live = is_live;
+
+        self.messages.insert_message(key, message);
     }
 
     fn insert_thread(&mut self, msg: RoomMessageEvent, thread_root: OwnedEventId) {
         let event_id = msg.event_id().to_owned();
         let key = (msg.origin_server_ts().into(), event_id.clone());
 
+        // Check if this is a live message
+        let is_live = self.live_message_ids.contains(&event_id);
+
         let replies = self
             .threads
             .entry(thread_root.clone())
             .or_insert_with(|| Messages::thread(thread_root.clone()));
         let loc = EventLocation::Message(Some(thread_root), key.clone());
-        self.keys.insert(event_id, loc);
-        replies.insert_message(key, msg);
+        self.keys.insert(event_id.clone(), loc);
+
+        let mut message: Message = msg.into();
+        message.is_live = is_live;
+
+        replies.insert_message(key, message);
     }
 
     /// Insert a new message event.

--- a/src/message/live.rs
+++ b/src/message/live.rs
@@ -1,0 +1,379 @@
+//! Live messaging support for Matrix (MSC4357)
+//!
+//! This module implements live message composition where messages are sent
+//! as they're being typed and continuously updated until finalized.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use matrix_sdk::ruma::{EventId, OwnedEventId, OwnedRoomId};
+use serde_json::{json, Value};
+
+/// Minimum interval between live message updates
+const MIN_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Rate limit window for tracking update frequency
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+/// Maximum updates allowed per window
+const MAX_UPDATES_PER_WINDOW: usize = 30;
+
+/// The live message marker key used in event content
+pub const LIVE_MESSAGE_MARKER: &str = "org.matrix.msc4357.live";
+
+/// Live message session state
+#[derive(Debug, Clone)]
+pub struct LiveMessageSession {
+    /// The event ID of the initial message
+    pub event_id: OwnedEventId,
+
+    /// Current content of the message
+    pub current_content: String,
+
+    /// Timestamp of the last update sent
+    pub last_update: Instant,
+
+    /// Number of updates sent for this message
+    pub update_count: usize,
+
+    /// Whether this session is still active
+    pub is_active: bool,
+}
+
+/// Rate limiter to prevent excessive updates
+#[derive(Debug)]
+struct RateLimiter {
+    /// Track update counts per room
+    update_counts: HashMap<OwnedRoomId, Vec<Instant>>,
+}
+
+impl RateLimiter {
+    fn new() -> Self {
+        Self {
+            update_counts: HashMap::new(),
+        }
+    }
+
+    fn can_send_update(&mut self, room_id: &OwnedRoomId) -> bool {
+        let now = Instant::now();
+        let updates = self.update_counts.entry(room_id.clone()).or_default();
+
+        // Remove old updates outside the window
+        updates.retain(|&t| now.duration_since(t) < RATE_LIMIT_WINDOW);
+
+        // Check if we're under the limit
+        updates.len() < MAX_UPDATES_PER_WINDOW
+    }
+
+    fn record_update(&mut self, room_id: OwnedRoomId) {
+        let updates = self.update_counts.entry(room_id).or_default();
+        updates.push(Instant::now());
+    }
+}
+
+/// Manager for live message sessions
+#[derive(Debug)]
+pub struct LiveMessageManager {
+    /// Active live message sessions per room
+    sessions: HashMap<OwnedRoomId, LiveMessageSession>,
+
+    /// Rate limiter for updates
+    rate_limiter: RateLimiter,
+
+    /// Whether live messaging is enabled
+    pub enabled: bool,
+}
+
+impl LiveMessageManager {
+    /// Create a new live message manager
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            rate_limiter: RateLimiter::new(),
+            enabled: false,
+        }
+    }
+
+    /// Start a new live message session
+    pub fn start_session(&mut self, room_id: OwnedRoomId, initial_content: String) -> Option<LiveMessageSession> {
+        tracing::info!("[LIVE] LiveMessageManager::start_session called, enabled={}", self.enabled);
+        if !self.enabled {
+            tracing::warn!("[LIVE] LiveMessageManager is disabled, cannot start session");
+            return None;
+        }
+
+        // Generate temporary event ID - use a valid format
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let temp_event_id = format!("$temp_{}_{}", timestamp, room_id.as_str().replace(":", "_"));
+        let event_id = temp_event_id.parse().ok()?;
+
+        let session = LiveMessageSession {
+            event_id,
+            current_content: initial_content,
+            last_update: Instant::now(),
+            update_count: 0,
+            is_active: true,
+        };
+
+        self.sessions.insert(room_id.clone(), session.clone());
+        self.rate_limiter.record_update(room_id);
+
+        Some(session)
+    }
+
+    /// Set the real event ID received from server
+    pub fn set_event_id(&mut self, room_id: &OwnedRoomId, event_id: OwnedEventId) {
+        if let Some(session) = self.sessions.get_mut(room_id) {
+            session.event_id = event_id;
+        }
+    }
+
+    /// Check if we still have a temporary event ID
+    pub fn has_temp_event_id(&self, room_id: &OwnedRoomId) -> bool {
+        self.sessions
+            .get(room_id)
+            .map(|s| s.event_id.as_str().starts_with("$temp_") || s.event_id.as_str().contains("local"))
+            .unwrap_or(false)
+    }
+
+    /// Update an existing session
+    pub fn update_session(&mut self, room_id: &OwnedRoomId, new_content: String) -> Option<LiveMessageSession> {
+        if !self.enabled {
+            return None;
+        }
+
+        let session = self.sessions.get_mut(room_id)?;
+
+        if !session.is_active {
+            return None;
+        }
+
+        session.current_content = new_content;
+        session.last_update = Instant::now();
+        session.update_count += 1;
+
+        self.rate_limiter.record_update(room_id.clone());
+
+        Some(session.clone())
+    }
+
+    /// Check if we should send an update now
+    pub fn should_send_update(&mut self, room_id: &OwnedRoomId) -> bool {
+        if !self.enabled {
+            return false;
+        }
+
+        let session = match self.sessions.get(room_id) {
+            Some(s) if s.is_active => s,
+            _ => return false,
+        };
+
+        // Don't send if we have a temp ID
+        if self.has_temp_event_id(room_id) {
+            return false;
+        }
+
+        // Check minimum interval
+        if session.last_update.elapsed() < MIN_UPDATE_INTERVAL {
+            return false;
+        }
+
+        // Check rate limit
+        self.rate_limiter.can_send_update(room_id)
+    }
+
+    /// Get the current session for a room
+    pub fn get_session(&self, room_id: &OwnedRoomId) -> Option<&LiveMessageSession> {
+        self.sessions.get(room_id)
+    }
+
+    /// End a live message session
+    pub fn end_session(&mut self, room_id: &OwnedRoomId) -> Option<LiveMessageSession> {
+        self.sessions.remove(room_id)
+    }
+}
+
+/// Create initial live message JSON with fields
+pub fn create_initial_live_message_with_fields(
+    content: &str,
+    custom_fields: Option<Value>,
+) -> Value {
+    let mut json = json!({
+        "msgtype": "m.text",
+        "body": content,
+        LIVE_MESSAGE_MARKER: true
+    });
+
+    if let Some(custom) = custom_fields {
+        if let Some(obj) = json.as_object_mut() {
+            if let Some(custom_obj) = custom.as_object() {
+                for (key, value) in custom_obj {
+                    if !matches!(key.as_str(), "msgtype" | "body") {
+                        obj.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    json
+}
+
+/// Create a live message update JSON with custom fields
+pub fn create_live_update_json_with_fields(
+    original_event_id: &EventId,
+    new_content: &str,
+    is_final: bool,
+    custom_fields: Option<Value>,
+) -> Value {
+    let mut json = json!({
+        "msgtype": "m.text",
+        "body": format!("* {}", new_content),
+        "m.new_content": {
+            "msgtype": "m.text",
+            "body": new_content,
+        },
+        "m.relates_to": {
+            "rel_type": "m.replace",
+            "event_id": original_event_id.to_string(),
+        }
+    });
+
+    // Add live marker to new_content unless it's final
+    if !is_final {
+        if let Some(new_content_obj) = json["m.new_content"].as_object_mut() {
+            new_content_obj.insert(LIVE_MESSAGE_MARKER.to_string(), json!(true));
+            tracing::debug!("[LIVE JSON] Added live marker to update");
+        }
+    } else {
+        tracing::info!("[LIVE JSON] Creating FINAL update WITHOUT live marker");
+    }
+
+    // Add custom fields if provided
+    if let Some(custom) = custom_fields {
+        if let Some(obj) = json.as_object_mut() {
+            if let Some(custom_obj) = custom.as_object() {
+                for (key, value) in custom_obj {
+                    if !matches!(key.as_str(), "msgtype" | "body" | "m.new_content" | "m.relates_to") {
+                        obj.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    json
+}
+
+/// Send a new live message with custom fields
+pub async fn send_live_message_with_custom_fields(
+    room: &matrix_sdk::Room,
+    content: &str,
+    custom_fields: Option<Value>,
+) -> Result<matrix_sdk::ruma::OwnedEventId, matrix_sdk::Error> {
+    let json = create_initial_live_message_with_fields(content, custom_fields);
+
+    // Log for debugging
+    tracing::debug!("Sending initial live message JSON: {}", serde_json::to_string_pretty(&json).unwrap_or_default());
+
+    let resp = room.send_raw("m.room.message", json).await?;
+    Ok(resp.event_id)
+}
+
+/// Send a live update with custom fields
+pub async fn send_live_update_with_custom_fields(
+    room: &matrix_sdk::Room,
+    original_event_id: &EventId,
+    new_content: &str,
+    is_final: bool,
+    custom_fields: Option<Value>,
+) -> Result<matrix_sdk::ruma::OwnedEventId, matrix_sdk::Error> {
+    let json = create_live_update_json_with_fields(
+        original_event_id,
+        new_content,
+        is_final,
+        custom_fields,
+    );
+
+    // Log for debugging
+    tracing::debug!("Sending live update JSON: {}", serde_json::to_string_pretty(&json).unwrap_or_default());
+
+    let resp = room.send_raw("m.room.message", json).await?;
+    Ok(resp.event_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_initial_live_message() {
+        let content = "Hello world";
+        let json = create_initial_live_message_with_fields(content, None);
+
+        // Check that the JSON has the required fields
+        assert_eq!(json["msgtype"], "m.text");
+        assert_eq!(json["body"], "Hello world");
+        assert_eq!(json["org.matrix.msc4357.live"], true);
+    }
+
+    #[test]
+    fn test_create_live_update_with_marker() {
+        use std::str::FromStr;
+        let event_id = OwnedEventId::from_str("$test_event_id:example.org").unwrap();
+        let content = "Updated content";
+        let json = create_live_update_json_with_fields(&event_id, content, false, None);
+
+        // Check update structure
+        assert_eq!(json["msgtype"], "m.text");
+        assert!(json["body"].as_str().unwrap().starts_with("* "));
+        assert_eq!(json["m.new_content"]["body"], "Updated content");
+        assert_eq!(json["m.new_content"]["org.matrix.msc4357.live"], true);
+        assert_eq!(json["m.relates_to"]["rel_type"], "m.replace");
+        assert_eq!(json["m.relates_to"]["event_id"], "$test_event_id:example.org");
+    }
+
+    #[test]
+    fn test_create_final_update_without_marker() {
+        use std::str::FromStr;
+        let event_id = OwnedEventId::from_str("$test_event_id:example.org").unwrap();
+        let content = "Final content";
+        let json = create_live_update_json_with_fields(&event_id, content, true, None);
+
+        // Check that final update doesn't have live marker
+        assert_eq!(json["m.new_content"]["body"], "Final content");
+        assert!(json["m.new_content"]["org.matrix.msc4357.live"].is_null());
+    }
+
+    #[test]
+    fn test_live_message_manager_session() {
+        use std::str::FromStr;
+        let mut manager = LiveMessageManager::new();
+        manager.enabled = true;
+
+        let room_id = OwnedRoomId::from_str("!test:example.org").unwrap();
+        let content = "Test message".to_string();
+
+        // Start a session
+        let session = manager.start_session(room_id.clone(), content.clone());
+        assert!(session.is_some());
+
+        let session = session.unwrap();
+        assert_eq!(session.current_content, "Test message");
+        assert!(session.is_active);
+
+        // Get the session
+        let retrieved = manager.get_session(&room_id);
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().current_content, "Test message");
+
+        // End the session
+        let ended = manager.end_session(&room_id);
+        assert!(ended.is_some());
+
+        // Session should be gone
+        assert!(manager.get_session(&room_id).is_none());
+    }
+}

--- a/src/message/live_detection.rs
+++ b/src/message/live_detection.rs
@@ -1,0 +1,215 @@
+//! Live message detection utilities
+//!
+//! This module provides centralized logic for detecting whether a Matrix event
+//! contains the MSC4357 live message marker.
+
+use matrix_sdk::ruma::serde::Raw;
+use serde_json::Value;
+
+/// The MSC4357 live message marker key
+pub const LIVE_MARKER: &str = "org.matrix.msc4357.live";
+
+/// Check if a raw JSON string contains the live message marker
+///
+/// This function checks for the presence of the live marker in:
+/// 1. Root level (for initial live messages)
+/// 2. Inside m.new_content (for replacement/edit messages)
+///
+/// # Arguments
+/// * `json_str` - The raw JSON string of the event
+///
+/// # Returns
+/// * `true` if the event has the live marker set to true
+/// * `false` otherwise
+pub fn has_live_marker_in_json(json_str: &str) -> bool {
+    // Quick string check first for performance
+    if !json_str.contains(LIVE_MARKER) {
+        return false;
+    }
+
+    // Parse JSON and check properly
+    if let Ok(json) = serde_json::from_str::<Value>(json_str) {
+        has_live_marker_in_value(&json)
+    } else {
+        // Fallback to simple string search if parsing fails
+        json_str.contains(&format!(r#""{}":true"#, LIVE_MARKER))
+    }
+}
+
+/// Check if a JSON value contains the live message marker
+///
+/// Checks both at root level and inside m.new_content for replacements
+pub fn has_live_marker_in_value(json: &Value) -> bool {
+    // Check in m.new_content first (for replacements)
+    if let Some(new_content) = json.get("m.new_content") {
+        if let Some(marker) = new_content.get(LIVE_MARKER) {
+            return marker.as_bool().unwrap_or(false);
+        }
+    }
+
+    // Check at root level (for initial messages)
+    if let Some(marker) = json.get(LIVE_MARKER) {
+        return marker.as_bool().unwrap_or(false);
+    }
+
+    // Also check in content field (for sync events)
+    if let Some(content) = json.get("content") {
+        // Check in content.m.new_content for replacements
+        if let Some(new_content) = content.get("m.new_content") {
+            if let Some(marker) = new_content.get(LIVE_MARKER) {
+                return marker.as_bool().unwrap_or(false);
+            }
+        }
+        // Check in content root for initial messages
+        if let Some(marker) = content.get(LIVE_MARKER) {
+            return marker.as_bool().unwrap_or(false);
+        }
+    }
+
+    false
+}
+
+/// Check if a Raw event contains the live message marker
+pub fn has_live_marker_in_raw<T>(raw: &Raw<T>) -> bool {
+    has_live_marker_in_json(raw.json().get())
+}
+
+/// Determine if a replacement event is a live update or final update
+///
+/// Returns Some(true) if it's a live update, Some(false) if it's final,
+/// or None if it's not a replacement
+#[allow(dead_code)]
+pub fn is_live_replacement(json: &Value) -> Option<bool> {
+    // Check if this is a replacement
+    let is_replacement = json.get("m.relates_to")
+        .and_then(|r| r.get("rel_type"))
+        .and_then(|t| t.as_str())
+        .map(|t| t == "m.replace")
+        .unwrap_or(false);
+
+    if !is_replacement {
+        // Also check in content.m.relates_to for sync events
+        let is_replacement_in_content = json.get("content")
+            .and_then(|c| c.get("m.relates_to"))
+            .and_then(|r| r.get("rel_type"))
+            .and_then(|t| t.as_str())
+            .map(|t| t == "m.replace")
+            .unwrap_or(false);
+
+        if !is_replacement_in_content {
+            return None;
+        }
+    }
+
+    // It's a replacement, check if it has the live marker
+    Some(has_live_marker_in_value(json))
+}
+
+/// Extract the target event ID from a replacement event
+#[allow(dead_code)]
+pub fn get_replacement_target_id(json: &Value) -> Option<String> {
+    // Check in m.relates_to
+    if let Some(event_id) = json.get("m.relates_to")
+        .and_then(|r| r.get("event_id"))
+        .and_then(|id| id.as_str()) {
+        return Some(event_id.to_string());
+    }
+
+    // Check in content.m.relates_to for sync events
+    json.get("content")
+        .and_then(|c| c.get("m.relates_to"))
+        .and_then(|r| r.get("event_id"))
+        .and_then(|id| id.as_str())
+        .map(|id| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_has_live_marker_in_json_root() {
+        let json = json!({
+            "msgtype": "m.text",
+            "body": "Hello",
+            "org.matrix.msc4357.live": true
+        });
+        let json_str = serde_json::to_string(&json).unwrap();
+        assert!(has_live_marker_in_json(&json_str));
+    }
+
+    #[test]
+    fn test_has_live_marker_in_json_new_content() {
+        let json = json!({
+            "msgtype": "m.text",
+            "body": "* Hello",
+            "m.new_content": {
+                "msgtype": "m.text",
+                "body": "Hello",
+                "org.matrix.msc4357.live": true
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$test"
+            }
+        });
+        let json_str = serde_json::to_string(&json).unwrap();
+        assert!(has_live_marker_in_json(&json_str));
+    }
+
+    #[test]
+    fn test_has_live_marker_in_sync_event() {
+        let json = json!({
+            "content": {
+                "msgtype": "m.text",
+                "body": "Hello",
+                "org.matrix.msc4357.live": true
+            },
+            "event_id": "$test"
+        });
+        assert!(has_live_marker_in_value(&json));
+    }
+
+    #[test]
+    fn test_no_live_marker() {
+        let json = json!({
+            "msgtype": "m.text",
+            "body": "Hello"
+        });
+        let json_str = serde_json::to_string(&json).unwrap();
+        assert!(!has_live_marker_in_json(&json_str));
+    }
+
+    #[test]
+    fn test_is_live_replacement() {
+        let live_replacement = json!({
+            "m.new_content": {
+                "body": "Hello",
+                "org.matrix.msc4357.live": true
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$test"
+            }
+        });
+        assert_eq!(is_live_replacement(&live_replacement), Some(true));
+
+        let final_replacement = json!({
+            "m.new_content": {
+                "body": "Hello"
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$test"
+            }
+        });
+        assert_eq!(is_live_replacement(&final_replacement), Some(false));
+
+        let not_replacement = json!({
+            "msgtype": "m.text",
+            "body": "Hello"
+        });
+        assert_eq!(is_live_replacement(&not_replacement), None);
+    }
+}

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -48,7 +48,7 @@ use matrix_sdk::ruma::{
 };
 
 use ratatui::{
-    style::{Modifier as StyleModifier, Style},
+    style::{Color, Modifier as StyleModifier, Style},
     symbols::line::THICK_VERTICAL,
     text::{Line, Span, Text},
 };
@@ -67,10 +67,18 @@ use crate::{
 
 mod compose;
 mod html;
+mod live;
+pub mod live_detection;
 mod printer;
 mod state;
 
-pub use self::compose::text_to_message;
+pub use self::compose::text_to_message_with_command;
+pub use self::live::{
+    LiveMessageManager,
+    LiveMessageSession,
+    send_live_message_with_custom_fields,
+    send_live_update_with_custom_fields,
+};
 use self::state::{body_cow_state, html_state};
 pub use html::TreeGenState;
 
@@ -478,6 +486,7 @@ impl MessageEvent {
         )
     }
 
+
     pub fn body(&self) -> Cow<'_, str> {
         match self {
             MessageEvent::EncryptedOriginal(_) => "[Unable to decrypt message]".into(),
@@ -844,12 +853,16 @@ pub struct Message {
     pub downloaded: bool,
     pub html: Option<StyleTree>,
     pub image_preview: ImageStatus,
+    pub is_live: bool,
 }
 
 impl Message {
     pub fn new(event: MessageEvent, sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
         let html = event.html();
         let downloaded = false;
+
+        // The is_live flag will be set explicitly by the caller if needed
+        let is_live = false;
 
         Message {
             event,
@@ -858,8 +871,10 @@ impl Message {
             downloaded,
             html,
             image_preview: ImageStatus::None,
+            is_live,
         }
     }
+
 
     pub fn reply_to(&self) -> Option<OwnedEventId> {
         let content = match &self.event {
@@ -914,9 +929,15 @@ impl Message {
             style = style.add_modifier(StyleModifier::ITALIC);
         }
 
+        // Apply user color first if enabled (but it will be overridden for live messages)
         if settings.tunables.message_user_color {
             let color = settings.get_user_color(&self.sender);
             style = style.fg(color);
+        }
+
+        // Make live messages appear gray to indicate they're still being composed
+        if self.is_live {
+            style = style.fg(Color::Rgb(100, 100, 100));
         }
 
         return style;
@@ -1068,6 +1089,7 @@ impl Message {
             if self.downloaded {
                 msg.to_mut().push_str(" \u{2705}");
             }
+
 
             let mut proto = None;
             let placeholder = match &self.image_preview {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -142,7 +142,7 @@ async fn send_notification_bell(store: &AsyncProgramStore) {
 async fn send_notification_desktop(
     summary: &str,
     body: Option<&str>,
-    room_id: OwnedRoomId,
+    _room_id: OwnedRoomId,
     _store: &AsyncProgramStore,
     sound_hint: Option<&str>,
 ) {
@@ -166,17 +166,19 @@ async fn send_notification_desktop(
 
     match desktop_notification.show() {
         Err(err) => tracing::error!("Failed to send notification: {err}"),
+        #[cfg(all(unix, not(target_os = "macos")))]
         Ok(handle) => {
-            #[cfg(all(unix, not(target_os = "macos")))]
             _store
                 .lock()
                 .await
                 .application
                 .open_notifications
-                .entry(room_id)
+                .entry(_room_id)
                 .or_default()
                 .push(NotificationHandle(Some(handle)));
         },
+        #[cfg(not(all(unix, not(target_os = "macos"))))]
+        Ok(_) => {},
     }
 }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -76,6 +76,12 @@ pub async fn register_notifications(
                 let room_id = room.room_id().to_owned();
                 match notification.event {
                     RawAnySyncOrStrippedTimelineEvent::Sync(e) => {
+                        // Skip notifications for live messages
+                        if crate::message::live_detection::has_live_marker_in_raw(&e) {
+                            tracing::debug!("Skipping notification for live message");
+                            return;
+                        }
+
                         match parse_full_notification(e, room, show_message).await {
                             Ok((summary, body, server_ts)) => {
                                 if server_ts < startup_ts {


### PR DESCRIPTION
Implements [MSC4357](https://github.com/matrix-org/matrix-spec-proposals/pull/4357) live messaging protocol for real-time message composition in iamb. Messages appear gray while being typed and update in real-time for all room participants.

## Features

- `/live <message>` command to compose messages that update as you type
- Live messages appear gray (RGB 100,100,100) to indicate they're still being composed
- Real-time updates visible to all room participants
- Messages finalize to normal color when Enter is pressed
- Rate limiting to prevent excessive server load

## Implementation Details
- **Live message detection**: Uses `org.matrix.msc4357.live` marker in message JSON
- **Raw event handling**: Preserves custom JSON fields that would be lost during deserialization
- **Session management**: `LiveMessageManager` tracks active live sessions per room
- **Proper edit handling**: Only the latest edit determines if a message is live (prevents old messages from appearing gray after restart)

## Bug Fixes

- Fixed issue where all historical edits were processed instead of just the latest one, which caused old messages to incorrectly appear as live after client restart

## Changes

- Added `src/message/live.rs` - Core live messaging functionality
- Added `src/message/live_detection.rs` - Centralized marker detection
- Modified worker to handle raw message events and track live status
- Updated chat window to handle `/live` command and send updates
- Messages with live marker render in gray color

https://github.com/user-attachments/assets/e70aee7b-0e9d-479d-acd4-c0583c5ae2ac

