### PR TITLE
Support login via a configured password file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can create a basic configuration in `$CONFIG_DIR/iamb/config.toml` that look
 user_id = "@user:example.com"
 ```
 
-If you homeserver is located on a different domain than the server part of the
+If your homeserver is located on a different domain than the server part of the
 `user_id` and you don't have a [`/.well-known`][well_known_entry] entry, then
 you can explicitly specify the homeserver URL to use:
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -2,6 +2,7 @@ default_profile = "default"
 
 [profiles.default]
 user_id = "@user:matrix.org"
+password_file = "/path/to/password"
 url = "https://matrix.org"
 
 [settings]

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -75,6 +75,8 @@ object.
 .It Sy user_id
 The user ID to use when connecting to the server.
 For example "user" in "@user:matrix.org".
+.It Sy password_file
+The path to the file containing the password to use when connecting to the server.
 .It Sy url
 The URL of the user's server.
 (For example "https://matrix.org" for "@user:matrix.org".)

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -4,7 +4,7 @@
 .\" information, see <https://manpages.bsd.lv/mdoc.html>.
 .\"
 .\" You can preview this file with:
-.\"     $ man ./docs/iamb.1
+.\"     $ man ./docs/iamb.5
 .Dd Mar 24, 2024
 .Dt IAMB 5
 .Os

--- a/src/config.rs
+++ b/src/config.rs
@@ -826,6 +826,7 @@ pub enum Layout {
 #[derive(Clone, Deserialize)]
 pub struct ProfileConfig {
     pub user_id: OwnedUserId,
+    pub password_file: Option<PathBuf>,
     pub url: Option<Url>,
     pub settings: Option<Tunables>,
     pub dirs: Option<Directories>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -813,6 +813,17 @@ async fn login(worker: &Requester, settings: &ApplicationSettings) -> IambResult
         return Ok(());
     }
 
+    if let Some(ref password_file) = settings.profile.password_file {
+        if let Err(e) = std::fs::read_to_string(password_file)
+            .map(|password| worker.login(LoginStyle::Password(password)))
+        {
+            println!("Failed to log in using password file {password_file:?}: {e}");
+            println!("Continuing on to interactive login");
+        } else {
+            return Ok(());
+        }
+    }
+
     loop {
         let login_style =
             match read_response("Please select login type: [p]assword / [s]ingle sign on")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -216,6 +216,7 @@ pub fn mock_settings() -> ApplicationSettings {
         profile_name: "test".into(),
         profile: ProfileConfig {
             user_id: user_id!("@user:example.com").to_owned(),
+            password_file: None,
             url: None,
             settings: None,
             dirs: None,


### PR DESCRIPTION
This allows for declarative setup such as using home-manager with sops-nix for secret management.