### PR TITLE
MSC4027: Display image reactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Install Rust (1.83 w/ clippy)
-      uses: dtolnay/rust-toolchain@1.83
+    - name: Install Rust (1.87 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.87
       with:
           components: clippy
     - name: Install Rust (nightly w/ rustfmt)

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -133,6 +133,13 @@ The room to show by default instead of the
 .Sy :welcome
 window.
 
+.IT Sy cache_policy
+Configure how downloaded files and image previews are cached internally.
+Specifying this object will replace the upstream defaults and possibly lead to unconstrained cache growth.
+Possible keys and their effect are documented at:
+.br
+.Lk https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRetentionPolicy.html#fields
+
 .It Sy image_preview
 Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -138,6 +138,13 @@ Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
 The available fields in this object are:
 .Bl -tag -width Ds
+.It Sy lazy_load
+If
+.Sy true
+(the default), download and render image previews when viewing a message with an image.
+If
+.Sy false ,
+load previews as soon as a message with an image is received.
 .It Sy size
 An optional object with
 .Sy width
@@ -538,8 +545,6 @@ Configured as an object under the key
 .It Sy cache
 Specifies where to store assets and temporary data in.
 (For example,
-.Sy image_preview
-and
 .Sy logs
 will also go in here by default.)
 Defaults to
@@ -554,11 +559,6 @@ Defaults to
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
-.It Sy image_previews
-Specifies where to store automatically downloaded image previews.
-Defaults to
-.Ev ${cache}/image_preview_downloads .
 
 .It Sy logs
 Specifies where to store log files.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -138,6 +138,13 @@ Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
 The available fields in this object are:
 .Bl -tag -width Ds
+.It Sy lazy_load
+If
+.Sy true
+(the default), download and render image previews when viewing a message with an image.
+If
+.Sy false ,
+load previews as soon as a message with an image is received.
 .It Sy size
 An optional object with
 .Sy width
@@ -588,8 +595,6 @@ Configured as an object under the key
 .It Sy cache
 Specifies where to store assets and temporary data in.
 (For example,
-.Sy image_preview
-and
 .Sy logs
 will also go in here by default.)
 Defaults to
@@ -604,11 +609,6 @@ Defaults to
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
-.It Sy image_previews
-Specifies where to store automatically downloaded image previews.
-Defaults to
-.Ev ${cache}/image_preview_downloads .
 
 .It Sy logs
 Specifies where to store log files.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,6 +126,12 @@ These options are configured as an object under the
 key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
+.It Sy cache_policy
+Configure how downloaded files and image previews are cached internally.
+Specifying this object will replace the upstream defaults and possibly lead to unconstrained cache growth.
+Possible keys and their effect are documented at:
+.br
+.Lk https://docs.rs/matrix-sdk/latest/matrix_sdk/media/struct.MediaRetentionPolicy.html#fields
 .It Sy default_markup
 Controls how text in the message bar is interpreted by default.
 Possible values are

--- a/src/base.rs
+++ b/src/base.rs
@@ -1239,7 +1239,7 @@ impl RoomInfo {
         &mut self,
         room_id: OwnedRoomId,
         store: AsyncProgramStore,
-        picker: Option<Picker>,
+        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
         settings: &mut ApplicationSettings,
         media: matrix_sdk::Media,
@@ -1259,6 +1259,7 @@ impl RoomInfo {
                     source,
                     media,
                     settings.dirs.image_previews.clone(),
+                    image_preview.size.clone(),
                 )
             }
         }
@@ -1602,7 +1603,7 @@ pub struct ChatStore {
     pub sync_info: SyncInfo,
 
     /// Image preview "protocol" picker.
-    pub picker: Option<Picker>,
+    pub picker: Option<Arc<Picker>>,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1628,7 +1629,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker,
+            picker: picker.map(Into::into),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::MediaSource;
+use matrix_sdk::ruma::OwnedMxcUri;
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -89,9 +91,9 @@ use modalkit::{
     prelude::{CommandType, WordStyle},
 };
 
-use crate::config::ImagePreviewProtocolValues;
+use crate::config::{ImagePreviewProtocolValues, ImagePreviewSize};
 use crate::notifications::NotificationHandle;
-use crate::preview::{source_from_event, PreviewManager};
+use crate::preview::{source_from_event, PreviewKind, PreviewManager};
 use crate::{
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
     worker::Requester,
@@ -686,7 +688,7 @@ pub type IambResult<T> = UIResult<T, IambInfo>;
 ///
 /// The event identifier used as a key here is the ID for the reaction, and not for the message
 /// it's reacting to.
-pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId)>;
+pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId, Option<MediaSource>)>;
 
 /// Errors encountered during application use.
 #[derive(thiserror::Error, Debug)]
@@ -992,22 +994,25 @@ impl RoomInfo {
     }
 
     /// Get the reactions and their counts for a message.
-    pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize)> {
+    pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize, &Option<MediaSource>)> {
         if let Some(reacts) = self.reactions.get(event_id) {
             let mut counts = HashMap::new();
 
             let mut seen_user_reactions = BTreeSet::new();
 
-            for (key, user) in reacts.values() {
+            for (key, user, source) in reacts.values() {
                 if !seen_user_reactions.contains(&(key, user)) {
                     seen_user_reactions.insert((key, user));
-                    let count = counts.entry(key.as_str()).or_default();
-                    *count += 1;
+                    let count = counts.entry(key.as_str()).or_insert((0, source));
+                    count.0 += 1;
                 }
             }
 
-            let mut reactions = counts.into_iter().collect::<Vec<_>>();
-            reactions.sort();
+            let mut reactions = counts
+                .into_iter()
+                .map(|(key, (count, source))| (key, count, source))
+                .collect::<Vec<_>>();
+            reactions.sort_by_key(|item| (item.0, item.1));
 
             reactions
         } else {
@@ -1068,24 +1073,46 @@ impl RoomInfo {
     }
 
     /// Insert a reaction to a message.
-    pub fn insert_reaction(&mut self, react: ReactionEvent) {
-        match react {
-            MessageLikeEvent::Original(react) => {
-                let rel_id = react.content.relates_to.event_id;
-                let key = react.content.relates_to.key;
+    fn insert_reaction(&mut self, react: ReactionEvent, source: Option<MediaSource>) {
+        let MessageLikeEvent::Original(react) = react else {
+            return;
+        };
+        let rel_id = react.content.relates_to.event_id;
+        let key = react.content.relates_to.key;
 
-                let message = self.reactions.entry(rel_id.clone()).or_default();
-                let event_id = react.event_id;
-                let user_id = react.sender;
+        let message = self.reactions.entry(rel_id.clone()).or_default();
+        let event_id = react.event_id;
+        let user_id = react.sender;
 
-                message.insert(event_id.clone(), (key, user_id));
+        message.insert(event_id.clone(), (key, user_id, source));
 
-                let loc = EventLocation::Reaction(rel_id);
-                self.keys.insert(event_id, loc);
-            },
-            MessageLikeEvent::Redacted(_) => {
-                return;
-            },
+        let loc = EventLocation::Reaction(rel_id);
+        self.keys.insert(event_id, loc);
+    }
+
+    /// Insert a reaction to a message.
+    pub fn insert_reaction_with_preview(
+        &mut self,
+        react: ReactionEvent,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
+        worker: &Requester,
+    ) {
+        let MessageLikeEvent::Original(ref orig_react) = react else {
+            return;
+        };
+        let image_uri = OwnedMxcUri::from(orig_react.content.relates_to.key.as_str());
+        let source = if image_uri.is_valid() && settings.tunables.image_preview.is_some() {
+            Some(MediaSource::Plain(image_uri))
+        } else {
+            None
+        };
+
+        self.insert_reaction(react, source.clone());
+
+        if let (Some(source), Some(_)) = (source, &settings.tunables.image_preview) {
+            let size = ImagePreviewSize { width: 2, height: 1 };
+            previews.register_preview(settings, source, PreviewKind::Reaction, size, worker);
         }
     }
 
@@ -1247,7 +1274,13 @@ impl RoomInfo {
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
             {
                 msg.image_preview = Some(source.clone());
-                previews.register_preview(settings, source, image_preview.size, worker)
+                previews.register_preview(
+                    settings,
+                    source,
+                    PreviewKind::Message,
+                    image_preview.size,
+                    worker,
+                )
             }
         }
     }
@@ -1404,7 +1437,7 @@ impl RoomInfo {
         if let Some(reactions) = self.reactions.get(event_id) {
             reactions
                 .values()
-                .any(|(annotation, user)| annotation == emoji && user == user_id)
+                .any(|(annotation, user, _)| annotation == emoji && user == user_id)
         } else {
             false
         }
@@ -2205,7 +2238,7 @@ pub mod tests {
         for i in 0..3 {
             let event_id = format!("$house_{i}");
             let react = create_reaction_event(&content, &event_id, "@foo:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
         let content = ReactionEventContent::new(Annotation::new(
@@ -2216,19 +2249,21 @@ pub mod tests {
         for i in 0..2 {
             let event_id = format!("$smile_{i}");
             let react = create_reaction_event(&content, &event_id, "@foo:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
         for i in 2..4 {
             let event_id = format!("$smile2_{i}");
             let react = create_reaction_event(&content, &event_id, "@bar:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
-        assert_eq!(info.get_reactions(&owned_event_id!("$my_reaction")), vec![
-            ("🏠", 1),
-            ("🙂", 2)
-        ]);
+        let reacts: Vec<_> = info
+            .get_reactions(&owned_event_id!("$my_reaction"))
+            .into_iter()
+            .map(|(key, count, _)| (key, count))
+            .collect();
+        assert_eq!(reacts, vec![("🏠", 1), ("🙂", 2)]);
     }
 
     #[test]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1238,7 +1238,7 @@ impl RoomInfo {
         &mut self,
         room_id: OwnedRoomId,
         store: AsyncProgramStore,
-        picker: Option<Picker>,
+        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
         settings: &mut ApplicationSettings,
         media: matrix_sdk::Media,
@@ -1258,6 +1258,7 @@ impl RoomInfo {
                     source,
                     media,
                     settings.dirs.image_previews.clone(),
+                    image_preview.size.clone(),
                 )
             }
         }
@@ -1601,7 +1602,7 @@ pub struct ChatStore {
     pub sync_info: SyncInfo,
 
     /// Image preview "protocol" picker.
-    pub picker: Option<Picker>,
+    pub picker: Option<Arc<Picker>>,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1627,7 +1628,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker,
+            picker: picker.map(Into::into),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -90,9 +90,8 @@ use modalkit::{
 };
 
 use crate::config::ImagePreviewProtocolValues;
-use crate::message::ImageStatus;
 use crate::notifications::NotificationHandle;
-use crate::preview::{source_from_event, spawn_insert_preview};
+use crate::preview::{source_from_event, PreviewManager};
 use crate::{
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
     worker::Requester,
@@ -1232,34 +1231,23 @@ impl RoomInfo {
         }
     }
 
-    /// Insert a new message event, and spawn a task for image-preview if it has an image
-    /// attachment.
+    /// Insert a new message event, and prepare for image-preview if it has an image attachment.
     pub fn insert_with_preview(
         &mut self,
-        room_id: OwnedRoomId,
-        store: AsyncProgramStore,
-        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
-        settings: &mut ApplicationSettings,
-        media: matrix_sdk::Media,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
+        worker: &Requester,
     ) {
-        let source = picker.and_then(|_| source_from_event(&ev));
+        let source = source_from_event(&ev);
         self.insert(ev);
 
         if let Some((event_id, source)) = source {
             if let (Some(msg), Some(image_preview)) =
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
             {
-                msg.image_preview = ImageStatus::Downloading(image_preview.size.clone());
-                spawn_insert_preview(
-                    store,
-                    room_id,
-                    event_id,
-                    source,
-                    media,
-                    settings.dirs.image_previews.clone(),
-                    image_preview.size.clone(),
-                )
+                msg.image_preview = Some(source.clone());
+                previews.register_preview(settings, source, image_preview.size, worker)
             }
         }
     }
@@ -1601,8 +1589,8 @@ pub struct ChatStore {
     /// Information gathered by the background thread.
     pub sync_info: SyncInfo,
 
-    /// Image preview "protocol" picker.
-    pub picker: Option<Arc<Picker>>,
+    /// Rendered image previews.
+    pub previews: PreviewManager,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1628,7 +1616,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker: picker.map(Into::into),
+            previews: PreviewManager::new(picker),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 
+use matrix_sdk::ruma::OwnedMxcUri;
 use matrix_sdk::ruma::OwnedTransactionId;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
@@ -93,6 +94,8 @@ use modalkit::{
     prelude::{CommandType, WordStyle},
 };
 
+use crate::config::ImagePreviewSize;
+use crate::preview::PreviewKind;
 use crate::{
     config::{ApplicationSettings, ImagePreviewProtocolValues},
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
@@ -702,7 +705,7 @@ pub type IambResult<T> = UIResult<T, IambInfo>;
 ///
 /// The event identifier used as a key here is the ID for the reaction, and not for the message
 /// it's reacting to.
-pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId)>;
+pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId, Option<MediaSource>)>;
 
 /// Errors encountered during application use.
 #[derive(thiserror::Error, Debug)]
@@ -1122,22 +1125,25 @@ impl RoomInfo {
     }
 
     /// Get the reactions and their counts for a message.
-    pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize)> {
+    pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize, &Option<MediaSource>)> {
         if let Some(reacts) = self.reactions.get(event_id) {
             let mut counts = HashMap::new();
 
             let mut seen_user_reactions = BTreeSet::new();
 
-            for (key, user) in reacts.values() {
+            for (key, user, source) in reacts.values() {
                 if !seen_user_reactions.contains(&(key, user)) {
                     seen_user_reactions.insert((key, user));
-                    let count = counts.entry(key.as_str()).or_default();
-                    *count += 1;
+                    let count = counts.entry(key.as_str()).or_insert((0, source));
+                    count.0 += 1;
                 }
             }
 
-            let mut reactions = counts.into_iter().collect::<Vec<_>>();
-            reactions.sort();
+            let mut reactions = counts
+                .into_iter()
+                .map(|(key, (count, source))| (key, count, source))
+                .collect::<Vec<_>>();
+            reactions.sort_by_key(|item| (item.0, item.1));
 
             reactions
         } else {
@@ -1204,25 +1210,21 @@ impl RoomInfo {
     }
 
     /// Insert a reaction to a message.
-    pub fn insert_reaction(&mut self, react: ReactionEvent) {
-        match react {
-            MessageLikeEvent::Original(react) => {
-                let rel_id = react.content.relates_to.event_id;
-                let key = react.content.relates_to.key;
+    fn insert_reaction(&mut self, react: ReactionEvent, source: Option<MediaSource>) {
+        let MessageLikeEvent::Original(react) = react else {
+            return;
+        };
+        let rel_id = react.content.relates_to.event_id;
+        let key = react.content.relates_to.key;
 
-                let message = self.reactions.entry(rel_id.clone()).or_default();
-                let event_id = react.event_id;
-                let user_id = react.sender;
+        let message = self.reactions.entry(rel_id.clone()).or_default();
+        let event_id = react.event_id;
+        let user_id = react.sender;
 
-                message.insert(event_id.clone(), (key, user_id));
+        message.insert(event_id.clone(), (key, user_id, source));
 
-                let loc = EventLocation::Reaction(rel_id);
-                self.keys.insert(event_id, loc);
-            },
-            MessageLikeEvent::Redacted(_) => {
-                return;
-            },
-        }
+        let loc = EventLocation::Reaction(rel_id);
+        self.keys.insert(event_id, loc);
     }
 
     /// Insert a sticker
@@ -1251,7 +1253,13 @@ impl RoomInfo {
                 ) {
                     let source: MediaSource = sticker_content.content.source.clone().into();
                     msg.image_preview = Some(source.clone());
-                    previews.register_preview(settings, source, image_preview.size, worker);
+                    previews.register_preview(
+                        settings,
+                        source,
+                        PreviewKind::Message,
+                        image_preview.size,
+                        worker,
+                    );
                 }
             },
             MessageLikeEvent::Redacted(ref redaction) => {
@@ -1262,6 +1270,32 @@ impl RoomInfo {
 
                 self.messages.insert_message(key.clone(), sticker.clone());
             },
+        }
+    }
+
+    /// Insert a reaction to a message.
+    pub fn insert_reaction_with_preview(
+        &mut self,
+        react: ReactionEvent,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
+        worker: &Requester,
+    ) {
+        let MessageLikeEvent::Original(ref orig_react) = react else {
+            return;
+        };
+        let image_uri = OwnedMxcUri::from(orig_react.content.relates_to.key.as_str());
+        let source = if image_uri.is_valid() && settings.tunables.image_preview.is_some() {
+            Some(MediaSource::Plain(image_uri))
+        } else {
+            None
+        };
+
+        self.insert_reaction(react, source.clone());
+
+        if let (Some(source), Some(_)) = (source, &settings.tunables.image_preview) {
+            let size = ImagePreviewSize { width: 2, height: 1 };
+            previews.register_preview(settings, source, PreviewKind::Reaction, size, worker);
         }
     }
 
@@ -1413,7 +1447,13 @@ impl RoomInfo {
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
         {
             msg.image_preview = Some(source.clone());
-            previews.register_preview(settings, source, image_preview.size, worker)
+            previews.register_preview(
+                settings,
+                source,
+                PreviewKind::Message,
+                image_preview.size,
+                worker,
+            )
         }
     }
 
@@ -1586,7 +1626,7 @@ impl RoomInfo {
         if let Some(reactions) = self.reactions.get(event_id) {
             reactions
                 .values()
-                .any(|(annotation, user)| annotation == emoji && user == user_id)
+                .any(|(annotation, user, _)| annotation == emoji && user == user_id)
         } else {
             false
         }
@@ -2405,7 +2445,7 @@ pub mod tests {
         for i in 0..3 {
             let event_id = format!("$house_{i}");
             let react = create_reaction_event(&content, &event_id, "@foo:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
         let content = ReactionEventContent::new(Annotation::new(
@@ -2416,19 +2456,21 @@ pub mod tests {
         for i in 0..2 {
             let event_id = format!("$smile_{i}");
             let react = create_reaction_event(&content, &event_id, "@foo:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
         for i in 2..4 {
             let event_id = format!("$smile2_{i}");
             let react = create_reaction_event(&content, &event_id, "@bar:example.com");
-            info.insert_reaction(react);
+            info.insert_reaction(react, None);
         }
 
-        assert_eq!(info.get_reactions(&owned_event_id!("$my_reaction")), vec![
-            ("🏠", 1),
-            ("🙂", 2)
-        ]);
+        let reacts: Vec<_> = info
+            .get_reactions(&owned_event_id!("$my_reaction"))
+            .into_iter()
+            .map(|(key, count, _)| (key, count))
+            .collect();
+        assert_eq!(reacts, vec![("🏠", 1), ("🙂", 2)]);
     }
 
     #[test]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1151,6 +1151,14 @@ impl RoomInfo {
         }
     }
 
+    pub fn get_reaction_images(&self, event_id: &EventId) -> impl Iterator<Item = &MediaSource> {
+        self.reactions
+            .get(event_id)
+            .map(HashMap::iter)
+            .unwrap_or_default()
+            .filter_map(|(_, (_, _, source))| source.as_ref())
+    }
+
     /// Map an event identifier to its [MessageKey].
     pub fn get_message_key(&self, event_id: &EventId) -> Option<&MessageKey> {
         self.keys.get(event_id)?.to_message_key()

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::process;
 
 use clap::Parser;
 use matrix_sdk::authentication::matrix::MatrixSession;
+use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
 use ratatui::text::Span;
@@ -584,6 +585,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub cache_policy: MediaRetentionPolicy,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -612,6 +614,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub cache_policy: Option<MediaRetentionPolicy>,
 }
 
 impl Tunables {
@@ -646,6 +649,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            cache_policy: self.cache_policy.or(other.cache_policy),
         }
     }
 
@@ -676,6 +680,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            cache_policy: self.cache_policy.unwrap_or_default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -489,12 +489,14 @@ pub struct Notifications {
 
 #[derive(Clone)]
 pub struct ImagePreviewValues {
+    pub lazy_load: bool,
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
+    pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
@@ -502,13 +504,14 @@ pub struct ImagePreview {
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
+            lazy_load: self.lazy_load.unwrap_or(true),
             size: self.size.unwrap_or_default(),
             protocol: self.protocol,
         }
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
@@ -683,19 +686,17 @@ pub struct DirectoryValues {
     pub data: PathBuf,
     pub logs: PathBuf,
     pub downloads: Option<PathBuf>,
-    pub image_previews: PathBuf,
 }
 
 impl DirectoryValues {
     fn create_dir_all(&self) -> std::io::Result<()> {
         use std::fs::create_dir_all;
 
-        let Self { cache, data, logs, downloads, image_previews } = self;
+        let Self { cache, data, logs, downloads } = self;
 
         create_dir_all(cache)?;
         create_dir_all(data)?;
         create_dir_all(logs)?;
-        create_dir_all(image_previews)?;
 
         if let Some(downloads) = downloads {
             create_dir_all(downloads)?;
@@ -711,7 +712,6 @@ pub struct Directories {
     pub data: Option<String>,
     pub logs: Option<String>,
     pub downloads: Option<String>,
-    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -721,7 +721,6 @@ impl Directories {
             data: self.data.or(other.data),
             logs: self.logs.or(other.logs),
             downloads: self.downloads.or(other.downloads),
-            image_previews: self.image_previews.or(other.image_previews),
         }
     }
 
@@ -776,20 +775,7 @@ impl Directories {
             })
             .or_else(dirs::download_dir);
 
-        let image_previews = self
-            .image_previews
-            .map(|dir| {
-                let dir = shellexpand::full(&dir)
-                    .expect("unable to expand shell variables in dirs.cache");
-                Path::new(dir.as_ref()).to_owned()
-            })
-            .unwrap_or_else(|| {
-                let mut dir = cache.clone();
-                dir.push("image_preview_downloads");
-                dir
-            });
-
-        DirectoryValues { cache, data, logs, downloads, image_previews }
+        DirectoryValues { cache, data, logs, downloads }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::process;
 
 use clap::Parser;
 use matrix_sdk::authentication::matrix::MatrixSession;
+use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
 use ratatui::text::Span;
@@ -543,6 +544,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub cache_policy: MediaRetentionPolicy,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -572,6 +574,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub cache_policy: Option<MediaRetentionPolicy>,
 }
 
 impl Tunables {
@@ -607,6 +610,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            cache_policy: self.cache_policy.or(other.cache_policy),
         }
     }
 
@@ -638,6 +642,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            cache_policy: self.cache_policy.unwrap_or_default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,12 +447,14 @@ pub struct Notifications {
 
 #[derive(Clone)]
 pub struct ImagePreviewValues {
+    pub lazy_load: bool,
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
+    pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
@@ -460,13 +462,14 @@ pub struct ImagePreview {
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
+            lazy_load: self.lazy_load.unwrap_or(true),
             size: self.size.unwrap_or_default(),
             protocol: self.protocol,
         }
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
@@ -645,19 +648,17 @@ pub struct DirectoryValues {
     pub data: PathBuf,
     pub logs: PathBuf,
     pub downloads: Option<PathBuf>,
-    pub image_previews: PathBuf,
 }
 
 impl DirectoryValues {
     fn create_dir_all(&self) -> std::io::Result<()> {
         use std::fs::create_dir_all;
 
-        let Self { cache, data, logs, downloads, image_previews } = self;
+        let Self { cache, data, logs, downloads } = self;
 
         create_dir_all(cache)?;
         create_dir_all(data)?;
         create_dir_all(logs)?;
-        create_dir_all(image_previews)?;
 
         if let Some(downloads) = downloads {
             create_dir_all(downloads)?;
@@ -673,7 +674,6 @@ pub struct Directories {
     pub data: Option<String>,
     pub logs: Option<String>,
     pub downloads: Option<String>,
-    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -683,7 +683,6 @@ impl Directories {
             data: self.data.or(other.data),
             logs: self.logs.or(other.logs),
             downloads: self.downloads.or(other.downloads),
-            image_previews: self.image_previews.or(other.image_previews),
         }
     }
 
@@ -738,20 +737,7 @@ impl Directories {
             })
             .or_else(dirs::download_dir);
 
-        let image_previews = self
-            .image_previews
-            .map(|dir| {
-                let dir = shellexpand::full(&dir)
-                    .expect("unable to expand shell variables in dirs.cache");
-                Path::new(dir.as_ref()).to_owned()
-            })
-            .unwrap_or_else(|| {
-                let mut dir = cache.clone();
-                dir.push("image_preview_downloads");
-                dir
-            });
-
-        DirectoryValues { cache, data, logs, downloads, image_previews }
+        DirectoryValues { cache, data, logs, downloads }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 use clap::Parser;
 use matrix_sdk::EncryptionState;
 use matrix_sdk::authentication::matrix::MatrixSession;
+use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::reqwest::header::{HeaderMap, HeaderValue};
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
@@ -837,6 +838,7 @@ pub struct TunableValues {
     pub members_split: Option<SplitDirection>,
     pub default_split: SplitDirection,
     pub ssl_verify: bool,
+    pub cache_policy: MediaRetentionPolicy,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -886,6 +888,7 @@ pub struct Tunables {
     pub members_split: Option<SplitDirection>,
     pub default_split: Option<SplitDirection>,
     pub ssl_verify: Option<bool>,
+    pub cache_policy: Option<MediaRetentionPolicy>,
 }
 
 impl Tunables {
@@ -934,6 +937,7 @@ impl Tunables {
             members_split: self.members_split.or(other.members_split),
             default_split: self.default_split.or(other.default_split),
             ssl_verify: self.ssl_verify.or(other.ssl_verify),
+            cache_policy: self.cache_policy.or(other.cache_policy),
         }
     }
 
@@ -974,6 +978,7 @@ impl Tunables {
             members_split: self.members_split,
             default_split: self.default_split.unwrap_or_default(),
             ssl_verify: self.ssl_verify.unwrap_or(true),
+            cache_policy: self.cache_policy.unwrap_or_default(),
         }
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
+use image::DynamicImage;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -844,6 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
+    Loading(Option<DynamicImage>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }
@@ -1085,6 +1087,9 @@ impl Message {
                 ImageStatus::None => None,
                 ImageStatus::Downloading(image_preview_size) => {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                ImageStatus::Loading(_, image_preview_size) => {
+                    placeholder_frame(Some("Loading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -59,7 +59,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
-use crate::preview::{ImageStatus, PreviewManager};
+use crate::preview::{ImageStatus, PreviewKind, PreviewManager};
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -780,16 +780,37 @@ impl<'a> MessageFormatter<'a> {
         proto
     }
 
-    fn push_reactions(&mut self, counts: Vec<(&'a str, usize)>, style: Style, text: &mut Text<'a>) {
+    fn push_reactions(
+        &mut self,
+        counts: Vec<(&'a str, usize, &'a Option<MediaSource>)>,
+        style: Style,
+        text: &mut Text<'a>,
+        settings: &ApplicationSettings,
+        previews: &'a PreviewManager,
+    ) -> Vec<ProtocolPreview<'a>> {
         let mut emojis = printer::TextPrinter::new(self.width(), style, false, self.settings);
         let mut reactions = 0;
+        let mut protos = Vec::new();
 
-        for (key, count) in counts {
+        for (key, count, source) in counts {
             if reactions != 0 {
                 emojis.push_str(" ", style);
             }
 
-            let name = if self.settings.tunables.reaction_shortcode_display {
+            let proto = match source
+                .as_ref()
+                .and_then(|source| previews.get(source, PreviewKind::Reaction))
+            {
+                Some(ImageStatus::Loaded(backend)) => Some(Some(backend)),
+                // Use empty space as placeholder
+                Some(ImageStatus::Queued(_)) | Some(ImageStatus::Downloading(_)) => Some(None),
+                // Fall back to text
+                None | Some(ImageStatus::Error(_)) => None,
+            };
+
+            let name = if proto.is_some() {
+                "  "
+            } else if self.settings.tunables.reaction_shortcode_display {
                 if let Some(emoji) = emojis::get(key) {
                     if let Some(short) = emoji.shortcode() {
                         short
@@ -808,6 +829,13 @@ impl<'a> MessageFormatter<'a> {
             };
 
             emojis.push_str("[", style);
+            if let Some(Some(proto)) = proto {
+                let (x, y) = emojis.curosor_pos();
+                let y = (y + text.lines.len()) as u16;
+                let x = x as u16 + self.cols.user_gutter_width(settings);
+
+                protos.push((proto, x, y));
+            }
             emojis.push_str(name, style);
             emojis.push_str(" ", style);
             emojis.push_span_nobreak(Span::styled(count.to_string(), style));
@@ -819,6 +847,8 @@ impl<'a> MessageFormatter<'a> {
         if reactions > 0 {
             self.push_text(emojis.finish(), style, text);
         }
+
+        protos
     }
 
     fn push_thread_reply_count(&mut self, len: usize, text: &mut Text<'a>) {
@@ -1044,7 +1074,8 @@ impl Message {
 
         if settings.tunables.reaction_display {
             let reactions = info.get_reactions(self.event.event_id());
-            fmt.push_reactions(reactions, style, &mut text);
+            let react_protos = fmt.push_reactions(reactions, style, &mut text, settings, previews);
+            protos.extend(react_protos);
         }
 
         if let Some(thread) = info.get_thread(Some(self.event.event_id())) {
@@ -1087,21 +1118,24 @@ impl Message {
             }
 
             let mut proto = None;
-            let placeholder =
-                match self.image_preview.as_ref().and_then(|source| previews.get(source)) {
-                    None => None,
-                    Some(ImageStatus::Queued(image_preview_size)) => {
-                        placeholder_frame(Some("Queued..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Downloading(image_preview_size)) => {
-                        placeholder_frame(Some("Downloading..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Loaded(backend)) => {
-                        proto = Some(backend);
-                        placeholder_frame(Some("No Space..."), width, &backend.area().into())
-                    },
-                    Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
-                };
+            let placeholder = match self
+                .image_preview
+                .as_ref()
+                .and_then(|source| previews.get(source, PreviewKind::Message))
+            {
+                None => None,
+                Some(ImageStatus::Queued(image_preview_size)) => {
+                    placeholder_frame(Some("Queued..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Downloading(image_preview_size)) => {
+                    placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Loaded(backend)) => {
+                    proto = Some(backend);
+                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
+                },
+                Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
+            };
 
             if let Some(placeholder) = placeholder {
                 msg.to_mut().insert_str(0, &placeholder);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::DynamicImage;
+use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -845,7 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loading(Option<DynamicImage>, ImagePreviewSize),
+    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,8 +10,8 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::MediaSource;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
@@ -56,6 +56,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
+use crate::preview::{ImageStatus, PreviewManager};
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -713,6 +714,7 @@ impl<'a> MessageFormatter<'a> {
         text: &mut Text<'a>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
             style.patch(settings.get_user_color(&msg.sender))
@@ -722,7 +724,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, previews);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -823,21 +825,13 @@ impl<'a> MessageFormatter<'a> {
     }
 }
 
-pub enum ImageStatus {
-    None,
-    Downloading(ImagePreviewSize),
-    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
-    Loaded(Protocol),
-    Error(String),
-}
-
 pub struct Message {
     pub event: MessageEvent,
     pub sender: OwnedUserId,
     pub timestamp: MessageTimeStamp,
     pub downloaded: bool,
     pub html: Option<StyleTree>,
-    pub image_preview: ImageStatus,
+    pub image_preview: Option<MediaSource>,
 }
 
 impl Message {
@@ -851,7 +845,7 @@ impl Message {
             timestamp,
             downloaded,
             html,
-            image_preview: ImageStatus::None,
+            image_preview: None,
         }
     }
 
@@ -876,7 +870,7 @@ impl Message {
         }
     }
 
-    fn thread_root(&self) -> Option<OwnedEventId> {
+    pub fn thread_root(&self) -> Option<OwnedEventId> {
         let content = match &self.event {
             MessageEvent::EncryptedOriginal(_) => return None,
             MessageEvent::EncryptedRedacted(_) => return None,
@@ -983,6 +977,7 @@ impl Message {
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
         let width = vwctx.get_width();
 
@@ -998,11 +993,11 @@ impl Message {
             .and_then(|e| info.get_event(&e));
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
-            fmt.push_in_reply(r, style, &mut text, info, settings)
+            fmt.push_in_reply(r, style, &mut text, info, settings, previews)
         });
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings);
+        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews);
 
         // Given our text so far, determine the image offset.
         let proto_main = proto.map(|p| {
@@ -1040,8 +1035,9 @@ impl Message {
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> Text<'a> {
-        self.show_with_preview(prev, selected, vwctx, info, settings).0
+        self.show_with_preview(prev, selected, vwctx, info, settings, previews).0
     }
 
     fn show_msg<'a>(
@@ -1050,6 +1046,7 @@ impl Message {
         style: Style,
         hide_reply: bool,
         settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
     ) -> (Text<'a>, Option<&'a Protocol>) {
         if let Some(html) = &self.html {
             (html.to_text(width, style, hide_reply, settings), None)
@@ -1064,20 +1061,21 @@ impl Message {
             }
 
             let mut proto = None;
-            let placeholder = match &self.image_preview {
-                ImageStatus::None => None,
-                ImageStatus::Downloading(image_preview_size) => {
-                    placeholder_frame(Some("Downloading..."), width, image_preview_size)
-                },
-                ImageStatus::Loading(_, image_preview_size) => {
-                    placeholder_frame(Some("Loading..."), width, image_preview_size)
-                },
-                ImageStatus::Loaded(backend) => {
-                    proto = Some(backend);
-                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
-                },
-                ImageStatus::Error(err) => Some(format!("[Image error: {err}]\n")),
-            };
+            let placeholder =
+                match self.image_preview.as_ref().and_then(|source| previews.get(source)) {
+                    None => None,
+                    Some(ImageStatus::Queued(image_preview_size)) => {
+                        placeholder_frame(Some("Queued..."), width, image_preview_size)
+                    },
+                    Some(ImageStatus::Downloading(image_preview_size)) => {
+                        placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                    },
+                    Some(ImageStatus::Loaded(backend)) => {
+                        proto = Some(backend);
+                        placeholder_frame(Some("No Space..."), width, &backend.area().into())
+                    },
+                    Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
+                };
 
             if let Some(placeholder) = placeholder {
                 msg.to_mut().insert_str(0, &placeholder);
@@ -1129,7 +1127,7 @@ impl Message {
         self.event.redact(redaction);
         self.html = None;
         self.downloaded = false;
-        self.image_preview = ImageStatus::None;
+        self.image_preview = None;
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::DynamicImage;
+use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use unicode_width::UnicodeWidthStr;
 
@@ -826,7 +826,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loading(Option<DynamicImage>, ImagePreviewSize),
+    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -978,7 +978,7 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-    ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
+    ) -> (Text<'a>, Vec<ProtocolPreview<'a>>) {
         let width = vwctx.get_width();
 
         let style = self.get_render_style(selected, settings);
@@ -986,28 +986,35 @@ impl Message {
         let mut text = Text::default();
         let width = fmt.width();
 
+        let mut protos = Vec::new();
+
         // Show the message that this one replied to, if any.
         let reply = self
             .reply_to()
             .or_else(|| self.thread_root())
             .and_then(|e| info.get_event(&e));
-        let proto_reply = reply.as_ref().and_then(|r| {
+        if let Some(reply) = reply {
             // Format the reply header, push it into the `Text` buffer, and get any image.
-            fmt.push_in_reply(r, style, &mut text, info, settings, previews)
-        });
+            if let Some(proto) =
+                fmt.push_in_reply(reply, style, &mut text, info, settings, previews)
+            {
+                protos.push(proto);
+            }
+        }
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
         let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews);
 
         // Given our text so far, determine the image offset.
-        let proto_main = proto.map(|p| {
+        if let Some(p) = proto {
             let y_off = text.lines.len() as u16;
             let x_off = fmt.cols.user_gutter_width(settings);
             // Adjust y_off by 1 if a date was printed before the message to account for
             // the extra line we're going to print.
             let y_off = if fmt.date.is_some() { y_off + 1 } else { y_off };
-            (p, x_off, y_off)
-        });
+
+            protos.push((p, x_off, y_off));
+        }
 
         fmt.push_text(msg, style, &mut text);
 
@@ -1025,7 +1032,7 @@ impl Message {
             fmt.push_thread_reply_count(thread.len(), &mut text);
         }
 
-        (text, [proto_main, proto_reply])
+        (text, protos)
     }
 
     pub fn show<'a>(

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -56,7 +56,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
-use crate::preview::{ImageStatus, PreviewManager};
+use crate::preview::{ImageStatus, PreviewKind, PreviewManager};
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -761,16 +761,37 @@ impl<'a> MessageFormatter<'a> {
         proto
     }
 
-    fn push_reactions(&mut self, counts: Vec<(&'a str, usize)>, style: Style, text: &mut Text<'a>) {
+    fn push_reactions(
+        &mut self,
+        counts: Vec<(&'a str, usize, &'a Option<MediaSource>)>,
+        style: Style,
+        text: &mut Text<'a>,
+        settings: &ApplicationSettings,
+        previews: &'a PreviewManager,
+    ) -> Vec<ProtocolPreview<'a>> {
         let mut emojis = printer::TextPrinter::new(self.width(), style, false, self.settings);
         let mut reactions = 0;
+        let mut protos = Vec::new();
 
-        for (key, count) in counts {
+        for (key, count, source) in counts {
             if reactions != 0 {
                 emojis.push_str(" ", style);
             }
 
-            let name = if self.settings.tunables.reaction_shortcode_display {
+            let proto = match source
+                .as_ref()
+                .and_then(|source| previews.get(source, PreviewKind::Reaction))
+            {
+                Some(ImageStatus::Loaded(backend)) => Some(Some(backend)),
+                // Use empty space as placeholder
+                Some(ImageStatus::Queued(_)) | Some(ImageStatus::Downloading(_)) => Some(None),
+                // Fall back to text
+                None | Some(ImageStatus::Error(_)) => None,
+            };
+
+            let name = if proto.is_some() {
+                "  "
+            } else if self.settings.tunables.reaction_shortcode_display {
                 if let Some(emoji) = emojis::get(key) {
                     if let Some(short) = emoji.shortcode() {
                         short
@@ -789,6 +810,13 @@ impl<'a> MessageFormatter<'a> {
             };
 
             emojis.push_str("[", style);
+            if let Some(Some(proto)) = proto {
+                let (x, y) = emojis.curosor_pos();
+                let y = (y + text.lines.len()) as u16;
+                let x = x as u16 + self.cols.user_gutter_width(settings);
+
+                protos.push((proto, x, y));
+            }
             emojis.push_str(name, style);
             emojis.push_str(" ", style);
             emojis.push_span_nobreak(Span::styled(count.to_string(), style));
@@ -800,6 +828,8 @@ impl<'a> MessageFormatter<'a> {
         if reactions > 0 {
             self.push_text(emojis.finish(), style, text);
         }
+
+        protos
     }
 
     fn push_thread_reply_count(&mut self, len: usize, text: &mut Text<'a>) {
@@ -1025,7 +1055,8 @@ impl Message {
 
         if settings.tunables.reaction_display {
             let reactions = info.get_reactions(self.event.event_id());
-            fmt.push_reactions(reactions, style, &mut text);
+            let react_protos = fmt.push_reactions(reactions, style, &mut text, settings, previews);
+            protos.extend(react_protos);
         }
 
         if let Some(thread) = info.get_thread(Some(self.event.event_id())) {
@@ -1068,21 +1099,24 @@ impl Message {
             }
 
             let mut proto = None;
-            let placeholder =
-                match self.image_preview.as_ref().and_then(|source| previews.get(source)) {
-                    None => None,
-                    Some(ImageStatus::Queued(image_preview_size)) => {
-                        placeholder_frame(Some("Queued..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Downloading(image_preview_size)) => {
-                        placeholder_frame(Some("Downloading..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Loaded(backend)) => {
-                        proto = Some(backend);
-                        placeholder_frame(Some("No Space..."), width, &backend.area().into())
-                    },
-                    Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
-                };
+            let placeholder = match self
+                .image_preview
+                .as_ref()
+                .and_then(|source| previews.get(source, PreviewKind::Message))
+            {
+                None => None,
+                Some(ImageStatus::Queued(image_preview_size)) => {
+                    placeholder_frame(Some("Queued..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Downloading(image_preview_size)) => {
+                    placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Loaded(backend)) => {
+                    proto = Some(backend);
+                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
+                },
+                Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
+            };
 
             if let Some(placeholder) = placeholder {
                 msg.to_mut().insert_str(0, &placeholder);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
+use image::DynamicImage;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use unicode_width::UnicodeWidthStr;
 
@@ -825,6 +826,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
+    Loading(Option<DynamicImage>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }
@@ -1066,6 +1068,9 @@ impl Message {
                 ImageStatus::None => None,
                 ImageStatus::Downloading(image_preview_size) => {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                ImageStatus::Loading(_, image_preview_size) => {
+                    placeholder_frame(Some("Loading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -60,7 +60,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
-use crate::preview::{ImageStatus, PreviewManager};
+use crate::preview::{ImageStatus, PreviewKind, PreviewManager};
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -848,16 +848,37 @@ impl<'a> MessageFormatter<'a> {
         proto
     }
 
-    fn push_reactions(&mut self, counts: Vec<(&'a str, usize)>, style: Style, text: &mut Text<'a>) {
+    fn push_reactions(
+        &mut self,
+        counts: Vec<(&'a str, usize, &'a Option<MediaSource>)>,
+        style: Style,
+        text: &mut Text<'a>,
+        settings: &ApplicationSettings,
+        previews: &'a PreviewManager,
+    ) -> Vec<ProtocolPreview<'a>> {
         let mut emojis = printer::TextPrinter::new(self.width(), style, self.settings);
         let mut reactions = 0;
+        let mut protos = Vec::new();
 
-        for (key, count) in counts {
+        for (key, count, source) in counts {
             if reactions != 0 {
                 emojis.push_str(" ", style);
             }
 
-            let name = if self.settings.tunables.reaction_shortcode_display {
+            let proto = match source
+                .as_ref()
+                .and_then(|source| previews.get(source, PreviewKind::Reaction))
+            {
+                Some(ImageStatus::Loaded(backend)) => Some(Some(backend)),
+                // Use empty space as placeholder
+                Some(ImageStatus::Queued(_)) | Some(ImageStatus::Downloading(_)) => Some(None),
+                // Fall back to text
+                None | Some(ImageStatus::Error(_)) => None,
+            };
+
+            let name = if proto.is_some() {
+                "  "
+            } else if self.settings.tunables.reaction_shortcode_display {
                 if let Some(emoji) = emojis::get(key) {
                     if let Some(short) = emoji.shortcode() {
                         short
@@ -876,6 +897,13 @@ impl<'a> MessageFormatter<'a> {
             };
 
             emojis.push_str("[", style);
+            if let Some(Some(proto)) = proto {
+                let (x, y) = emojis.curosor_pos();
+                let y = (y + text.lines.len()) as u16;
+                let x = x as u16 + self.cols.user_gutter_width(settings);
+
+                protos.push((proto, x, y));
+            }
             emojis.push_str(name, style);
             emojis.push_str(" ", style);
             emojis.push_span_nobreak(Span::styled(count.to_string(), style));
@@ -887,6 +915,8 @@ impl<'a> MessageFormatter<'a> {
         if reactions > 0 {
             self.push_text(emojis.finish(), style, text);
         }
+
+        protos
     }
 
     fn push_thread_reply_count(&mut self, len: usize, text: &mut Text<'a>) {
@@ -1123,7 +1153,8 @@ impl Message {
         if settings.tunables.reaction_display {
             let reactions =
                 self.event.event_id().map(|id| info.get_reactions(id)).unwrap_or_default();
-            fmt.push_reactions(reactions, style, &mut text);
+            let react_protos = fmt.push_reactions(reactions, style, &mut text, settings, previews);
+            protos.extend(react_protos);
         }
 
         if let Some(thread) = self.event.event_id().and_then(|id| info.get_thread(Some(id))) {
@@ -1153,7 +1184,10 @@ impl Message {
         previews: &'a PreviewManager,
     ) -> (Text<'a>, Option<&'a Protocol>) {
         let mut proto = None;
-        let placeholder = match self.image_preview.as_ref().and_then(|source| previews.get(source))
+        let placeholder = match self
+            .image_preview
+            .as_ref()
+            .and_then(|source| previews.get(source, PreviewKind::Message))
         {
             None => None,
             Some(ImageStatus::Queued(image_preview_size)) => {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -898,7 +898,7 @@ impl<'a> MessageFormatter<'a> {
 
             emojis.push_str("[", style);
             if let Some(Some(proto)) = proto {
-                let (x, y) = emojis.curosor_pos();
+                let (x, y) = emojis.cursor_pos();
                 let y = (y + text.lines.len()) as u16;
                 let x = x as u16 + self.cols.user_gutter_width(settings);
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1067,7 +1067,7 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-    ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
+    ) -> (Text<'a>, Vec<ProtocolPreview<'a>>) {
         let width = vwctx.get_width();
 
         let style = self.get_render_style(selected, settings);
@@ -1075,12 +1075,17 @@ impl Message {
         let mut text = Text::default();
         let width = fmt.width();
 
+        let mut protos = Vec::new();
+
         // Show the message that this one replied to, if any.
         let reply = self.reply_to().or_else(|| self.thread_root()).map(|e| info.get_event(&e));
-        let proto_reply = reply.as_ref().and_then(|r| {
+        if let Some(r) = reply {
             if let Some(r) = r {
                 // Format the reply header, push it into the `Text` buffer, and get any image.
-                fmt.push_in_reply(r, style, &mut text, info, settings, previews)
+                let proto_reply = fmt.push_in_reply(r, style, &mut text, info, settings, previews);
+                if let Some(proto) = proto_reply {
+                    protos.push(proto)
+                }
             } else {
                 fmt.push_spans(
                     Line::from(vec![
@@ -1092,22 +1097,21 @@ impl Message {
                     style,
                     &mut text,
                 );
-                None
             }
-        });
+        }
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
         let (msg, proto) = self.show_msg(width, style, settings, previews);
 
         // Given our text so far, determine the image offset.
-        let proto_main = proto.map(|p| {
+        if let Some(p) = proto {
             let y_off = text.lines.len() as u16;
             let x_off = fmt.cols.user_gutter_width(settings);
 
             // Account for extra lines printed before the message;
             let y_off = y_off + fmt.message_start_line();
-            (p, x_off, y_off)
-        });
+            protos.push((p, x_off, y_off));
+        }
 
         fmt.push_text(msg, style, &mut text);
 
@@ -1126,7 +1130,7 @@ impl Message {
             fmt.push_thread_reply_count(thread.len(), &mut text);
         }
 
-        (text, [proto_main, proto_reply])
+        (text, protos)
     }
 
     pub fn show<'a>(

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -57,6 +57,11 @@ impl<'a> TextPrinter<'a> {
         }
     }
 
+    /// The position where the next text will be printed. (x, y)
+    pub fn curosor_pos(&self) -> (usize, usize) {
+        (self.curr_width, self.text.lines.len().saturating_sub(1))
+    }
+
     /// Configure the alignment for each line.
     pub fn align(mut self, alignment: Alignment) -> Self {
         self.alignment = alignment;

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -50,6 +50,11 @@ impl<'a> TextPrinter<'a> {
         }
     }
 
+    /// The position where the next text will be printed. (x, y)
+    pub fn curosor_pos(&self) -> (usize, usize) {
+        (self.curr_width, self.text.lines.len().saturating_sub(1))
+    }
+
     /// Configure the alignment for each line.
     pub fn align(mut self, alignment: Alignment) -> Self {
         self.alignment = alignment;

--- a/src/message/printer.rs
+++ b/src/message/printer.rs
@@ -50,8 +50,8 @@ impl<'a> TextPrinter<'a> {
         }
     }
 
-    /// The position where the next text will be printed. (x, y)
-    pub fn curosor_pos(&self) -> (usize, usize) {
+    /// The `(x, y)` position where the next text will be printed.
+    pub fn cursor_pos(&self) -> (usize, usize) {
         (self.curr_width, self.text.lines.len().saturating_sub(1))
     }
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,11 +1,7 @@
-use std::{
-    fs::File,
-    io::{Read, Write},
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{
-    media::{MediaFormat, MediaRequestParameters},
+    media::{MediaFormat, MediaRequestParameters, UniqueKey},
     ruma::{
         events::{
             room::{
@@ -15,18 +11,101 @@ use matrix_sdk::{
             MessageLikeEvent,
         },
         OwnedEventId,
-        OwnedRoomId,
     },
     Media,
 };
 use ratatui::layout::Rect;
-use ratatui_image::Resize;
+use ratatui_image::{picker::Picker, protocol::Protocol, Resize};
+use tokio::sync::Semaphore;
 
 use crate::{
-    base::{AsyncProgramStore, ChatStore, IambError},
-    config::ImagePreviewSize,
-    message::ImageStatus,
+    base::{AsyncProgramStore, IambError},
+    config::{ApplicationSettings, ImagePreviewSize},
+    worker::Requester,
 };
+
+pub enum ImageStatus {
+    Queued(ImagePreviewSize),
+    Downloading(ImagePreviewSize),
+    Loaded(Protocol),
+    Error(String),
+}
+
+pub struct PreviewManager {
+    /// Image preview "protocol" picker.
+    picker: Option<Arc<Picker>>,
+
+    /// Permits for rendering images in background thread.
+    permits: Arc<Semaphore>,
+
+    /// Indexed by [`MediaSource::unique_key`]
+    previews: HashMap<String, ImageStatus>,
+}
+
+impl PreviewManager {
+    pub fn new(picker: Option<Picker>) -> Self {
+        Self {
+            picker: picker.map(Into::into),
+            permits: Arc::new(Semaphore::new(2)),
+            previews: Default::default(),
+        }
+    }
+
+    pub fn get(&self, source: &MediaSource) -> Option<&ImageStatus> {
+        self.previews.get(&source.unique_key())
+    }
+
+    fn insert(&mut self, key: String, status: ImageStatus) {
+        self.previews.insert(key, status);
+    }
+
+    /// Queue download and preparation of preview
+    pub fn load(&mut self, source: &MediaSource, worker: &Requester) {
+        let Some(status) = self.previews.get_mut(&source.unique_key()) else {
+            return;
+        };
+        let Some(picker) = &self.picker else { return };
+
+        if let ImageStatus::Queued(size) = status {
+            let size = *size;
+            *status = ImageStatus::Downloading(size);
+
+            worker.load_image(
+                source.to_owned(),
+                size.to_owned(),
+                Arc::clone(picker),
+                Arc::clone(&self.permits),
+            );
+        }
+    }
+
+    pub fn register_preview(
+        &mut self,
+        settings: &ApplicationSettings,
+        source: MediaSource,
+        size: ImagePreviewSize,
+        worker: &Requester,
+    ) {
+        if self.picker.is_none() {
+            return;
+        }
+
+        let key = source.unique_key();
+        if self.previews.contains_key(&key) {
+            return;
+        }
+        self.previews.insert(key, ImageStatus::Queued(size));
+
+        if settings
+            .tunables
+            .image_preview
+            .as_ref()
+            .is_some_and(|setting| !setting.lazy_load)
+        {
+            self.load(&source, worker);
+        }
+    }
+}
 
 pub fn source_from_event(
     ev: &MessageLikeEvent<RoomMessageEventContent>,
@@ -50,171 +129,54 @@ impl From<Rect> for ImagePreviewSize {
     }
 }
 
-/// Download and prepare the preview, and then lock the store to insert it.
-pub fn spawn_insert_preview(
+pub async fn load_image(
     store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    source: MediaSource,
     media: Media,
-    cache_dir: PathBuf,
-    preview: ImagePreviewSize,
+    source: MediaSource,
+    picker: Arc<Picker>,
+    permits: Arc<Semaphore>,
+    size: ImagePreviewSize,
 ) {
-    tokio::spawn(async move {
-        let img = download_or_load(event_id.to_owned(), source, media, cache_dir)
+    async fn load_image_inner(
+        media: Media,
+        source: MediaSource,
+        picker: Arc<Picker>,
+        permits: Arc<Semaphore>,
+        size: ImagePreviewSize,
+    ) -> Result<ImageStatus, IambError> {
+        let reader = media
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
             .await
             .map(std::io::Cursor::new)
             .map(image::ImageReader::new)
             .map_err(IambError::Matrix)
-            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError));
+            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError))?;
 
-        match img {
-            Err(err) => {
-                try_set_msg_preview_error(
-                    &mut store.lock().await.application,
-                    room_id,
-                    event_id,
-                    err,
-                );
-            },
-            Ok(img) => {
-                let mut locked = store.lock().await;
+        let image = reader.decode().map_err(IambError::Image)?;
 
-                match locked
-                    .application
-                    .rooms
-                    .get_or_default(room_id.clone())
-                    .get_event_mut(&event_id)
-                    .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-                {
-                    Err(err) => {
-                        try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-                    },
-                    Ok(msg) => msg.image_preview = ImageStatus::Loading(Some(img), preview),
-                }
-            },
-        }
-    });
-}
+        let permit = permits
+            .acquire()
+            .await
+            .map_err(|err| IambError::Preview(err.to_string()))?;
 
-pub async fn render_preview(
-    store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-) {
-    let mut locked = store.lock().await;
-
-    let picker = locked.application.picker.clone();
-    let Some(img) = locked
-        .application
-        .rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .map(|msg| {
-            if let ImageStatus::Loading(reader, size) = &mut msg.image_preview {
-                reader.take().map(|reader| (reader, size.clone()))
-            } else {
-                None
-            }
-        })
-        .transpose()
-    else {
-        // ignore if image is already being loaded
-        return;
-    };
-
-    // make shure to unlock store while computing `new_protocol`
-    drop(locked);
-
-    let image = picker
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .and_then(|picker| {
-            let (reader, size) = img?;
-            Ok((picker, reader, size))
-        })
-        .and_then(|(picker, reader, size)| {
-            let image = reader.decode().map_err(IambError::Image)?;
-            Ok((picker, image, size))
-        })
-        .and_then(|(picker, image, size)| {
+        let handle = tokio::task::spawn_blocking(move || {
             picker
                 .new_protocol(image, size.into(), Resize::Fit(None))
-                .map_err(|err| IambError::Preview(format!("{err}")))
+                .map_err(|err| IambError::Preview(err.to_string()))
         });
 
+        let image = handle.await.map_err(|err| IambError::Preview(err.to_string()))??;
+        std::mem::drop(permit);
+
+        Ok(ImageStatus::Loaded(image))
+    }
+    let key = source.unique_key();
+
+    let status = match load_image_inner(media, source, picker, permits, size).await {
+        Ok(status) => status,
+        Err(err) => ImageStatus::Error(format!("{err:?}")),
+    };
+
     let mut locked = store.lock().await;
-
-    match image {
-        Err(err) => {
-            try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-        },
-        Ok(backend) => {
-            locked
-                .application
-                .rooms
-                .get_or_default(room_id)
-                .get_event_mut(&event_id)
-                .unwrap()
-                .image_preview = ImageStatus::Loaded(backend);
-        },
-    }
-}
-
-fn try_set_msg_preview_error(
-    application: &mut ChatStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    err: IambError,
-) {
-    let rooms = &mut application.rooms;
-
-    match rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-    {
-        Ok(msg) => msg.image_preview = ImageStatus::Error(format!("{err:?}")),
-        Err(err) => {
-            tracing::error!(
-                "Failed to set error on msg.image_backend for event {}, room {}: {}",
-                event_id,
-                room_id,
-                err
-            )
-        },
-    }
-}
-
-async fn download_or_load(
-    event_id: OwnedEventId,
-    source: MediaSource,
-    media: Media,
-    mut cache_path: PathBuf,
-) -> Result<Vec<u8>, matrix_sdk::Error> {
-    cache_path.push(Path::new(event_id.localpart()));
-
-    match File::open(&cache_path) {
-        Ok(mut f) => {
-            let mut buffer = Vec::new();
-            f.read_to_end(&mut buffer)?;
-            Ok(buffer)
-        },
-        Err(_) => {
-            media
-                .get_media_content(
-                    &MediaRequestParameters { source, format: MediaFormat::File },
-                    true,
-                )
-                .await
-                .and_then(|buffer| {
-                    if let Err(err) =
-                        File::create(&cache_path).and_then(|mut f| f.write_all(&buffer))
-                    {
-                        return Err(err.into());
-                    }
-                    Ok(buffer)
-                })
-        },
-    }
+    locked.application.previews.insert(key, status);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -201,6 +201,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        cache_policy: Default::default(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -163,7 +163,6 @@ pub fn mock_dirs() -> DirectoryValues {
         data: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
-        image_previews: PathBuf::new(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,7 +164,6 @@ pub fn mock_dirs() -> DirectoryValues {
         data: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
-        image_previews: PathBuf::new(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -203,6 +203,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        cache_policy: Default::default(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -208,6 +208,7 @@ pub fn mock_tunables() -> TunableValues {
         members_split: Default::default(),
         default_split: Default::default(),
         ssl_verify: true,
+        cache_policy: Default::default(),
     }
 }
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -506,21 +506,22 @@ impl ChatState {
                     None => return Ok(None),
                 };
 
-                let reactions = reactions.iter().filter_map(|(event_id, (reaction, user_id))| {
-                    if user_id != &settings.profile.user_id {
-                        return None;
-                    }
-
-                    if let Some(emoji) = &emoji {
-                        if emoji == reaction {
-                            return Some(event_id);
-                        } else {
+                let reactions =
+                    reactions.iter().filter_map(|(event_id, (reaction, user_id, _))| {
+                        if user_id != &settings.profile.user_id {
                             return None;
                         }
-                    } else {
-                        return Some(event_id);
-                    }
-                });
+
+                        if let Some(emoji) = &emoji {
+                            if emoji == reaction {
+                                return Some(event_id);
+                            } else {
+                                return None;
+                            }
+                        } else {
+                            return Some(event_id);
+                        }
+                    });
 
                 for reaction in reactions {
                     let _ = room.redact(reaction, None, None).await.map_err(IambError::from)?;

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -547,21 +547,22 @@ impl ChatState {
                     None => return Ok(None),
                 };
 
-                let reactions = reactions.iter().filter_map(|(event_id, (reaction, user_id))| {
-                    if user_id != &settings.profile.user_id {
-                        return None;
-                    }
-
-                    if let Some(emoji) = &emoji {
-                        if emoji == reaction {
-                            return Some(event_id);
-                        } else {
+                let reactions =
+                    reactions.iter().filter_map(|(event_id, (reaction, user_id, _))| {
+                        if user_id != &settings.profile.user_id {
                             return None;
                         }
-                    } else {
-                        return Some(event_id);
-                    }
-                });
+
+                        if let Some(emoji) = &emoji {
+                            if emoji == reaction {
+                                return Some(event_id);
+                            } else {
+                                return None;
+                            }
+                        } else {
+                            return Some(event_id);
+                        }
+                    });
 
                 for reaction in reactions {
                     let _ = room.redact(reaction, None, None).await.map_err(IambError::from)?;

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,7 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageKey, Messages},
+    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -1347,6 +1347,14 @@ impl StatefulWidget for Scrollback<'_> {
 
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
+
+            if let ImageStatus::Loading(_, _) = &item.image_preview {
+                self.store
+                    .application
+                    .worker
+                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
+            }
+
             let (txt, [mut msg_preview, mut reply_preview]) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,8 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
+    message::{Message, MessageCursor, MessageKey, Messages},
+    preview::PreviewManager,
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -270,6 +271,7 @@ impl ScrollbackState {
         pos: MovePosition,
         info: &RoomInfo,
         settings: &ApplicationSettings,
+        previews: &PreviewManager,
     ) {
         let Some(thread) = self.get_thread(info) else {
             return;
@@ -292,7 +294,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     if key == &idx {
                         lines += len / 2;
@@ -315,7 +318,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     lines += len;
 
@@ -338,7 +342,12 @@ impl ScrollbackState {
         self.jumped.push(self.cursor.clone());
     }
 
-    fn shift_cursor(&mut self, info: &RoomInfo, settings: &ApplicationSettings) {
+    fn shift_cursor(
+        &mut self,
+        info: &RoomInfo,
+        settings: &ApplicationSettings,
+        previews: &PreviewManager,
+    ) {
         let Some(thread) = self.get_thread(info) else {
             return;
         };
@@ -368,7 +377,10 @@ impl ScrollbackState {
                 break;
             }
 
-            lines += item.show(prev, false, &self.viewctx, info, settings).height().max(1);
+            lines += item
+                .show(prev, false, &self.viewctx, info, settings, previews)
+                .height()
+                .max(1);
 
             if lines >= self.viewctx.get_height() {
                 // We've reached the end of the viewport; move cursor into it.
@@ -1067,6 +1079,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
     ) -> EditResult<EditInfo, IambInfo> {
         let info = store.application.rooms.get_or_default(self.room_id.clone());
         let settings = &store.application.settings;
+        let previews = &store.application.previews;
         let mut corner = self.viewctx.corner.clone();
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
@@ -1094,7 +1107,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 for (key, item) in thread.range(..=&corner_key).rev() {
                     let sel = key == cursor_key;
                     let prev = prevmsg(key, thread);
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1122,7 +1135,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                 for (key, item) in thread.range(&corner_key..) {
                     let sel = key == cursor_key;
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1160,7 +1173,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         }
 
         self.viewctx.corner = corner;
-        self.shift_cursor(info, settings);
+        self.shift_cursor(info, settings, previews);
 
         Ok(None)
     }
@@ -1182,10 +1195,11 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
             Axis::Vertical => {
                 let info = store.application.rooms.get_or_default(self.room_id.clone());
                 let settings = &store.application.settings;
+                let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
                 if let Some(key) = self.cursor.to_key(thread).cloned() {
-                    self.scrollview(key, pos, info, settings);
+                    self.scrollview(key, pos, info, settings, previews);
                 }
 
                 Ok(None)
@@ -1345,18 +1359,33 @@ impl StatefulWidget for Scrollback<'_> {
         let mut sawit = false;
         let mut prev = prevmsg(&corner_key, thread);
 
+        // load image previews
+        for (_, item) in thread.range(&corner_key..).rev() {
+            if let Some(source) = &item.image_preview {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+            let reply = item
+                .reply_to()
+                .or_else(|| item.thread_root())
+                .and_then(|e| info.get_event(&e))
+                .and_then(|msg| msg.image_preview.as_ref());
+            if let Some(source) = reply {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+        }
+
+        let previews = &self.store.application.previews;
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            if let ImageStatus::Loading(_, _) = &item.image_preview {
-                self.store
-                    .application
-                    .worker
-                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
-            }
-
             let (txt, [mut msg_preview, mut reply_preview]) =
-                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
+                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
 
             let incomplete_ok = !full || !sel;
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1384,12 +1384,8 @@ impl StatefulWidget for Scrollback<'_> {
                     &self.store.application.worker,
                 );
             }
-            let reactions =
-                key.id.as_origin().and_then(|id| info.reactions.get(id)).map(|reactions| {
-                    reactions.iter().filter_map(|(_, (_, _, source))| source.as_ref())
-                });
-            if let Some(reactions) = reactions {
-                for source in reactions {
+            if let Some(event_id) = key.id.as_origin() {
+                for source in info.get_reaction_images(event_id) {
                     self.store.application.previews.load(
                         source,
                         PreviewKind::Reaction,

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -55,7 +55,7 @@ use crate::{
     },
     config::ApplicationSettings,
     message::{Message, MessageCursor, MessageKey, Messages},
-    preview::PreviewManager,
+    preview::{PreviewKind, PreviewManager},
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -1364,12 +1364,13 @@ impl StatefulWidget for Scrollback<'_> {
         let mut prev = prevmsg(&corner_key, thread);
 
         // load image previews
-        for (_, item) in thread.range(&corner_key..).rev() {
+        for (key, item) in thread.range(&corner_key..).rev() {
             if let Some(source) = &item.image_preview {
-                self.store
-                    .application
-                    .previews
-                    .load(source, &self.store.application.worker);
+                self.store.application.previews.load(
+                    source,
+                    PreviewKind::Message,
+                    &self.store.application.worker,
+                );
             }
             let reply = item
                 .reply_to()
@@ -1377,10 +1378,24 @@ impl StatefulWidget for Scrollback<'_> {
                 .and_then(|e| info.get_event(&e))
                 .and_then(|msg| msg.image_preview.as_ref());
             if let Some(source) = reply {
-                self.store
-                    .application
-                    .previews
-                    .load(source, &self.store.application.worker);
+                self.store.application.previews.load(
+                    source,
+                    PreviewKind::Message,
+                    &self.store.application.worker,
+                );
+            }
+            let reactions =
+                key.id.as_origin().and_then(|id| info.reactions.get(id)).map(|reactions| {
+                    reactions.iter().filter_map(|(_, (_, _, source))| source.as_ref())
+                });
+            if let Some(reactions) = reactions {
+                for source in reactions {
+                    self.store.application.previews.load(
+                        source,
+                        PreviewKind::Reaction,
+                        &self.store.application.worker,
+                    );
+                }
             }
         }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1388,7 +1388,7 @@ impl StatefulWidget for Scrollback<'_> {
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            let (txt, [mut msg_preview, mut reply_preview]) =
+            let (txt, mut msg_previews) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
 
             let incomplete_ok = !full || !sel;
@@ -1405,17 +1405,9 @@ impl StatefulWidget for Scrollback<'_> {
                     continue;
                 }
 
-                // Only take the preview into the matching row number.
-                // `reply` and `msg` previews are on rows,
-                // so an `or` works to pick the one that matches (if any)
-                let line_preview = match msg_preview {
-                    Some((_, _, y)) if y as usize == row => msg_preview.take(),
-                    _ => None,
-                }
-                .or(match reply_preview {
-                    Some((_, _, y)) if y as usize == row => reply_preview.take(),
-                    _ => None,
-                });
+                // Only take the previews into the matching row number.
+                let line_preview: Vec<_> =
+                    msg_previews.extract_if(.., |(_, _, y)| *y as usize == row).collect();
 
                 lines.push((key, row, line, line_preview));
                 sawit |= sel;
@@ -1440,9 +1432,9 @@ impl StatefulWidget for Scrollback<'_> {
         let mut image_previews = vec![];
         for (_, _, txt, line_preview) in lines.into_iter() {
             let _ = buf.set_line(x, y, &txt, area.width);
-            if let Some((backend, msg_x, _)) = line_preview {
-                image_previews.push((x + msg_x, y, backend));
-            }
+            image_previews.extend(
+                line_preview.into_iter().map(|(backend, msg_x, _)| (x + msg_x, y, backend)),
+            );
 
             y += 1;
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,7 +13,6 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
-use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::ruma::events::room::MediaSource;
 use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -764,13 +763,7 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
 
     client
         .media()
-        .set_media_retention_policy(
-            MediaRetentionPolicy::new()
-                // 4 GiB.
-                .with_max_cache_size(Some(4 * 1024 * 1024 * 1024))
-                // 200 MiB.
-                .with_max_file_size(Some(200 * 1024 * 1024)),
-        )
+        .set_media_retention_policy(settings.tunables.cache_policy)
         .await
         .expect("Failed to set cache policy");
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -90,6 +90,7 @@ use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::MessageNeed;
 use crate::notifications::register_notifications;
+use crate::preview::render_preview;
 use crate::{
     base::{
         AsyncProgramStore,
@@ -635,6 +636,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
+    RenderImage(OwnedRoomId, OwnedEventId),
 }
 
 impl Debug for WorkerTask {
@@ -696,6 +698,12 @@ impl Debug for WorkerTask {
                 f.debug_tuple("WorkerTask::VerifyRequest")
                     .field(user_id)
                     .field(&format_args!("_"))
+                    .finish()
+            },
+            WorkerTask::RenderImage(room_id, message_id) => {
+                f.debug_tuple("WorkerTask::RenderImage")
+                    .field(room_id)
+                    .field(message_id)
                     .finish()
             },
         }
@@ -843,6 +851,10 @@ impl Requester {
 
         return response.recv();
     }
+
+    pub fn render_image(&self, room_id: OwnedRoomId, message_id: OwnedEventId) {
+        self.tx.send(WorkerTask::RenderImage(room_id, message_id)).unwrap();
+    }
 }
 
 pub struct ClientWorker {
@@ -851,6 +863,9 @@ pub struct ClientWorker {
     client: Client,
     load_handle: Option<JoinHandle<()>>,
     sync_handle: Option<JoinHandle<()>>,
+
+    /// Take care when locking since worker commands are sent with the lock already hold
+    store: Option<AsyncProgramStore>,
 }
 
 impl ClientWorker {
@@ -863,6 +878,7 @@ impl ClientWorker {
             client: client.clone(),
             load_handle: None,
             sync_handle: None,
+            store: None,
         };
 
         tokio::spawn(async move {
@@ -935,6 +951,10 @@ impl ClientWorker {
             WorkerTask::VerifyRequest(user_id, reply) => {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
+            },
+            WorkerTask::RenderImage(room_id, message_id) => {
+                assert!(self.initialized);
+                tokio::spawn(render_preview(self.store.clone().unwrap(), room_id, message_id));
             },
         }
     }
@@ -1246,6 +1266,8 @@ impl ClientWorker {
                 }
             },
         );
+
+        self.store = Some(store.clone());
 
         self.load_handle = tokio::spawn({
             let client = self.client.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
+use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::ruma::events::room::MediaSource;
 use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -93,7 +94,7 @@ use modalkit::prelude::{EditInfo, InfoMessage};
 use crate::base::MessageNeed;
 use crate::config::ImagePreviewSize;
 use crate::notifications::register_notifications;
-use crate::preview::load_image;
+use crate::preview::PreviewKind;
 use crate::{
     base::{
         AsyncProgramStore,
@@ -347,7 +348,7 @@ fn load_insert(
                         info.insert_with_preview(msg, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Reaction(ev)) => {
-                        info.insert_reaction(ev);
+                        info.insert_reaction_with_preview(ev, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(_) => {
                         continue;
@@ -629,7 +630,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
-    LoadImage(MediaSource, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
+    LoadImage(MediaSource, PreviewKind, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
 }
 
 impl Debug for WorkerTask {
@@ -693,9 +694,10 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::LoadImage(source, size, _, _) => {
+            WorkerTask::LoadImage(source, kind, size, _, _) => {
                 f.debug_tuple("WorkerTask::RenderImage")
                     .field(source)
+                    .field(kind)
                     .field(size)
                     .field(&format_args!("_"))
                     .field(&format_args!("_"))
@@ -721,7 +723,10 @@ async fn create_client_inner(
         .build()
         .unwrap();
 
-    let req_config = RequestConfig::new().timeout(req_timeout).max_retry_time(req_timeout);
+    let req_config = RequestConfig::new()
+        .timeout(req_timeout)
+        .max_retry_time(req_timeout)
+        .retry_limit(8);
 
     // Set up the Matrix client for the selected profile.
     let builder = Client::builder()
@@ -753,7 +758,21 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
         res => res,
     };
 
-    res.expect("Failed to instantiate client")
+    let client = res.expect("Failed to instantiate client");
+
+    client
+        .media()
+        .set_media_retention_policy(
+            MediaRetentionPolicy::new()
+                // 4 GiB.
+                .with_max_cache_size(Some(4 * 1024 * 1024 * 1024))
+                // 200 MiB.
+                .with_max_file_size(Some(200 * 1024 * 1024)),
+        )
+        .await
+        .expect("Failed to set cache policy");
+
+    client
 }
 
 #[derive(Clone)]
@@ -850,11 +869,14 @@ impl Requester {
     pub fn load_image(
         &self,
         source: MediaSource,
+        kind: PreviewKind,
         size: ImagePreviewSize,
         picker: Arc<Picker>,
         permits: Arc<Semaphore>,
     ) {
-        self.tx.send(WorkerTask::LoadImage(source, size, picker, permits)).unwrap();
+        self.tx
+            .send(WorkerTask::LoadImage(source, kind, size, picker, permits))
+            .unwrap();
     }
 }
 
@@ -953,12 +975,13 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
             },
-            WorkerTask::LoadImage(source, size, picker, permits) => {
+            WorkerTask::LoadImage(source, kind, size, picker, permits) => {
                 assert!(self.initialized);
-                tokio::spawn(load_image(
+                tokio::spawn(crate::preview::load_image(
                     self.store.clone().unwrap(),
                     self.client.media(),
                     source,
+                    kind,
                     picker,
                     permits,
                     size,
@@ -1062,9 +1085,18 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let ChatStore { rooms, previews, settings, worker, .. } =
+                        &mut locked.application;
+                    let info = rooms.get_or_default(room_id.to_owned());
+
                     update_event_receipts(info, &room, ev.event_id()).await;
-                    info.insert_reaction(ev.into_full_event(room_id.to_owned()));
+
+                    info.insert_reaction_with_preview(
+                        ev.into_full_event(room_id.to_owned()),
+                        settings,
+                        previews,
+                        worker,
+                    );
                 }
             },
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
+use matrix_sdk::ruma::events::room::MediaSource;
+use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -89,8 +91,9 @@ use modalkit::errors::UIError;
 use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::MessageNeed;
+use crate::config::ImagePreviewSize;
 use crate::notifications::register_notifications;
-use crate::preview::render_preview;
+use crate::preview::load_image;
 use crate::{
     base::{
         AsyncProgramStore,
@@ -255,11 +258,10 @@ async fn run_plan(client: &Client, store: &AsyncProgramStore, plan: Plan, permit
         Plan::Messages(room_id, fetch_id, message_need) => {
             let limit = MIN_MSG_LOAD;
             let client = client.clone();
-            let store_clone = store.clone();
 
             let res = load_older_one(&client, &room_id, fetch_id, limit).await;
             let mut locked = store.lock().await;
-            load_insert(room_id, res, locked.deref_mut(), store_clone, message_need);
+            load_insert(room_id, res, locked.deref_mut(), message_need);
         },
         Plan::Members(room_id) => {
             let res = members_load(client, &room_id).await;
@@ -321,13 +323,11 @@ fn load_insert(
     room_id: OwnedRoomId,
     res: MessageFetchResult,
     locked: &mut ProgramStore,
-    store: AsyncProgramStore,
     message_needs: Vec<MessageNeed>,
 ) {
-    let ChatStore { presences, rooms, worker, picker, settings, .. } = &mut locked.application;
+    let ChatStore { presences, rooms, previews, settings, worker, .. } = &mut locked.application;
     let info = rooms.get_or_default(room_id.clone());
     info.fetching = false;
-    let client = &worker.client;
 
     match res {
         Ok((fetch_id, msgs)) => {
@@ -344,14 +344,7 @@ fn load_insert(
                         info.insert_encrypted(msg);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(msg)) => {
-                        info.insert_with_preview(
-                            room_id.clone(),
-                            store.clone(),
-                            picker.clone(),
-                            msg,
-                            settings,
-                            client.media(),
-                        );
+                        info.insert_with_preview(msg, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Reaction(ev)) => {
                         info.insert_reaction(ev);
@@ -636,7 +629,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
-    RenderImage(OwnedRoomId, OwnedEventId),
+    LoadImage(MediaSource, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
 }
 
 impl Debug for WorkerTask {
@@ -700,10 +693,12 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::RenderImage(room_id, message_id) => {
+            WorkerTask::LoadImage(source, size, _, _) => {
                 f.debug_tuple("WorkerTask::RenderImage")
-                    .field(room_id)
-                    .field(message_id)
+                    .field(source)
+                    .field(size)
+                    .field(&format_args!("_"))
+                    .field(&format_args!("_"))
                     .finish()
             },
         }
@@ -852,8 +847,14 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn render_image(&self, room_id: OwnedRoomId, message_id: OwnedEventId) {
-        self.tx.send(WorkerTask::RenderImage(room_id, message_id)).unwrap();
+    pub fn load_image(
+        &self,
+        source: MediaSource,
+        size: ImagePreviewSize,
+        picker: Arc<Picker>,
+        permits: Arc<Semaphore>,
+    ) {
+        self.tx.send(WorkerTask::LoadImage(source, size, picker, permits)).unwrap();
     }
 }
 
@@ -952,9 +953,16 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
             },
-            WorkerTask::RenderImage(room_id, message_id) => {
+            WorkerTask::LoadImage(source, size, picker, permits) => {
                 assert!(self.initialized);
-                tokio::spawn(render_preview(self.store.clone().unwrap(), room_id, message_id));
+                tokio::spawn(load_image(
+                    self.store.clone().unwrap(),
+                    self.client.media(),
+                    source,
+                    picker,
+                    permits,
+                    size,
+                ));
             },
         }
     }
@@ -1030,20 +1038,14 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let ChatStore { rooms, picker, settings, .. } = &mut locked.application;
+                    let ChatStore { rooms, previews, settings, worker, .. } =
+                        &mut locked.application;
                     let info = rooms.get_or_default(room_id.to_owned());
 
                     update_event_receipts(info, &room, ev.event_id()).await;
 
                     let full_ev = ev.into_full_event(room_id.to_owned());
-                    info.insert_with_preview(
-                        room_id.to_owned(),
-                        store.clone(),
-                        picker.clone(),
-                        full_ev,
-                        settings,
-                        client.media(),
-                    );
+                    info.insert_with_preview(full_ev, settings, previews, worker);
                 }
             },
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,7 +13,6 @@ use std::time::{Duration, Instant};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
-use matrix_sdk::media::MediaRetentionPolicy;
 use matrix_sdk::ruma::events::room::MediaSource;
 use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -762,13 +761,7 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
 
     client
         .media()
-        .set_media_retention_policy(
-            MediaRetentionPolicy::new()
-                // 4 GiB.
-                .with_max_cache_size(Some(4 * 1024 * 1024 * 1024))
-                // 200 MiB.
-                .with_max_file_size(Some(200 * 1024 * 1024)),
-        )
+        .set_media_retention_policy(settings.tunables.cache_policy)
         .await
         .expect("Failed to set cache policy");
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -886,6 +886,12 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
     client.event_cache().subscribe().expect("Failed to start event cache");
 
     client
+        .media()
+        .set_media_retention_policy(settings.tunables.cache_policy)
+        .await
+        .expect("Failed to start event cache");
+
+    client
 }
 
 #[derive(Clone)]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -98,7 +98,7 @@ use crate::base::{EchoLocation, MessageNeed};
 use crate::config::{ImagePreviewSize, ProxyUrl};
 use crate::message::{Message, MessageEvent, MessageId, MessageKey};
 use crate::notifications::register_notifications;
-use crate::preview::load_image;
+use crate::preview::PreviewKind;
 use crate::{
     ApplicationSettings,
     base::{
@@ -326,7 +326,7 @@ fn load_insert(
                         info.insert_with_preview(msg, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Reaction(ev)) => {
-                        info.insert_reaction(ev);
+                        info.insert_reaction_with_preview(ev, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Sticker(ev)) => {
                         info.insert_sticker(ev, settings, previews, worker);
@@ -726,7 +726,7 @@ pub enum WorkerTask {
     TypingNotice(OwnedRoomId),
     Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
     VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
-    LoadImage(MediaSource, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
+    LoadImage(MediaSource, PreviewKind, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
 }
 
 impl Debug for WorkerTask {
@@ -790,9 +790,10 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
-            WorkerTask::LoadImage(source, size, _, _) => {
+            WorkerTask::LoadImage(source, kind, size, _, _) => {
                 f.debug_tuple("WorkerTask::RenderImage")
                     .field(source)
+                    .field(kind)
                     .field(size)
                     .field(&format_args!("_"))
                     .field(&format_args!("_"))
@@ -845,7 +846,10 @@ async fn create_client_inner(
 
     let http = builder.build().map_err(matrix_sdk::HttpError::Reqwest)?;
 
-    let req_config = RequestConfig::new().timeout(req_timeout).max_retry_time(req_timeout);
+    let req_config = RequestConfig::new()
+        .timeout(req_timeout)
+        .max_retry_time(req_timeout)
+        .retry_limit(8);
 
     // Set up the Matrix client for the selected profile.
     let builder = Client::builder()
@@ -978,11 +982,14 @@ impl Requester {
     pub fn load_image(
         &self,
         source: MediaSource,
+        kind: PreviewKind,
         size: ImagePreviewSize,
         picker: Arc<Picker>,
         permits: Arc<Semaphore>,
     ) {
-        self.tx.send(WorkerTask::LoadImage(source, size, picker, permits)).unwrap();
+        self.tx
+            .send(WorkerTask::LoadImage(source, kind, size, picker, permits))
+            .unwrap();
     }
 }
 
@@ -1081,12 +1088,13 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.verify_request(user_id).await);
             },
-            WorkerTask::LoadImage(source, size, picker, permits) => {
+            WorkerTask::LoadImage(source, kind, size, picker, permits) => {
                 assert!(self.initialized);
-                tokio::spawn(load_image(
+                tokio::spawn(crate::preview::load_image(
                     self.store.clone().unwrap(),
                     self.client.media(),
                     source,
+                    kind,
                     picker,
                     permits,
                     size,
@@ -1188,9 +1196,18 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let ChatStore { rooms, previews, settings, worker, .. } =
+                        &mut locked.application;
+                    let info = rooms.get_or_default(room_id.to_owned());
+
                     update_event_receipts(info, &room, ev.event_id()).await;
-                    info.insert_reaction(ev.into_full_event(room_id.to_owned()));
+
+                    info.insert_reaction_with_preview(
+                        ev.into_full_event(room_id.to_owned()),
+                        settings,
+                        previews,
+                        worker,
+                    );
                 }
             },
         );


### PR DESCRIPTION
This renders reaction images if normal message previews are enabled.

[MSC4027](https://github.com/matrix-org/matrix-spec-proposals/pull/4027) is used widely by matrix bridges to other services.

~includes #464~
addresses #487 and #320