### PR TITLE
Fix incorrect empty unreads window message

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -641,7 +641,7 @@ impl WindowOps<IambInfo> for IambWindow {
                 state.set(items);
 
                 List::new(store)
-                    .empty_message("You do not have rooms or dms yet")
+                    .empty_message("You do not have any unreads yet")
                     .empty_alignment(Alignment::Center)
                     .focus(focused)
                     .render(area, buf, state);


### PR DESCRIPTION
The message that shows when there is nothing in dms/rooms is not accurate for the unreads window. This is a very minor change to give it a different message, consistent with the other ones.