### PR TITLE
Expand `~` and shell variables in dirs config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "shellexpand",
  "sled",
  "temp-dir",
  "thiserror 1.0.69",
@@ -5106,6 +5107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static 1.5.0",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ url = {version = "^2.2.2", features = ["serde"]}
 edit = "0.1.4"
 humansize = "2.0.0"
 linkify = "0.10.0"
+shellexpand = "3.1.1"
 
 [dependencies.comrak]
 version = "0.22.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -707,11 +707,11 @@ impl DirectoryValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Directories {
-    pub cache: Option<PathBuf>,
-    pub data: Option<PathBuf>,
-    pub logs: Option<PathBuf>,
-    pub downloads: Option<PathBuf>,
-    pub image_previews: Option<PathBuf>,
+    pub cache: Option<String>,
+    pub data: Option<String>,
+    pub logs: Option<String>,
+    pub downloads: Option<String>,
+    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -728,6 +728,11 @@ impl Directories {
     fn values(self) -> DirectoryValues {
         let cache = self
             .cache
+            .map(|dir| {
+                let dir = shellexpand::full(&dir)
+                    .expect("unable to expand shell variables in dirs.cache");
+                Path::new(dir.as_ref()).to_owned()
+            })
             .or_else(|| {
                 let mut dir = dirs::cache_dir()?;
                 dir.push("iamb");
@@ -737,6 +742,11 @@ impl Directories {
 
         let data = self
             .data
+            .map(|dir| {
+                let dir = shellexpand::full(&dir)
+                    .expect("unable to expand shell variables in dirs.cache");
+                Path::new(dir.as_ref()).to_owned()
+            })
             .or_else(|| {
                 let mut dir = dirs::data_dir()?;
                 dir.push("iamb");
@@ -744,19 +754,40 @@ impl Directories {
             })
             .expect("no dirs.data value configured!");
 
-        let logs = self.logs.unwrap_or_else(|| {
-            let mut dir = cache.clone();
-            dir.push("logs");
-            dir
-        });
+        let logs = self
+            .logs
+            .map(|dir| {
+                let dir = shellexpand::full(&dir)
+                    .expect("unable to expand shell variables in dirs.cache");
+                Path::new(dir.as_ref()).to_owned()
+            })
+            .unwrap_or_else(|| {
+                let mut dir = cache.clone();
+                dir.push("logs");
+                dir
+            });
 
-        let downloads = self.downloads.or_else(dirs::download_dir);
+        let downloads = self
+            .downloads
+            .map(|dir| {
+                let dir = shellexpand::full(&dir)
+                    .expect("unable to expand shell variables in dirs.cache");
+                Path::new(dir.as_ref()).to_owned()
+            })
+            .or_else(dirs::download_dir);
 
-        let image_previews = self.image_previews.unwrap_or_else(|| {
-            let mut dir = cache.clone();
-            dir.push("image_preview_downloads");
-            dir
-        });
+        let image_previews = self
+            .image_previews
+            .map(|dir| {
+                let dir = shellexpand::full(&dir)
+                    .expect("unable to expand shell variables in dirs.cache");
+                Path::new(dir.as_ref()).to_owned()
+            })
+            .unwrap_or_else(|| {
+                let mut dir = cache.clone();
+                dir.push("image_preview_downloads");
+                dir
+            });
 
         DirectoryValues { cache, data, logs, downloads, image_previews }
     }


### PR DESCRIPTION
fixes #244