### PR TITLE
Bump MSRV to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = [".github", "CONTRIBUTING.md"]
 keywords = ["matrix", "chat", "tui", "vim"]
 categories = ["command-line-utilities"]
-rust-version = "1.88"
+rust-version = "1.89"
 build = "build.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cargo install --locked --path .
 
 ## Installation (via `crates.io`)
 
-Install Rust (1.83.0 or above) and Cargo, and then run:
+Install Rust (1.89.0 or above) and Cargo, and then run:
 
 ```
 cargo install --locked iamb

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
 components = [ "clippy" ]


### PR DESCRIPTION
There seems to be a weird hash conflict with the Nix workflow since bumping `rust-toolchain.toml` to be `1.88`, so I'm going to try `1.89` to see if that fixes the issue.