### PR TITLE
Support placing encryption indicator in room title instead of prompt

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -21,6 +21,10 @@ typing_notice_send = true
 user_gutter_width = 30
 username_display = "username"
 
+[settings.encryption]
+indicator = "only-encrypted"
+location = "title|prompt"
+
 [settings.image_preview]
 protocol.type = "sixel"
 size = { "width" = 66, "height" = 10 }

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -133,6 +133,16 @@ The room to show by default instead of the
 .Sy :welcome
 window.
 
+.It Sy encryption_indicator
+Defines whether to add a red open lock to the title of unencrypted rooms and a green closed lock to encrypted rooms.
+Possible values are:
+.Dq Sy enabled ,
+.Dq Sy disabled ,
+.Dq Sy unencryptedonly ,
+and
+.Dq Sy encryptedonly
+(the default).
+
 .It Sy image_preview
 Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,21 +126,17 @@ These options are configured as an object under the
 key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
+.It Sy encryption
+Configuration subsection for specific settings related to room encryption.
+See
+.Sx ENCRYPTION
+for more details.
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 .It Sy default_room
 The room to show by default instead of the
 .Sy :welcome
 window.
-.It Sy encryption_indicator
-Defines whether to add a red open lock to the title of unencrypted rooms and a green closed lock to encrypted rooms.
-Possible values are:
-.Dq Sy enabled 
-(default),
-.Dq Sy disabled ,
-.Dq Sy unencryptedonly ,
-and
-.Dq Sy encryptedonly .
 .It Sy image_preview
 Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
@@ -267,6 +263,32 @@ reaction_shortcode_display = true
 [settings]
 request_timeout = 120
 .Ed
+.Sh ENCRYPTION
+The
+.Sy settings.encryption
+subsection allows controlling how encrypted rooms are presented.
+.Pp
+The available fields in this subsection are:
+.Bl -tag -width Ds
+.It Sy indicator
+Defines when an encryption status indicator is shown.
+Possible values are:
+.Dq Sy enabled
+(default, always indicate status),
+.Dq Sy disabled
+(never indicate status),
+.Dq Sy only-unencrypted ,
+and
+.Dq Sy only-encrypted .
+.It Sy indicator_location
+Defines where the encryption status indicator is shown when relevant.
+Possible values are:
+.Dq Sy title ,
+and
+.Dq Sy prompt
+(the default).
+Both can be used via
+.Dq Sy title|prompt .
 .Sh MOUSE
 The
 .Sy settings.mouse

--- a/src/config.rs
+++ b/src/config.rs
@@ -342,6 +342,34 @@ where
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum EncryptionIndicator {
+    Enabled,
+    Disabled,
+    EncryptedOnly,
+    UnencryptedOnly,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EncryptionIndicatorValues {
+    /// Show an indicator for encrypted rooms.
+    pub encrypted: bool,
+    /// Show an indicator for unencrypted rooms.
+    pub unencrypted: bool,
+}
+
+impl From<EncryptionIndicator> for EncryptionIndicatorValues {
+    fn from(value: EncryptionIndicator) -> Self {
+        match value {
+            EncryptionIndicator::Enabled => Self { encrypted: true, unencrypted: true },
+            EncryptionIndicator::Disabled => Self { encrypted: false, unencrypted: false },
+            EncryptionIndicator::EncryptedOnly => Self { encrypted: true, unencrypted: false },
+            EncryptionIndicator::UnencryptedOnly => Self { encrypted: false, unencrypted: true },
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum UserDisplayStyle {
@@ -516,6 +544,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
+    pub encryption_indicator: EncryptionIndicatorValues,
     pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
@@ -544,6 +573,7 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
+    pub encryption_indicator: Option<EncryptionIndicator>,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -574,6 +604,7 @@ pub struct Tunables {
 impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
+            encryption_indicator: self.encryption_indicator.or(other.encryption_indicator),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -610,6 +641,10 @@ impl Tunables {
     fn values(self) -> TunableValues {
         TunableValues {
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
+            encryption_indicator: self
+                .encryption_indicator
+                .unwrap_or(EncryptionIndicator::EncryptedOnly)
+                .into(),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use std::process;
 use clap::Parser;
 use matrix_sdk::authentication::matrix::MatrixSession;
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
+use matrix_sdk::EncryptionState;
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
 use ratatui::text::Span;
 use ratatui_image::picker::ProtocolType;
@@ -53,6 +54,7 @@ const DEFAULT_ROOM_SORT: [SortColumn<SortFieldRoom>; 5] = [
     SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
 ];
 
+const DEFAULT_ENC_INDICATOR_LOC: EncryptionIndicatorLocation = EncryptionIndicatorLocation::PROMPT;
 const DEFAULT_REQ_TIMEOUT: u64 = 120;
 
 const COLORS: [Color; 13] = [
@@ -315,6 +317,13 @@ pub struct UserDisplayTunables {
 
 pub type UserOverrides = HashMap<OwnedUserId, UserDisplayTunables>;
 
+fn merge_encryption(profile: Encryption, global: Encryption) -> Encryption {
+    Encryption {
+        indicator: profile.indicator.or(global.indicator),
+        indicator_location: profile.indicator_location.or(global.indicator_location),
+    }
+}
+
 fn merge_sorts(profile: SortOverrides, global: SortOverrides) -> SortOverrides {
     SortOverrides {
         chats: profile.chats.or(global.chats),
@@ -345,31 +354,66 @@ where
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
 pub enum EncryptionIndicator {
+    /// Always indicate the room's encryption status.
+    #[default]
     Enabled,
+    /// Never indicate the room's encryption status.
     Disabled,
-    EncryptedOnly,
-    UnencryptedOnly,
+    /// Only indicate the room's encryption status when it is encrypted.
+    OnlyEncrypted,
+    /// Only indicate the room's encryption status when it is unencrypted.
+    OnlyUnencrypted,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EncryptionIndicatorValues {
-    /// Show an indicator for encrypted rooms.
-    pub encrypted: bool,
-    /// Show an indicator for unencrypted rooms.
-    pub unencrypted: bool,
+bitflags::bitflags! {
+    /// Available options for where to show the encryption status indicator.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct EncryptionIndicatorLocation: u8 {
+        const NONE   = 0b00000000;
+        const TITLE  = 0b00000001;
+        const PROMPT = 0b00000010;
+    }
 }
 
-impl From<EncryptionIndicator> for EncryptionIndicatorValues {
-    fn from(value: EncryptionIndicator) -> Self {
-        match value {
-            EncryptionIndicator::Enabled => Self { encrypted: true, unencrypted: true },
-            EncryptionIndicator::Disabled => Self { encrypted: false, unencrypted: false },
-            EncryptionIndicator::EncryptedOnly => Self { encrypted: true, unencrypted: false },
-            EncryptionIndicator::UnencryptedOnly => Self { encrypted: false, unencrypted: true },
+pub struct EncryptionIndicatorLocationVisitor;
+
+impl Visitor<'_> for EncryptionIndicatorLocationVisitor {
+    type Value = EncryptionIndicatorLocation;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a valid encryption indicator location (e.g. \"title\" or \"prompt\")")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: SerdeError,
+    {
+        let mut location = EncryptionIndicatorLocation::NONE;
+
+        for value in value.split('|') {
+            match value.to_ascii_lowercase().as_str() {
+                "title" => location |= EncryptionIndicatorLocation::TITLE,
+                "prompt" => location |= EncryptionIndicatorLocation::PROMPT,
+                _ => {
+                    return Err(E::custom("could not parse into an encryption indicator location"))
+                },
+            };
         }
+
+        Ok(location)
+    }
+}
+
+impl<'de> Deserialize<'de> for EncryptionIndicatorLocation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(EncryptionIndicatorLocationVisitor)
     }
 }
 
@@ -455,6 +499,69 @@ impl<'de> Deserialize<'de> for NotifyVia {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_str(NotifyViaVisitor)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct Encryption {
+    indicator: Option<EncryptionIndicator>,
+    indicator_location: Option<EncryptionIndicatorLocation>,
+}
+
+impl Encryption {
+    pub fn values(self) -> EncryptionValues {
+        EncryptionValues {
+            indicator: self.indicator.unwrap_or_default(),
+            indicator_location: self.indicator_location.unwrap_or(DEFAULT_ENC_INDICATOR_LOC),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EncryptionValues {
+    pub indicator: EncryptionIndicator,
+    pub indicator_location: EncryptionIndicatorLocation,
+}
+
+impl EncryptionValues {
+    pub fn get_indicator(
+        &self,
+        location: EncryptionIndicatorLocation,
+        state: EncryptionState,
+    ) -> Option<Span<'static>> {
+        if !self.indicator_location.contains(location) {
+            return None;
+        }
+
+        let indicator = match (self.indicator, state) {
+            (EncryptionIndicator::Disabled, _) |
+            (EncryptionIndicator::OnlyUnencrypted, EncryptionState::Encrypted) |
+            (EncryptionIndicator::OnlyEncrypted, EncryptionState::NotEncrypted) => {
+                // User doesn't want to see anything:
+                return None;
+            },
+            (
+                EncryptionIndicator::Enabled | EncryptionIndicator::OnlyEncrypted,
+                EncryptionState::Encrypted,
+            ) => {
+                // Green lock:
+                Span::styled("\u{1F512}\u{FE0E} ", Style::new().fg(Color::LightGreen))
+            },
+            (
+                EncryptionIndicator::Enabled | EncryptionIndicator::OnlyUnencrypted,
+                EncryptionState::NotEncrypted,
+            ) => {
+                // Red unlocked lock:
+                Span::styled("\u{1F513}\u{FE0E} ", Style::new().fg(Color::Red))
+            },
+
+            (_, EncryptionState::Unknown) => {
+                // Yellow question mark:
+                Span::styled("? ", Style::new().fg(Color::Yellow))
+            },
+        };
+
+        Some(indicator)
     }
 }
 
@@ -547,7 +654,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
-    pub encryption_indicator: EncryptionIndicatorValues,
+    pub encryption: EncryptionValues,
     pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
@@ -577,7 +684,8 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
-    pub encryption_indicator: Option<EncryptionIndicator>,
+    #[serde(default)]
+    pub encryption: Encryption,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -609,7 +717,7 @@ pub struct Tunables {
 impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
-            encryption_indicator: self.encryption_indicator.or(other.encryption_indicator),
+            encryption: merge_encryption(self.encryption, other.encryption),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -647,10 +755,7 @@ impl Tunables {
     fn values(self) -> TunableValues {
         TunableValues {
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
-            encryption_indicator: self
-                .encryption_indicator
-                .unwrap_or(EncryptionIndicator::EncryptedOnly)
-                .into(),
+            encryption: self.encryption.values(),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),
@@ -1371,5 +1476,100 @@ mod tests {
         assert!(dirs.is_some());
         assert!(layout.is_some());
         assert!(macros.is_some());
+    }
+
+    #[test]
+    fn test_encryption_indicator_enabled() {
+        use EncryptionState::*;
+
+        let enc = EncryptionValues {
+            indicator: EncryptionIndicator::Enabled,
+            indicator_location: EncryptionIndicatorLocation::TITLE,
+        };
+
+        // Always shows in the title:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Encrypted).is_some());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::TITLE, NotEncrypted)
+            .is_some());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Unknown).is_some());
+
+        // Doesn't show in the prompt:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Encrypted).is_none());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::PROMPT, NotEncrypted)
+            .is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Unknown).is_none());
+    }
+
+    #[test]
+    fn test_encryption_indicator_disabled() {
+        use EncryptionState::*;
+
+        let enc = EncryptionValues {
+            indicator: EncryptionIndicator::Disabled,
+            indicator_location: EncryptionIndicatorLocation::TITLE,
+        };
+
+        // Never shows in the title or the prompt:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Encrypted).is_none());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::TITLE, NotEncrypted)
+            .is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Unknown).is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Encrypted).is_none());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::PROMPT, NotEncrypted)
+            .is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Unknown).is_none());
+    }
+
+    #[test]
+    fn test_encryption_indicator_only_encrypted() {
+        use EncryptionState::*;
+
+        let enc = EncryptionValues {
+            indicator: EncryptionIndicator::OnlyEncrypted,
+            indicator_location: EncryptionIndicatorLocation::PROMPT,
+        };
+
+        // Shows in the prompt when encrypted or unknown:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Encrypted).is_some());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Unknown).is_some());
+
+        // But is hidden when unencrypted:
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::PROMPT, NotEncrypted)
+            .is_none());
+
+        // Doesn't show in the title:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Encrypted).is_none());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::TITLE, NotEncrypted)
+            .is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Unknown).is_none());
+    }
+    #[test]
+    fn test_encryption_indicator_only_unencrypted() {
+        use EncryptionState::*;
+
+        let enc = EncryptionValues {
+            indicator: EncryptionIndicator::OnlyUnencrypted,
+            indicator_location: EncryptionIndicatorLocation::all(),
+        };
+
+        // Shows in both the prompt and title when unencrypted or unknown:
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::TITLE, NotEncrypted)
+            .is_some());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Unknown).is_some());
+        assert!(enc
+            .get_indicator(EncryptionIndicatorLocation::PROMPT, NotEncrypted)
+            .is_some());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Unknown).is_some());
+
+        // But is hidden when encrypted:
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::TITLE, Encrypted).is_none());
+        assert!(enc.get_indicator(EncryptionIndicatorLocation::PROMPT, Encrypted).is_none());
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,6 +27,7 @@ use crate::{
         user_style_from_color,
         ApplicationSettings,
         DirectoryValues,
+        EncryptionIndicator,
         Notifications,
         NotifyVia,
         ProfileConfig,
@@ -170,6 +171,7 @@ pub fn mock_dirs() -> DirectoryValues {
 
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
+        encryption_indicator: EncryptionIndicator::EncryptedOnly.into(),
         default_room: None,
         log_level: "warn".into(),
         max_log_files: 7,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,7 +26,7 @@ use crate::{
         user_style_from_color,
         ApplicationSettings,
         DirectoryValues,
-        EncryptionIndicator,
+        Encryption,
         Notifications,
         NotifyVia,
         ProfileConfig,
@@ -170,8 +170,8 @@ pub fn mock_dirs() -> DirectoryValues {
 
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
-        encryption_indicator: EncryptionIndicator::EncryptedOnly.into(),
         default_room: None,
+        encryption: Encryption::default().values(),
         log_level: "warn".into(),
         max_log_files: 7,
         message_shortcode_display: false,

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -7,9 +7,7 @@ use std::path::{Path, PathBuf};
 
 use edit::edit_with_builder as external_edit;
 use edit::Builder;
-use matrix_sdk::EncryptionState;
 use modalkit::editing::store::RegisterError;
-use ratatui::style::{Color, Style};
 use std::process::Command;
 use tokio;
 use url::Url;
@@ -992,16 +990,7 @@ impl StatefulWidget for Chat<'_> {
             Paragraph::new(desc_spans).render(descarea, buf);
         }
 
-        let prompt = match (self.focused, state.room().encryption_state()) {
-            (false, _) => Span::raw("  "),
-            (_, EncryptionState::Encrypted) => {
-                Span::styled("\u{1F512}\u{FE0E} ", Style::new().fg(Color::LightGreen))
-            },
-            (_, EncryptionState::NotEncrypted) => {
-                Span::styled("\u{1F513}\u{FE0E} ", Style::new().fg(Color::Red))
-            },
-            (_, EncryptionState::Unknown) => Span::styled("> ", Style::new().fg(Color::Red)),
-        };
+        let prompt = if self.focused { "> " } else { "  " };
 
         let tbox = TextBox::new().prompt(prompt);
         tbox.render(textarea, buf, &mut state.tbox);

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -86,6 +86,7 @@ use crate::base::{
     SendAction,
 };
 
+use crate::config::EncryptionIndicatorLocation;
 use crate::message::{
     text_to_message,
     Message,
@@ -994,7 +995,14 @@ impl StatefulWidget for Chat<'_> {
             Paragraph::new(desc_spans).render(descarea, buf);
         }
 
-        let prompt = if self.focused { "> " } else { "  " };
+        let encryption_settings = &self.store.application.settings.tunables.encryption;
+        let encryption_indicator = encryption_settings
+            .get_indicator(EncryptionIndicatorLocation::PROMPT, state.room().encryption_state());
+        let prompt = match (self.focused, encryption_indicator) {
+            (false, _) => Span::raw("  "),
+            (true, Some(i)) => i,
+            (true, None) => Span::raw("> "),
+        };
 
         let tbox = TextBox::new().prompt(prompt);
         tbox.render(textarea, buf, &mut state.tbox);

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -26,6 +26,7 @@ use matrix_sdk::{
         OwnedUserId,
         RoomId,
     },
+    EncryptionState,
     RoomDisplayName,
     RoomState as MatrixRoomState,
 };
@@ -33,7 +34,7 @@ use matrix_sdk::{
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
-    style::{Modifier as StyleModifier, Style},
+    style::{Color, Modifier as StyleModifier, Style},
     text::{Line, Span, Text},
     widgets::{Paragraph, StatefulWidget, Widget},
 };
@@ -659,6 +660,8 @@ impl RoomState {
     }
 
     pub fn get_title(&self, store: &mut ProgramStore) -> Line<'_> {
+        let room = store.application.worker.client.get_room(self.id());
+
         let title = store.application.get_room_title(self.id());
         let style = Style::default().add_modifier(StyleModifier::BOLD);
         let mut spans = vec![];
@@ -671,13 +674,32 @@ impl RoomState {
 
         spans.push(Span::styled(title, style));
 
+        match room.map(|room| room.encryption_state()) {
+            Some(EncryptionState::Encrypted) => {
+                if store.application.settings.tunables.encryption_indicator.encrypted {
+                    spans.push(Span::styled(
+                        " \u{1F512}\u{FE0E}",
+                        Style::new().fg(Color::LightGreen),
+                    ));
+                }
+            },
+            Some(EncryptionState::NotEncrypted) => {
+                if store.application.settings.tunables.encryption_indicator.unencrypted {
+                    spans.push(Span::styled(" \u{1F513}\u{FE0E}", Style::new().fg(Color::Red)));
+                }
+            },
+            _ => (),
+        }
+
         match self.room().topic() {
             Some(desc) if !desc.is_empty() => {
                 spans.push(" (".into());
                 spans.push(desc.into());
                 spans.push(")".into());
             },
-            _ => {},
+            _ => {
+                spans.push(" ".into());
+            },
         }
 
         Line::from(spans)

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -20,7 +20,6 @@ use matrix_sdk::{
         OwnedUserId,
         RoomId,
     },
-    EncryptionState,
     RoomDisplayName,
     RoomState as MatrixRoomState,
 };
@@ -28,7 +27,7 @@ use matrix_sdk::{
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
-    style::{Color, Modifier as StyleModifier, Style},
+    style::{Modifier as StyleModifier, Style},
     text::{Line, Span, Text},
     widgets::{Paragraph, StatefulWidget, Widget},
 };
@@ -66,6 +65,7 @@ use crate::base::{
 
 use self::chat::ChatState;
 use self::space::{Space, SpaceState};
+use crate::config::EncryptionIndicatorLocation;
 
 use std::convert::TryFrom;
 
@@ -654,21 +654,11 @@ impl RoomState {
 
         spans.push(Span::styled(title, style));
 
-        match room.map(|room| room.encryption_state()) {
-            Some(EncryptionState::Encrypted) => {
-                if store.application.settings.tunables.encryption_indicator.encrypted {
-                    spans.push(Span::styled(
-                        " \u{1F512}\u{FE0E}",
-                        Style::new().fg(Color::LightGreen),
-                    ));
-                }
-            },
-            Some(EncryptionState::NotEncrypted) => {
-                if store.application.settings.tunables.encryption_indicator.unencrypted {
-                    spans.push(Span::styled(" \u{1F513}\u{FE0E}", Style::new().fg(Color::Red)));
-                }
-            },
-            _ => (),
+        if let Some(room) = room {
+            let encryption_settings = &store.application.settings.tunables.encryption;
+            let encryption_indicator = encryption_settings
+                .get_indicator(EncryptionIndicatorLocation::TITLE, room.encryption_state());
+            spans.extend(encryption_indicator);
         }
 
         match self.room().topic() {


### PR DESCRIPTION
This is a partial revert of #522

Instead of showing the encryption indicator in the message bar show it in the window title. This should work around some issues where emojis aren't displayed correctly which leads to inconsistent text input.

Also add the config option `encryption_indicator` to disable this feature.

addresses #551
fixes #569 #552