### PR TITLE
Support disabling SSL verification.

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -241,6 +241,10 @@ Defaults to 30.
 .It Sy tabstop
 Number of spaces that a <Tab> counts for.
 Defaults to 4.
+
+.It Sy ssl_verify
+Enable SSL verification for the HTTP requests.
+Defaults to true.
 .El
 
 .Ss Example 1: Avoid showing Emojis (useful for terminals w/o support)

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,6 +581,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub ssl_verify: bool,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -609,6 +610,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub ssl_verify: Option<bool>,
 }
 
 impl Tunables {
@@ -643,6 +645,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            ssl_verify: self.ssl_verify.or(other.ssl_verify),
         }
     }
 
@@ -673,6 +676,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            ssl_verify: self.ssl_verify.unwrap_or(true),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,6 +202,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        ssl_verify: true,
     }
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -717,6 +717,7 @@ async fn create_client_inner(
         .pool_idle_timeout(Duration::from_secs(60))
         .pool_max_idle_per_host(10)
         .tcp_keepalive(Duration::from_secs(10))
+        .danger_accept_invalid_certs(!settings.tunables.ssl_verify)
         .build()
         .unwrap();
 


### PR DESCRIPTION
This merge request adds a new `boolean` configuration setting called `ssl_verify`, defaulting to `true`.

The name is inspired by `matrix_sdk::ClientBuilder.disable_ssl_verification` but it removes the negation.

Implementation-wise, unfortunately that method is mutually exclusive with setting our own `http_client` (like we do):

https://docs.rs/matrix-sdk/0.14.0/matrix_sdk/struct.ClientBuilder.html#example-for-using-a-custom-http-client

therefore we reimplement it as per:

https://github.com/matrix-org/matrix-rust-sdk/blob/2f7887d607e440609056a3a8da4dcabd01c0fe91/crates/matrix-sdk/src/http_client/native.rs#L189-L192

Last but not least: thank you for the excellent `iamb`, I discovered it just a few days ago but it has already become my favourite matrix client!