### PR TITLE
Socks proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "regex",
+ "reqwest",
  "rpassword",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,11 @@ features = ["e2e-encryption", "sqlite", "sso-login"]
 [dependencies.matrix-sdk-crypto]
 version = "0.16.0"
 
+[dependencies.reqwest]
+version = "0.12"
+default-features = false
+features = ["socks"]
+
 [dependencies.tokio]
 version = "1.24.1"
 features = ["macros", "net", "rt-multi-thread", "sync", "time"]

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -300,12 +300,17 @@ The behaviour of
 .Nm
 is affected by the following environment variables.
 .Bl -tag -width Ds
+.It Sy "ALL_PROXY, HTTP_PROXY, HTTPS_PROXY"
+Sets the proxy server to use.
+These names also work in lowercase.
+Example:
+.Dq export all_proxy=socks5://localhost:9050 .
 .It Sy "RUST_LOG"
 Overwrites the value set by the
 .Sy log_level
 config value.
 The syntax is defined at
-.Lk https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
+.Lk https://docs.rs/tracing_subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
 
 .Sh EXAMPLES
 .Ss Example 1: Starting with a specific profile

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -205,6 +205,10 @@ Defines a custom  command and its arguments to run when opening downloads instea
 (For example,
 .Sy ["my-open",\ "--file"] . )
 
+.It Sy proxy
+The proxy server to use.
+Leave empty to force unproxied traffic.
+
 .It Sy reaction_display
 Defines whether or not reactions should be shown.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -540,6 +540,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub proxy: Option<String>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -569,6 +570,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub proxy: Option<String>,
 }
 
 impl Tunables {
@@ -604,6 +606,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            proxy: self.proxy.or(other.proxy),
         }
     }
 
@@ -635,6 +638,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            proxy: self.proxy,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -204,6 +204,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        proxy: None,
     }
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -709,14 +709,24 @@ async fn create_client_inner(
     let req_timeout = Duration::from_secs(settings.tunables.request_timeout);
 
     // Set up the HTTP client.
-    let http = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .user_agent(IAMB_USER_AGENT)
         .timeout(req_timeout)
         .pool_idle_timeout(Duration::from_secs(60))
         .pool_max_idle_per_host(10)
-        .tcp_keepalive(Duration::from_secs(10))
-        .build()
-        .unwrap();
+        .tcp_keepalive(Duration::from_secs(10));
+
+    if let Some(proxy) = settings.tunables.proxy.as_deref() {
+        // interpret empty string as no proxy to allow profile specific override of global proxy
+        if proxy.is_empty() {
+            builder = builder.no_proxy();
+        } else {
+            builder = builder
+                .proxy(reqwest::Proxy::all(proxy).expect("proxy setting has invalid format"));
+        }
+    }
+
+    let http = builder.build().unwrap();
 
     let req_config = RequestConfig::new().timeout(req_timeout).max_retry_time(req_timeout);
 


### PR DESCRIPTION
Support the use of `socks5://` proxies and document the usage of proxies.

Also add `settings.proxy` to specify a proxy per profile or ignore the system proxy (set to empty string).

fixes #80
alternative to #575