### PR TITLE
Indicate encryption state of room in messagebar

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -283,6 +283,9 @@ async fn load_older_one(
     limit: u32,
 ) -> MessageFetchResult {
     if let Some(room) = client.get_room(room_id) {
+        // Update cached encryption state. This is a noop if the state is already cached.
+        let _ = room.request_encryption_state().await;
+
         let mut opts = match &fetch_id {
             Some(id) => MessagesOptions::backward().from(id.as_str()),
             None => MessagesOptions::backward(),


### PR DESCRIPTION
This replaces the prompt of the message bar with a green `🔒︎` for encrypted rooms and a red `🔓︎` for unencrypted rooms.

fixes #137