### PR TITLE
Use `matrix-sdk-ui` for internal representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,23 +4,14 @@ version = 4
 
 [[package]]
 name = "accessory"
-version = "1.3.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87537f9ae7cfa78d5b8ebd1a1db25959f5e737126be4d8eb44a5452fc4b63cde"
+checksum = "28e416a3ab45838bac2ab2d81b1088d738d7b2d2c5272a54d39366565a29bd80"
 dependencies = [
  "macroific",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -76,12 +67,6 @@ name = "alternating-iter"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e7bb35addfa5b45ff1fa39992babbcd35dc05a9f8ff0d915fcf4e364d6e765"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -164,7 +149,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -208,7 +193,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -383,7 +368,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -433,7 +418,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -450,7 +435,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -553,28 +538,13 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand 2.3.0",
  "gloo-timers",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -618,11 +588,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -742,15 +712,15 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
-version = "2.0.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cassowary"
@@ -799,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -835,17 +805,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -891,7 +860,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1059,7 +1028,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot 0.12.4",
@@ -1138,7 +1107,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1186,7 +1155,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1208,7 +1177,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1219,11 +1188,12 @@ checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
 
 [[package]]
 name = "deadpool"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
  "deadpool-runtime",
+ "lazy_static 1.5.0",
  "num_cpus",
  "tokio",
 ]
@@ -1235,17 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
-]
-
-[[package]]
-name = "deadpool-sqlite"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8510000b26f632483a35120c2ce280c29e1e14c2dcb27b5055dbdac276f63f58"
-dependencies = [
- "deadpool",
- "deadpool-sync",
- "rusqlite",
 ]
 
 [[package]]
@@ -1269,14 +1228,16 @@ dependencies = [
 
 [[package]]
 name = "delegate-display"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a85201f233142ac819bbf6226e36d0b5e129a47bd325084674261c82d4cd66"
+checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
 dependencies = [
+ "impartial-ord",
+ "itoa",
  "macroific",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1350,7 +1311,49 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1402,7 +1405,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -1414,7 +1417,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1464,7 +1467,7 @@ name = "editor-types"
 version = "0.0.2"
 source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "editor-types-macros",
  "keybindings",
  "regex",
@@ -1479,7 +1482,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1508,11 +1511,11 @@ dependencies = [
 
 [[package]]
 name = "emojis"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52f3d011046a013bdefbc63a5523b06ad0c0f1e227941baf98475496229d634"
+checksum = "50c1c1870b766fc398e5f0526498d09c94b6de15be5fd769a28bbc804fb1b05d"
 dependencies = [
- "phf 0.12.1",
+ "phf 0.13.1",
 ]
 
 [[package]]
@@ -1545,7 +1548,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1639,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e8e9d31591be508826b875d8fe6056aebcaec3281ac0e45434ff303686c566"
+checksum = "4790c03df183c2b46665c1a58118c04fd3e3976ec2fe16a0aa00e00c9eea7754"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1651,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda2d08a8fa99050bdb84d077193a371e9abd29696921971aa26ae076adb6023"
+checksum = "809fa2e8e59c25a41f5b2440aa937f1e84df6ae48b707e65f69ce259b1c44bda"
 dependencies = [
  "arrayvec",
  "eyeball-im",
@@ -1677,14 +1680,14 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy_constructor"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b19d0e43eae2bfbafe4931b5e79c73fb1a849ca15cd41a761a7b8587f9a1a2"
+checksum = "28a27643a5d05f3a22f5afd6e0d0e6e354f92d37907006f97b84b9cb79082198"
 dependencies = [
  "macroific",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1886,7 +1889,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1948,7 +1951,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.4",
 ]
 
@@ -1994,9 +1997,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2008,12 +2024,6 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
@@ -2093,12 +2103,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2198,13 +2214,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
- "markup5ever 0.14.1",
+ "markup5ever 0.35.0",
  "match_token",
 ]
 
@@ -2356,7 +2371,7 @@ version = "0.0.11-alpha.1"
 dependencies = [
  "alternating-iter",
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "chrono",
  "clap",
  "comrak",
@@ -2375,6 +2390,7 @@ dependencies = [
  "linkify",
  "markup5ever_rcdom",
  "matrix-sdk",
+ "matrix-sdk-crypto",
  "matrix-sdk-ui",
  "mime",
  "mime_guess",
@@ -2396,7 +2412,7 @@ dependencies = [
  "temp-dir",
  "thiserror 1.0.69",
  "tokio",
- "toml",
+ "toml 0.8.22",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2523,6 +2539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a9c4770bc47b0a933256a496cfb8b6531f753ea9bccb19c6dff0ff7273fc"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4308a675e4cfc1920f36a8f4d8fb62d5533b7da106844bd1ec51c6f1fa94a0c"
+checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
 dependencies = [
  "archery",
  "bitmaps",
@@ -2613,6 +2635,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
+name = "impartial-ord"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,30 +2665,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexed_db_futures"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43315957678a70eb21fb0d2384fe86dde0d6c859a01e24ce127eb65a0143d28c"
-dependencies = [
- "accessory",
- "cfg-if",
- "delegate-display",
- "fancy_constructor",
- "js-sys",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -2686,7 +2702,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2706,7 +2722,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2727,17 +2743,6 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -2827,9 +2832,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2846,11 +2851,11 @@ dependencies = [
 
 [[package]]
 name = "js_option"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2902,6 +2907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,7 +2946,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -3027,7 +3038,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3056,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "macroific"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05c00ac596022625d01047c421a0d97d7f09a18e429187b341c201cb631b9dd"
+checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
@@ -3067,38 +3078,39 @@ dependencies = [
 
 [[package]]
 name = "macroific_attr_parse"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94d5da95b30ae6e10621ad02340909346ad91661f3f8c0f2b62345e46a2f67"
+checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
 dependencies = [
- "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "sealed",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "macroific_core"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13198c120864097a565ccb3ff947672d969932b7975ebd4085732c9f09435e55"
+checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "sealed",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "macroific_macro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c9853143cbed7f1e41dc39fee95f9b361bec65c8dc2a01bf609be01b61f5ae"
+checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3123,16 +3135,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -3149,13 +3158,13 @@ dependencies = [
 
 [[package]]
 name = "match_token"
-version = "0.1.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3193,14 +3202,14 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "matrix-sdk"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa71339f867dcada2e7f1130f858fd8892088b1a4c123dd50a99ed2399ab22"
+checksum = "b33f9bc45edd7f8e25161521fdd30654da5c55e6749be6afa1aa9d6cf838ace0"
 dependencies = [
  "anymap2",
  "aquamarine",
@@ -3243,7 +3252,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3257,13 +3266,13 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14659a7e902ea8a821ec217f36b168fb4c79020d91b912175ac188b6c364225"
+checksum = "70f404a390ff98a73c426b1496b169be60ce6a93723a9a664e579d978a84c5e4"
 dependencies = [
  "as_variant",
  "async-trait",
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "decancer",
  "eyeball",
  "eyeball-im",
@@ -3277,7 +3286,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "unicode-normalization",
@@ -3285,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb33a986495135e217f28cfe0918bf7d01a9800e42f4ef88afbd48e23b8cc53"
+checksum = "54fae2bdfc3d760d21a84d6d2036b5db5c48d9a3dee3794119e3fb9c4cc4ccc5"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -3298,7 +3307,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3309,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bf6c3195de301c98339283413a4e9d9d63c4f214ef8955147643caab161256"
+checksum = "304fc576810a9618bb831c4ad6403c758ec424f677668a49a196e3cde4b8f99f"
 dependencies = [
  "aes",
  "aquamarine",
@@ -3337,7 +3346,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -3350,29 +3359,31 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-indexeddb"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2752015e69b6b56a8df72e52f91a834771259f755eb1c65232b77348ffb16b"
+checksum = "1b6096084cc8d339c03e269ca25534d0f1e88d0097c35a215eb8c311797ec3e9"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "futures-util",
  "getrandom 0.2.16",
  "gloo-utils",
  "hkdf",
- "indexed_db_futures",
  "js-sys",
+ "matrix-sdk-base",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
+ "matrix_indexed_db_futures",
  "rmp-serde",
  "ruma",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "wasm-bindgen",
  "web-sys",
  "zeroize",
@@ -3380,13 +3391,14 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-sqlite"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662a128004b553196365d88ea46917047d7350a24dfe7ce829e7b78636673604"
+checksum = "4325742fc06b7f75c80eec39e8fb32b06ea4b09b7aa1d432b67b01d08fbacc28"
 dependencies = [
  "as_variant",
  "async-trait",
- "deadpool-sqlite",
+ "deadpool",
+ "deadpool-sync",
  "itertools 0.14.0",
  "matrix-sdk-base",
  "matrix-sdk-crypto",
@@ -3398,21 +3410,23 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "vodozemac",
+ "zeroize",
 ]
 
 [[package]]
 name = "matrix-sdk-store-encryption"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0aac550e685306fbbd57faae8f98af9812f19bbf0f83da7559d67cf4789679"
+checksum = "162a93e83114d5cef25c0ebaea72aa01b9f233df6ec4a2af45f175d01ec26323"
 dependencies = [
  "base64 0.22.1",
  "blake3",
  "chacha20poly1305",
+ "getrandom 0.2.16",
  "hmac",
  "pbkdf2",
  "rand 0.8.5",
@@ -3420,23 +3434,23 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
 [[package]]
 name = "matrix-sdk-ui"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11354688a758f1b20b9d057553d76c288670d538aae824ac3eb63df07a8b380"
+checksum = "61e167d1ae208479959202c5bd0e73db3592cacfd3e71a5933874dcc6f6085cc"
 dependencies = [
  "as_variant",
  "async-rx",
  "async-stream",
  "async_cell",
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "chrono",
- "emojis 0.7.2",
+ "emojis 0.8.0",
  "eyeball",
  "eyeball-im",
  "eyeball-im-util",
@@ -3456,12 +3470,51 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
  "unicode-normalization",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "matrix_indexed_db_futures"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245ff6a224b4df7b0c90dda2dd5a6eb46112708d49e8bdd8b007fccb09fea8e4"
+dependencies = [
+ "accessory",
+ "cfg-if",
+ "delegate-display",
+ "derive_more 2.1.1",
+ "fancy_constructor",
+ "futures-core",
+ "js-sys",
+ "matrix_indexed_db_futures_macros_internal",
+ "sealed",
+ "serde",
+ "serde-wasm-bindgen",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm_evt_listener",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "matrix_indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b428aee5c0fe9e5babd29e99d289b7f64718c444989aac0442d1fd6d3e3f66d1"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3555,9 +3608,9 @@ source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a969
 dependencies = [
  "anymap2",
  "arboard",
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "crossterm",
- "derive_more",
+ "derive_more 0.99.20",
  "editor-types",
  "intervaltree",
  "keybindings",
@@ -3691,7 +3744,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3777,7 +3830,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -3789,7 +3842,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -3800,7 +3853,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3819,7 +3872,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -3832,18 +3885,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3874,7 +3918,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3891,7 +3935,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4044,11 +4088,11 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4111,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -4253,6 +4297,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,7 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4340,7 +4394,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4390,7 +4444,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4411,7 +4465,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4445,6 +4499,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
@@ -4530,7 +4590,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4662,7 +4722,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4678,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4690,9 +4750,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4707,11 +4767,10 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
@@ -4826,9 +4885,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b698b728bc3747f564a9115c83b4f2e229b52377f6a1cca2e6add9cf4a13be"
+checksum = "a9f620a2116d0d3082f9256e61dcdf67f2ec266d3f6bb9d2f9c8a20ec5a1fabb"
 dependencies = [
  "assign",
  "js_int",
@@ -4838,15 +4897,14 @@ dependencies = [
  "ruma-events",
  "ruma-federation-api",
  "ruma-html",
- "ruma-signatures",
  "web-time",
 ]
 
 [[package]]
 name = "ruma-client-api"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54e56c591f9ad686defb0bacbebba5c8882eb0c9f8734f6a080345b4e3dd941"
+checksum = "dbc977d1a91ea15dcf896cbd7005ed4a253784468833638998109ffceaee53e7"
 dependencies = [
  "as_variant",
  "assign",
@@ -4861,16 +4919,16 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "url",
  "web-time",
 ]
 
 [[package]]
 name = "ruma-common"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7f59b9f7639667d0d6ae3ae242c8912e9ed061cea1fbaf72710a402e83b53e"
+checksum = "597a01993f22d291320b7c9267675e7395775e95269ff526e2c8c3ed5e13175b"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4890,7 +4948,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -4902,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fa815769ed4fe1ef5b50aa0ba6f350317c13b5a9f1e008b014f4a3ddf14204"
+checksum = "2dbdeccb62cb4ffe3282325de8ba28cbc0fdce7c78a3f11b7241fbfdb9cb9907"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -4918,7 +4976,7 @@ dependencies = [
  "ruma-macros",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "web-time",
@@ -4928,68 +4986,68 @@ dependencies = [
 
 [[package]]
 name = "ruma-federation-api"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbc887ba1292e48e6363b29e0dec4571b52d2b5102ebf60068105efadaa6e0a"
+checksum = "dcb45c15badbf4299c6113a6b90df3e7cb64edbe756bbd8e0224144b56b38305"
 dependencies = [
  "headers",
  "http",
  "http-auth",
- "httparse",
  "js_int",
- "memchr",
  "mime",
  "ruma-common",
  "ruma-events",
+ "ruma-signatures",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "ruma-html"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6124d74847ea788601477c89a44485894432a806824cae93885c5825a8ae9dbc"
+checksum = "7a6dcd6e9823e177d15460d3cd3a413f38a2beea381f26aca1001c05cd6954ff"
 dependencies = [
  "as_variant",
- "html5ever 0.29.1",
+ "html5ever 0.35.0",
  "tracing",
  "wildmatch",
 ]
 
 [[package]]
 name = "ruma-identifiers-validation"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a7b93ac1e571c585f8fa5cef09c07bb8a15529775fd56b9a3eac4f9233dff2"
+checksum = "c9c6b5643060beec0fc9d7acfb41d2c5d91e1591db440ff62361d178e77c35fe"
 dependencies = [
  "js_int",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ruma-macros"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9911c7188517f28505d2d513339511d00e0f50cec5c2dde820cd0ec7e6a833"
+checksum = "0a0753312ad577ac462de1742bf2e326b6ba9856ff6f13343aeb17d423fd5426"
 dependencies = [
+ "as_variant",
  "cfg-if",
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "ruma-identifiers-validation",
  "serde",
- "syn 2.0.101",
- "toml",
+ "syn 2.0.117",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "ruma-signatures"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47cd146d56ae6e7a4a8d912a30dfe57c70e5bf18806fdf617527d4d4f2dd2a4"
+checksum = "146ace2cd59b60ec80d3e801a84e7e6a91e3e01d18a9f5d896ea7ca16a6b8e08"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4998,7 +5056,7 @@ dependencies = [
  "ruma-common",
  "serde_json",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5007,19 +5065,13 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -5056,7 +5108,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5069,7 +5121,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5145,12 +5197,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5175,9 +5238,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5205,35 +5268,35 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
  "indexmap",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5251,12 +5314,13 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5267,7 +5331,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5277,6 +5341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5443,6 +5516,9 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -5564,7 +5640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5586,9 +5662,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5612,7 +5688,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5624,7 +5700,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml",
+ "toml 0.8.22",
  "version-compare",
 ]
 
@@ -5696,11 +5772,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5711,18 +5787,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5806,31 +5882,28 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "slab",
  "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5867,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5885,9 +5958,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_edit 0.22.26",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5900,13 +5986,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.9",
  "winnow 0.5.40",
 ]
 
@@ -5918,10 +6013,19 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_write",
- "winnow 0.7.10",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5948,17 +6052,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.4",
+ "async-compression",
+ "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6008,7 +6117,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6143,9 +6252,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -6178,6 +6287,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -6239,12 +6354,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -6320,7 +6436,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
@@ -6356,38 +6472,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -6396,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6406,24 +6528,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -6437,6 +6581,36 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasm_evt_listener"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc92d6378b411ed94839112a36d9dbc77143451d85b05dfb0cce93a78dab1963"
+dependencies = [
+ "accessory",
+ "derivative",
+ "derive_more 1.0.0",
+ "fancy_constructor",
+ "futures-core",
+ "js-sys",
+ "smallvec",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.3",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -6458,7 +6632,7 @@ version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
@@ -6470,7 +6644,7 @@ version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -6482,7 +6656,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6511,9 +6685,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6526,7 +6700,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -6634,7 +6821,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -6647,7 +6834,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6658,7 +6845,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6669,7 +6856,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6680,7 +6867,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6688,6 +6875,12 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
@@ -6704,7 +6897,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6723,7 +6916,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6766,6 +6959,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6942,11 +7144,31 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -6955,7 +7177,75 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -6969,7 +7259,7 @@ dependencies = [
  "os_pipe",
  "rustix 0.38.44",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -7065,7 +7355,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7152,7 +7442,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7172,15 +7462,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -7193,7 +7483,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7226,7 +7516,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-rx"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30de4e5329a0947e389f738a6ca0d0b938fea5cb7baaeae7d72e243614468a2"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-signal"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +445,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
 ]
 
 [[package]]
@@ -917,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0436149c9f6a1935b13306206c739b1ba84fa81f551b5eb87fc2ca7a13700af"
 dependencies = [
  "derive_builder",
- "emojis",
+ "emojis 0.5.3",
  "entities",
  "memchr",
  "once_cell",
@@ -1485,6 +1504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "emojis"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52f3d011046a013bdefbc63a5523b06ad0c0f1e227941baf98475496229d634"
+dependencies = [
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1644,20 @@ dependencies = [
  "imbl",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "eyeball-im-util"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda2d08a8fa99050bdb84d077193a371e9abd29696921971aa26ae076adb6023"
+dependencies = [
+ "arrayvec",
+ "eyeball-im",
+ "futures-core",
+ "imbl",
+ "pin-project-lite",
+ "smallvec",
 ]
 
 [[package]]
@@ -1875,12 +1917,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -2293,7 +2359,7 @@ dependencies = [
  "css-color-parser",
  "dirs",
  "edit",
- "emojis",
+ "emojis 0.5.3",
  "feruca",
  "futures",
  "gethostname",
@@ -2305,6 +2371,7 @@ dependencies = [
  "linkify",
  "markup5ever_rcdom",
  "matrix-sdk",
+ "matrix-sdk-ui",
  "mime",
  "mime_guess",
  "modalkit",
@@ -2930,6 +2997,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3153,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -3330,6 +3419,46 @@ dependencies = [
  "sha2",
  "thiserror 2.0.16",
  "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-ui"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11354688a758f1b20b9d057553d76c288670d538aae824ac3eb63df07a8b380"
+dependencies = [
+ "as_variant",
+ "async-rx",
+ "async-stream",
+ "async_cell",
+ "bitflags 2.9.4",
+ "chrono",
+ "emojis 0.7.2",
+ "eyeball",
+ "eyeball-im",
+ "eyeball-im-util",
+ "futures-core",
+ "futures-util",
+ "fuzzy-matcher",
+ "growable-bloom-filter",
+ "imbl",
+ "indexmap",
+ "itertools 0.14.0",
+ "matrix-sdk",
+ "matrix-sdk-base",
+ "matrix-sdk-common",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicode-normalization",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3913,6 +4042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,6 +4104,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -4765,6 +4912,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ruma-common",
+ "ruma-html",
  "ruma-identifiers-validation",
  "ruma-macros",
  "serde",
@@ -4982,6 +5130,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5883,10 +6037,14 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,8 +1462,7 @@ dependencies = [
 [[package]]
 name = "editor-types"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e99679670f67825fcd24a23cb4eb655a0f92c82bd4d1c1a1357c0cd71e87"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "bitflags 2.9.4",
  "editor-types-macros",
@@ -1474,8 +1473,7 @@ dependencies = [
 [[package]]
 name = "editor-types-macros"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42680de76cf91f231abd90cc623750d39077f7d2fadb7962325fb082871f4c66"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "editor-types-parser",
  "nom",
@@ -1487,8 +1485,7 @@ dependencies = [
 [[package]]
 name = "editor-types-parser"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac4b91fe830fbbe0a60c37ba0264b6e9ffc70e3664c028234dac59e79299ad4"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "nom",
  "thiserror 1.0.69",
@@ -2859,8 +2856,7 @@ dependencies = [
 [[package]]
 name = "keybindings"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a726307ed87e05155c31329676130e6a237e62dda80211f7e1ed811e47630f"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "textwrap",
  "unicode-segmentation",
@@ -3555,8 +3551,7 @@ dependencies = [
 [[package]]
 name = "modalkit"
 version = "0.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbb03c35f23ec7d13f7870049803cd8829f5e60b69d38fa98f5e7876de9f34e"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "anymap2",
  "arboard",
@@ -3578,8 +3573,7 @@ dependencies = [
 [[package]]
 name = "modalkit-ratatui"
 version = "0.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9b01555837e6d34c67ba887aee1d3d83e4622c42cbad0da1d90de00230d2aa"
+source = "git+https://github.com/ulyssa/modalkit?rev=118da3b9d724c0c54d54708a9694b65839703d19#118da3b9d724c0c54d54708a9694b65839703d19"
 dependencies = [
  "crossterm",
  "intervaltree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alternating-iter"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e7bb35addfa5b45ff1fa39992babbcd35dc05a9f8ff0d915fcf4e364d6e765"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2357,7 @@ dependencies = [
 name = "iamb"
 version = "0.0.11-alpha.1"
 dependencies = [
+ "alternating-iter",
  "anyhow",
  "bitflags 2.9.4",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,13 +82,13 @@ optional = true
 [dependencies.modalkit]
 version = "0.0.24"
 default-features = false
-#git = "https://github.com/ulyssa/modalkit"
-#rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
+git = "https://github.com/ulyssa/modalkit"
+rev = "118da3b9d724c0c54d54708a9694b65839703d19"
 
 [dependencies.modalkit-ratatui]
 version = "0.0.24"
-#git = "https://github.com/ulyssa/modalkit"
-#rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
+git = "https://github.com/ulyssa/modalkit"
+rev = "118da3b9d724c0c54d54708a9694b65839703d19"
 
 [dependencies.matrix-sdk]
 version = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ build = "build.rs"
 default = ["bundled", "desktop"]
 bundled = ["matrix-sdk/bundled-sqlite", "rustls-tls"]
 desktop = ["dep:notify-rust", "modalkit/clipboard"]
-native-tls = ["matrix-sdk/native-tls"]
-rustls-tls = ["matrix-sdk/rustls-tls"]
+native-tls = ["matrix-sdk/native-tls", "matrix-sdk-ui/native-tls"]
+rustls-tls = ["matrix-sdk/rustls-tls", "matrix-sdk-ui/rustls-tls"]
 
 [build-dependencies.vergen]
 version = "8"
@@ -93,6 +93,10 @@ version = "0.0.24"
 version = "0.14.0"
 default-features = false
 features = ["e2e-encryption", "sqlite", "sso-login"]
+
+[dependencies.matrix-sdk-ui]
+version = "0.14.0"
+default-features = false
 
 [dependencies.tokio]
 version = "1.24.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ edit = "0.1.4"
 humansize = "2.0.0"
 linkify = "0.10.0"
 shellexpand = "3.1.1"
+alternating-iter = "0.3.1"
 
 [dependencies.comrak]
 version = "0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,13 +91,16 @@ git = "https://github.com/ulyssa/modalkit"
 rev = "118da3b9d724c0c54d54708a9694b65839703d19"
 
 [dependencies.matrix-sdk]
-version = "0.14.0"
+version = "0.16.0"
 default-features = false
 features = ["e2e-encryption", "sqlite", "sso-login"]
 
 [dependencies.matrix-sdk-ui]
-version = "0.14.0"
+version = "0.16.0"
 default-features = false
+
+[dependencies.matrix-sdk-crypto]
+version = "0.16.0"
 
 [dependencies.tokio]
 version = "1.24.1"

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -61,6 +61,8 @@ Log out of
 View a list of joined rooms.
 .It Sy ":spaces"
 View a list of joined spaces.
+.It Sy ":invites"
+View a list of room invites.
 .It Sy ":unreads"
 View a list of unread rooms.
 .It Sy ":unreads clear"

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -138,6 +138,13 @@ Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
 The available fields in this object are:
 .Bl -tag -width Ds
+.It Sy lazy_load
+If
+.Sy true
+(the default), download and render image previews when viewing a message with an image.
+If
+.Sy false ,
+load previews as soon as a message with an image is received.
 .It Sy size
 An optional object with
 .Sy width
@@ -538,8 +545,6 @@ Configured as an object under the key
 .It Sy cache
 Specifies where to store assets and temporary data in.
 (For example,
-.Sy image_preview
-and
 .Sy logs
 will also go in here by default.)
 Defaults to
@@ -554,11 +559,6 @@ Defaults to
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
-.It Sy image_previews
-Specifies where to store automatically downloaded image previews.
-Defaults to
-.Ev ${cache}/image_preview_downloads .
 
 .It Sy logs
 Specifies where to store log files.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -344,6 +344,13 @@ window.
 Defaults to the
 .Sy rooms
 value.
+.It Sy invites
+How to sort the
+.Sy :invites
+window.
+Defaults to the
+.Sy rooms
+value.
 .It Sy members
 How to sort the
 .Sy :members

--- a/src/base.rs
+++ b/src/base.rs
@@ -1239,7 +1239,7 @@ impl RoomInfo {
         &mut self,
         room_id: OwnedRoomId,
         store: AsyncProgramStore,
-        picker: Option<Picker>,
+        picker: Option<Arc<Picker>>,
         ev: RoomMessageEvent,
         settings: &mut ApplicationSettings,
         media: matrix_sdk::Media,
@@ -1259,6 +1259,7 @@ impl RoomInfo {
                     source,
                     media,
                     settings.dirs.image_previews.clone(),
+                    image_preview.size.clone(),
                 )
             }
         }
@@ -1602,7 +1603,7 @@ pub struct ChatStore {
     pub sync_info: SyncInfo,
 
     /// Image preview "protocol" picker.
-    pub picker: Option<Picker>,
+    pub picker: Option<Arc<Picker>>,
 
     /// Last draw time, used to match with RoomInfo's draw_last.
     pub draw_curr: Option<Instant>,
@@ -1628,7 +1629,7 @@ impl ChatStore {
         ChatStore {
             worker,
             settings,
-            picker,
+            picker: picker.map(Into::into),
             cmds: crate::commands::setup_commands(),
             emojis: emoji_map(),
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -46,7 +46,6 @@ use matrix_sdk::{
         OwnedRoomId,
         OwnedUserId,
         RoomId,
-        UserId,
     },
 };
 
@@ -950,31 +949,6 @@ impl RoomInfo {
         }
     }
 
-    pub fn fully_read(&mut self, _user_id: &UserId) {
-        // let Some((key, _)) = self.messages.last_key_value() else {
-        //     return;
-        // };
-        //
-        // self.set_receipt(ReceiptThread::Main, user_id.to_owned(), key.id().to_owned());
-        //
-        // let newest = self
-        //     .threads
-        //     .iter()
-        //     .filter_map(|(thread_id, messages)| {
-        //         let thread = ReceiptThread::Thread(thread_id.to_owned());
-        //
-        //         messages
-        //             .last_key_value()
-        //             .map(|(key, _)| (thread, key.id().to_owned()))
-        //     })
-        //     .collect::<Vec<_>>();
-        //
-        // for (thread, event_id) in newest.into_iter() {
-        //     self.set_receipt(thread, user_id.to_owned(), event_id.clone());
-        // }
-        todo!()
-    }
-
     fn get_typers(&self) -> &[UserWithName] {
         if let Some((t, users)) = &self.users_typing {
             if t.elapsed() < Duration::from_secs(4) {
@@ -1127,43 +1101,6 @@ pub struct SyncInfo {
     pub dms: Vec<OwnedRoomId>,
 }
 
-#[derive(Default)]
-pub struct Rooms(CompletionMap<OwnedRoomId, RoomInfo>);
-
-impl Rooms {
-    /// Get the [RoomInfo] for a given room identifier.
-    pub fn get_or_default(&mut self, room_id: OwnedRoomId) -> &mut RoomInfo {
-        if self.0.get(&room_id).is_none() {
-            self.0.insert(room_id.clone(), RoomInfo {
-                messages: Messages::main(),
-
-                tags: Default::default(),
-                threads: Default::default(),
-                users_typing: Default::default(),
-                draw_last: Default::default(),
-                htmls: Default::default(),
-            });
-        }
-        self.0.get_mut(&room_id).expect("default value should have been inserted")
-    }
-
-    pub fn insert(&mut self, room_id: OwnedRoomId, room: RoomInfo) -> Option<RoomInfo> {
-        self.0.insert(room_id, room)
-    }
-
-    pub fn get_mut(&mut self, room_id: &RoomId) -> Option<&mut RoomInfo> {
-        self.0.get_mut(room_id)
-    }
-
-    pub fn get(&self, room_id: &RoomId) -> Option<&RoomInfo> {
-        self.0.get(room_id)
-    }
-
-    pub fn complete(&self, prefix: &str) -> Vec<OwnedRoomId> {
-        self.0.complete(prefix)
-    }
-}
-
 /// The main application state.
 pub struct ChatStore {
     /// `:`-commands
@@ -1173,7 +1110,7 @@ pub struct ChatStore {
     pub worker: Requester,
 
     /// Map of joined rooms.
-    pub rooms: Rooms,
+    pub rooms: CompletionMap<OwnedRoomId, RoomInfo>,
 
     /// Map of room names.
     pub names: CompletionMap<String, OwnedRoomId>,

--- a/src/base.rs
+++ b/src/base.rs
@@ -1235,6 +1235,9 @@ pub enum IambId {
 
     /// The `:unreads` window.
     UnreadList,
+
+    /// The `:invites` window.
+    InviteList,
 }
 
 impl Display for IambId {
@@ -1256,6 +1259,7 @@ impl Display for IambId {
             IambId::Welcome => f.write_str("iamb://welcome"),
             IambId::ChatList => f.write_str("iamb://chats"),
             IambId::UnreadList => f.write_str("iamb://unreads"),
+            IambId::InviteList => f.write_str("iamb://invites"),
         }
     }
 }
@@ -1394,6 +1398,13 @@ impl Visitor<'_> for IambIdVisitor {
 
                 Ok(IambId::UnreadList)
             },
+            Some("invites") => {
+                if url.path() != "" {
+                    return Err(E::custom("iamb://invites takes no path"));
+                }
+
+                Ok(IambId::UnreadList)
+            },
             Some(s) => Err(E::custom(format!("{s:?} is not a valid window"))),
             None => Err(E::custom("Invalid iamb window URL")),
         }
@@ -1464,6 +1475,9 @@ pub enum IambBufferId {
 
     /// The `:unreads` window.
     UnreadList,
+
+    /// The `:invits` window.
+    InviteList,
 }
 
 impl IambBufferId {
@@ -1480,6 +1494,7 @@ impl IambBufferId {
             IambBufferId::Welcome => IambId::Welcome,
             IambBufferId::ChatList => IambId::ChatList,
             IambBufferId::UnreadList => IambId::UnreadList,
+            IambBufferId::InviteList => IambId::InviteList,
         };
 
         Some(id)
@@ -1524,6 +1539,7 @@ impl Completer<IambInfo> for IambCompleter {
             IambBufferId::Welcome => vec![],
             IambBufferId::ChatList => vec![],
             IambBufferId::UnreadList => vec![],
+            IambBufferId::InviteList => vec![],
         }
     }
 }
@@ -1850,7 +1866,7 @@ pub mod tests {
         let text = EditRope::from("abo hor inv");
         let mut cursor = Cursor::new(0, 11);
         let res = complete_cmdbar(&text, &mut cursor, &store);
-        assert_eq!(res, vec!["invite"]);
+        assert_eq!(res, vec!["invite", "invites"]);
 
         let text = EditRope::from("abo hor invite \n");
         let mut cursor = Cursor::new(0, 15);

--- a/src/base.rs
+++ b/src/base.rs
@@ -36,10 +36,7 @@ use matrix_sdk::{
     encryption::verification::SasVerification,
     room::Room as MatrixRoom,
     ruma::{
-        events::{
-            room::message::RoomMessageEvent,
-            tag::{TagName, Tags},
-        },
+        events::tag::{TagName, Tags},
         presence::PresenceState,
         EventId,
         OwnedEventId,
@@ -855,8 +852,13 @@ impl RoomInfo {
     pub async fn new(
         room: &MatrixRoom,
         store: AsyncProgramStore,
+        locked: &mut ProgramStore,
     ) -> Result<Self, matrix_sdk_ui::timeline::Error> {
         let (messages, htmls) = Messages::new(room, None, store).await?;
+
+        let ChatStore { settings, previews, worker, .. } = &mut locked.application;
+
+        messages.register_image_previews(settings, previews, worker);
 
         Ok(Self {
             messages,
@@ -875,6 +877,8 @@ impl RoomInfo {
     pub fn ensure_thread(
         &mut self,
         root: &EventId,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
         worker: &Requester,
     ) -> Result<bool, matrix_sdk_ui::timeline::Error> {
         if self.threads.contains_key(root) {
@@ -882,6 +886,8 @@ impl RoomInfo {
         }
 
         let (messages, htmls) = worker.get_messages(self.room().clone(), Some(root.to_owned()))?;
+
+        messages.register_image_previews(settings, previews, worker);
 
         self.htmls.extend(htmls);
 
@@ -927,25 +933,6 @@ impl RoomInfo {
             notifications: self.room().num_unread_notifications().max(notification_count),
             highlights: self.room().num_unread_mentions().max(highlight_count),
             latest,
-        }
-    }
-
-    /// Insert a new message event, and prepare for image-preview if it has an image attachment.
-    #[allow(unused)]
-    pub fn insert_with_preview(
-        &mut self,
-        ev: RoomMessageEvent,
-        settings: &ApplicationSettings,
-        previews: &mut PreviewManager,
-        worker: &Requester,
-    ) {
-        // TODO: also register stickers
-        let source = todo!();
-
-        if let Some(source) = source {
-            if let Some(image_preview) = &settings.tunables.image_preview {
-                previews.register_preview(settings, source, image_preview.size, worker)
-            }
         }
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -38,18 +38,15 @@ use matrix_sdk::{
     ruma::{
         events::{
             reaction::ReactionEvent,
-            relation::{Replacement, Thread},
-            room::encrypted::RoomEncryptedEvent,
+            relation::Thread,
             room::message::{
                 OriginalRoomMessageEvent,
                 Relation,
                 RoomMessageEvent,
                 RoomMessageEventContent,
-                RoomMessageEventContentWithoutRelation,
             },
             room::redaction::{OriginalSyncRoomRedactionEvent, SyncRoomRedactionEvent},
             tag::{TagName, Tags},
-            AnySyncStateEvent,
             MessageLikeEvent,
         },
         presence::PresenceState,
@@ -94,7 +91,7 @@ use crate::config::ImagePreviewProtocolValues;
 use crate::notifications::NotificationHandle;
 use crate::preview::{source_from_event, PreviewManager};
 use crate::{
-    message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
+    message::{Message, MessageKey, MessageTimeStamp, Messages},
     worker::Requester,
     ApplicationSettings,
 };
@@ -1068,54 +1065,6 @@ impl RoomInfo {
         }
     }
 
-    /// Insert an edit.
-    pub fn insert_edit(&mut self, msg: Replacement<RoomMessageEventContentWithoutRelation>) {
-        let event_id = msg.event_id;
-        let new_msgtype = msg.new_content;
-
-        let Some(EventLocation::Message(thread, key)) = self.keys.get(&event_id) else {
-            return;
-        };
-
-        let source = if let Some(thread) = thread {
-            self.threads
-                .entry(thread.clone())
-                .or_insert_with(|| Messages::thread(thread.clone()))
-        } else {
-            &mut self.messages
-        };
-
-        let Some(msg) = source.get_mut(key) else {
-            return;
-        };
-
-        match msg.event_mut() {
-            MessageEvent::Original(orig) => {
-                orig.content.apply_replacement(new_msgtype);
-            },
-            MessageEvent::Local(_, content) => {
-                content.apply_replacement(new_msgtype);
-            },
-            MessageEvent::Redacted(_) |
-            MessageEvent::State(_) |
-            MessageEvent::EncryptedOriginal(_) |
-            MessageEvent::EncryptedRedacted(_) => {
-                return;
-            },
-        }
-
-        msg.set_html(msg.event().html());
-    }
-
-    pub fn insert_any_state(&mut self, msg: AnySyncStateEvent) {
-        let event_id = msg.event_id().to_owned();
-        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
-
-        let loc = EventLocation::State(key.clone());
-        self.keys.insert(event_id, loc);
-        self.messages.insert_message(key, msg);
-    }
-
     /// Indicates whether this room has unread messages.
     pub fn unreads(&self, settings: &ApplicationSettings) -> UnreadInfo {
         let last_message = self.messages.last_key_value();
@@ -1160,15 +1109,6 @@ impl RoomInfo {
         }
     }
 
-    /// Inserts events that couldn't be decrypted into the scrollback.
-    pub fn insert_encrypted(&mut self, msg: RoomEncryptedEvent) {
-        let event_id = msg.event_id().to_owned();
-        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
-
-        self.keys.insert(event_id, EventLocation::Message(None, key.clone()));
-        self.messages.insert(key, msg.into());
-    }
-
     /// Insert a new message.
     pub fn insert_message(&mut self, msg: RoomMessageEvent) {
         let event_id = msg.event_id().to_owned();
@@ -1176,20 +1116,22 @@ impl RoomInfo {
 
         let loc = EventLocation::Message(None, key.clone());
         self.keys.insert(event_id, loc);
-        self.messages.insert_message(key, msg);
+        // self.messages.insert_message(key, msg);
+        todo!()
     }
 
     fn insert_thread(&mut self, msg: RoomMessageEvent, thread_root: OwnedEventId) {
         let event_id = msg.event_id().to_owned();
         let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
 
-        let replies = self
-            .threads
-            .entry(thread_root.clone())
-            .or_insert_with(|| Messages::thread(thread_root.clone()));
+        // let replies = self
+        //     .threads
+        //     .entry(thread_root.clone())
+        //     .or_insert_with(|| Messages::thread(thread_root.clone()));
         let loc = EventLocation::Message(Some(thread_root), key.clone());
         self.keys.insert(event_id, loc);
-        replies.insert_message(key, msg);
+        // replies.insert_message(key, msg);
+        todo!()
     }
 
     /// Insert a new message event.
@@ -1200,7 +1142,7 @@ impl RoomInfo {
                 ..
             }) => {
                 match relates_to {
-                    Relation::Replacement(repl) => self.insert_edit(repl.clone()),
+                    Relation::Replacement(_) => todo!(),
                     Relation::Thread(Thread { event_id, .. }) => {
                         let event_id = event_id.clone();
                         self.insert_thread(msg, event_id);

--- a/src/base.rs
+++ b/src/base.rs
@@ -932,7 +932,7 @@ pub struct RoomInfo {
 impl Default for RoomInfo {
     fn default() -> Self {
         Self {
-            messages: Messages::new(ReceiptThread::Main),
+            messages: Messages::main(),
 
             name: Default::default(),
             tags: Default::default(),
@@ -967,32 +967,6 @@ impl RoomInfo {
                 .or_insert_with(|| Messages::thread(thread_root))
         } else {
             &mut self.messages
-        }
-    }
-
-    /// Get the event for the last message in a thread (or the thread root if there are no
-    /// in-thread replies yet).
-    ///
-    /// This returns `None` if the event identifier isn't in the room.
-    pub fn get_thread_last<'a>(
-        &'a self,
-        thread_root: &OwnedEventId,
-    ) -> Option<&'a OriginalRoomMessageEvent> {
-        let last = self.threads.get(thread_root).and_then(|t| Some(t.last_key_value()?.1));
-
-        let msg = if let Some(last) = last {
-            last.event()
-        } else if let EventLocation::Message(_, key) = self.keys.get(thread_root)? {
-            let msg = self.messages.get(key)?;
-            msg.event()
-        } else {
-            return None;
-        };
-
-        if let MessageEvent::Original(ev) = &msg {
-            Some(ev)
-        } else {
-            None
         }
     }
 
@@ -1247,6 +1221,7 @@ impl RoomInfo {
         previews: &mut PreviewManager,
         worker: &Requester,
     ) {
+        // TODO: also register stickers
         let source = source_from_event(&ev);
         self.insert(ev);
 
@@ -1400,22 +1375,6 @@ impl RoomInfo {
             .render(bar, buf);
 
         return top;
-    }
-
-    /// Checks if a given user has reacted with the given emoji on the given event
-    pub fn user_reactions_contains(
-        &mut self,
-        user_id: &UserId,
-        event_id: &EventId,
-        emoji: &str,
-    ) -> bool {
-        if let Some(reactions) = self.reactions.get(event_id) {
-            reactions
-                .values()
-                .any(|(annotation, user)| annotation == emoji && user == user_id)
-        } else {
-            false
-        }
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 use matrix_sdk::sync::UnreadNotificationsCount;
+use matrix_sdk::{RoomDisplayName, RoomState};
 use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ratatui::{
     buffer::Buffer,
@@ -828,9 +829,6 @@ impl UnreadInfo {
 
 /// Information about room's the user's joined.
 pub struct RoomInfo {
-    /// The display name for this room.
-    pub name: String,
-
     /// The tags placed on this room.
     pub tags: Option<Tags>,
 
@@ -866,7 +864,6 @@ impl RoomInfo {
             messages,
             htmls,
 
-            name: Default::default(),
             tags: Default::default(),
             threads: Default::default(),
             users_typing: Default::default(),
@@ -1135,7 +1132,6 @@ impl Rooms {
             self.0.insert(room_id.clone(), RoomInfo {
                 messages: Messages::main(),
 
-                name: Default::default(),
                 tags: Default::default(),
                 threads: Default::default(),
                 users_typing: Default::default(),
@@ -1238,23 +1234,24 @@ impl ChatStore {
     }
 
     /// Get a joined room.
-    pub fn get_joined_room(&self, _room_id: &RoomId) -> Option<MatrixRoom> {
-        todo!()
-        // let room = self.worker.client.get_room(room_id)?;
-        //
-        // if room.state() == MatrixRoomState::Joined {
-        //     Some(room)
-        // } else {
-        //     None
-        // }
+    pub fn get_joined_room(&self, room_id: &RoomId) -> Option<MatrixRoom> {
+        let room = self.worker.client.get_room(room_id)?;
+
+        if room.state() == RoomState::Joined {
+            Some(room)
+        } else {
+            None
+        }
     }
 
     /// Get the title for a room.
     pub fn get_room_title(&self, room_id: &RoomId) -> String {
-        self.rooms
-            .get(room_id)
-            .map(|i| i.name.clone())
-            .unwrap_or_else(|| "Untitled Matrix Room".to_string())
+        self.worker
+            .client
+            .get_room(room_id)
+            .and_then(|room| room.cached_display_name())
+            .unwrap_or(RoomDisplayName::Empty)
+            .to_string()
     }
 
     /// Insert a new E2EE verification.

--- a/src/base.rs
+++ b/src/base.rs
@@ -875,6 +875,27 @@ impl RoomInfo {
         })
     }
 
+    /// Create the thread if it didn't already exists.
+    ///
+    /// Returns whether a new thread was created.
+    pub fn ensure_thread(
+        &mut self,
+        root: &EventId,
+        worker: &Requester,
+    ) -> Result<bool, matrix_sdk_ui::timeline::Error> {
+        if self.threads.contains_key(root) {
+            return Ok(false);
+        }
+
+        let (messages, htmls) = worker.get_messages(self.room().clone(), Some(root.to_owned()))?;
+
+        self.htmls.extend(htmls);
+
+        self.threads.insert(root.to_owned(), messages);
+
+        Ok(true)
+    }
+
     #[inline]
     pub fn room(&self) -> &MatrixRoom {
         self.messages.timeline().room()

--- a/src/base.rs
+++ b/src/base.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use emojis::Emoji;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
+use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -88,6 +89,7 @@ use modalkit::{
 };
 
 use crate::config::ImagePreviewProtocolValues;
+use crate::message::html::StyleTree;
 use crate::notifications::NotificationHandle;
 use crate::preview::{source_from_event, PreviewManager};
 use crate::{
@@ -924,6 +926,8 @@ pub struct RoomInfo {
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
+
+    pub htmls: HashMap<TimelineEventItemId, StyleTree>,
 }
 
 impl Default for RoomInfo {
@@ -944,6 +948,7 @@ impl Default for RoomInfo {
             users_typing: Default::default(),
             display_names: Default::default(),
             draw_last: Default::default(),
+            htmls: Default::default(),
         }
     }
 }
@@ -1233,6 +1238,10 @@ impl RoomInfo {
             .render(bar, buf);
 
         return top;
+    }
+
+    pub fn get_html(&self, id: &TimelineEventItemId) -> Option<&StyleTree> {
+        self.htmls.get(id)
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -849,13 +849,8 @@ impl RoomInfo {
     pub async fn new(
         room: &MatrixRoom,
         store: AsyncProgramStore,
-        locked: &mut ProgramStore,
     ) -> Result<Self, matrix_sdk_ui::timeline::Error> {
         let (messages, htmls) = Messages::new(room, None, store).await?;
-
-        let ChatStore { settings, previews, worker, .. } = &mut locked.application;
-
-        messages.register_image_previews(settings, previews, worker);
 
         Ok(Self {
             messages,
@@ -887,8 +882,6 @@ impl RoomInfo {
     pub fn ensure_thread(
         &mut self,
         root: &EventId,
-        settings: &ApplicationSettings,
-        previews: &mut PreviewManager,
         worker: &Requester,
     ) -> Result<bool, matrix_sdk_ui::timeline::Error> {
         if self.threads.contains_key(root) {
@@ -896,8 +889,6 @@ impl RoomInfo {
         }
 
         let (messages, htmls) = worker.get_messages(self.room().clone(), Some(root.to_owned()))?;
-
-        messages.register_image_previews(settings, previews, worker);
 
         self.htmls.extend(htmls);
 
@@ -1086,11 +1077,14 @@ pub struct SyncInfo {
     /// Spaces that the user is a member of.
     pub spaces: Vec<OwnedRoomId>,
 
-    /// Rooms that the user is a member of.
+    /// Normal rooms that the user is a member of.
     pub rooms: Vec<OwnedRoomId>,
 
     /// DMs that the user is a member of.
     pub dms: Vec<OwnedRoomId>,
+
+    /// Rooms that the user is invited to.
+    pub invites: Vec<OwnedRoomId>,
 }
 
 /// The main application state.
@@ -1175,6 +1169,21 @@ impl ChatStore {
         } else {
             None
         }
+    }
+
+    pub fn join_room(&mut self, name: String) -> IambResult<&mut RoomInfo> {
+        let room = self.worker.join_room(name.clone())?;
+
+        let room_id = room.room_id().to_owned();
+
+        if self.rooms.get(&room_id).is_none() {
+            let info = self.worker.create_room_info(room).map_err(IambError::from)?;
+            self.rooms.insert(room_id.clone(), info);
+
+            self.names.insert(name, room_id.clone());
+        }
+
+        Ok(self.rooms.get_mut(&room_id).expect("value should have been inserted"))
     }
 
     /// Get the title for a room.

--- a/src/base.rs
+++ b/src/base.rs
@@ -2,8 +2,7 @@
 //!
 //! The types defined here get used throughout iamb.
 use std::borrow::Cow;
-use std::collections::hash_map::IntoIter;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{self, Display};
 use std::hash::Hash;
@@ -12,8 +11,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use emojis::Emoji;
-use matrix_sdk::ruma::events::receipt::ReceiptThread;
-use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ratatui::{
     buffer::Buffer,
@@ -38,17 +35,8 @@ use matrix_sdk::{
     room::Room as MatrixRoom,
     ruma::{
         events::{
-            reaction::ReactionEvent,
-            relation::Thread,
-            room::message::{
-                OriginalRoomMessageEvent,
-                Relation,
-                RoomMessageEvent,
-                RoomMessageEventContent,
-            },
-            room::redaction::OriginalSyncRoomRedactionEvent,
+            room::message::RoomMessageEvent,
             tag::{TagName, Tags},
-            MessageLikeEvent,
         },
         presence::PresenceState,
         EventId,
@@ -91,9 +79,9 @@ use modalkit::{
 use crate::config::ImagePreviewProtocolValues;
 use crate::message::html::StyleTree;
 use crate::notifications::NotificationHandle;
-use crate::preview::{source_from_event, PreviewManager};
+use crate::preview::PreviewManager;
 use crate::{
-    message::{Message, MessageKey, MessageTimeStamp, Messages},
+    message::{MessageKey, MessageTimeStamp, Messages},
     worker::Requester,
     ApplicationSettings,
 };
@@ -113,6 +101,7 @@ fn is_mxid_char(c: char) -> bool {
         ":-./@_#!".contains(c);
 }
 
+#[allow(unused)]
 const ROOM_FETCH_DEBOUNCE: Duration = Duration::from_secs(2);
 
 /// Empty type used solely to implement [ApplicationInfo].
@@ -682,12 +671,6 @@ pub type AsyncProgramStore = Arc<AsyncMutex<ProgramStore>>;
 /// Alias for an action result.
 pub type IambResult<T> = UIResult<T, IambInfo>;
 
-/// Reaction events for some message.
-///
-/// The event identifier used as a key here is the ID for the reaction, and not for the message
-/// it's reacting to.
-pub type MessageReactions = HashMap<OwnedEventId, (String, OwnedUserId)>;
-
 /// Errors encountered during application use.
 #[derive(thiserror::Error, Debug)]
 pub enum IambError {
@@ -826,45 +809,6 @@ impl From<IambError> for UIError<IambInfo> {
 
 impl ApplicationError for IambError {}
 
-/// Status for tracking how much room scrollback we've fetched.
-#[derive(Default)]
-pub enum RoomFetchStatus {
-    /// Room history has been completely fetched.
-    Done,
-
-    /// More room history can be fetched.
-    HaveMore(String),
-
-    /// We have not yet started fetching history for this room.
-    #[default]
-    NotStarted,
-}
-
-/// Indicates where an [EventId] lives in the [ChatStore].
-pub enum EventLocation {
-    /// The [EventId] belongs to a message.
-    ///
-    /// If the first argument is [None], then it's part of the main scrollback. When [Some],
-    /// it specifies which thread it's in reply to.
-    Message(Option<OwnedEventId>, MessageKey),
-
-    /// The [EventId] belongs to a reaction to the given event.
-    Reaction(OwnedEventId),
-
-    /// The [EventId] belongs to a state event in the main timeline of the room.
-    State(MessageKey),
-}
-
-impl EventLocation {
-    fn to_message_key(&self) -> Option<&MessageKey> {
-        if let EventLocation::Message(_, key) = self {
-            Some(key)
-        } else {
-            None
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct UnreadInfo {
     pub(crate) unread: bool,
@@ -889,34 +833,11 @@ pub struct RoomInfo {
     /// The tags placed on this room.
     pub tags: Option<Tags>,
 
-    /// A map of event IDs to where they are stored in this struct.
-    pub keys: HashMap<OwnedEventId, EventLocation>,
-
     /// The messages loaded for this room.
     messages: Messages,
 
-    /// A map of read markers to display on different events.
-    pub event_receipts: HashMap<ReceiptThread, HashMap<OwnedEventId, HashSet<OwnedUserId>>>,
-    /// A map of the most recent read marker for each user.
-    ///
-    /// Every receipt in this map should also have an entry in [`event_receipts`](`Self::event_receipts`),
-    /// however not every user has an entry. If a user's most recent receipt is
-    /// older than the oldest loaded event, that user will not be included.
-    pub user_receipts: HashMap<ReceiptThread, HashMap<OwnedUserId, OwnedEventId>>,
-    /// A map of message identifiers to a map of reaction events.
-    pub reactions: HashMap<OwnedEventId, MessageReactions>,
-
     /// A map of message identifiers to thread replies.
     threads: HashMap<OwnedEventId, Messages>,
-
-    /// Whether the scrollback for this room is currently being fetched.
-    pub fetching: bool,
-
-    /// Where to continue fetching from when we continue loading scrollback history.
-    pub fetch_id: RoomFetchStatus,
-
-    /// The time that we last fetched scrollback for this room.
-    pub fetch_last: Option<Instant>,
 
     /// Users currently typing in this room, and when we received notification of them doing so.
     pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
@@ -939,69 +860,9 @@ impl RoomInfo {
         }
     }
 
-    /// Get the reactions and their counts for a message.
-    pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize)> {
-        if let Some(reacts) = self.reactions.get(event_id) {
-            let mut counts = HashMap::new();
-
-            let mut seen_user_reactions = BTreeSet::new();
-
-            for (key, user) in reacts.values() {
-                if !seen_user_reactions.contains(&(key, user)) {
-                    seen_user_reactions.insert((key, user));
-                    let count = counts.entry(key.as_str()).or_default();
-                    *count += 1;
-                }
-            }
-
-            let mut reactions = counts.into_iter().collect::<Vec<_>>();
-            reactions.sort();
-
-            reactions
-        } else {
-            vec![]
-        }
-    }
-
     /// Map an event identifier to its [MessageKey].
-    pub fn get_message_key(&self, event_id: &EventId) -> Option<&MessageKey> {
-        self.keys.get(event_id)?.to_message_key()
-    }
-
-    /// Get an event for an identifier.
-    pub fn get_event(&self, event_id: &EventId) -> Option<&Message> {
-        self.messages.get_message(self.get_message_key(event_id)?)
-    }
-
-    pub fn redact(&mut self, ev: OriginalSyncRoomRedactionEvent, rules: &RedactionRules) {
-        let _ = rules;
-        let Some(_redacts) = &ev.redacts else {
-            return;
-        };
-
+    pub fn get_message_key(&self, _event_id: &EventId) -> Option<&MessageKey> {
         todo!()
-    }
-
-    /// Insert a reaction to a message.
-    pub fn insert_reaction(&mut self, react: ReactionEvent) {
-        match react {
-            MessageLikeEvent::Original(react) => {
-                let rel_id = react.content.relates_to.event_id;
-                let key = react.content.relates_to.key;
-
-                let message = self.reactions.entry(rel_id.clone()).or_default();
-                let event_id = react.event_id;
-                let user_id = react.sender;
-
-                message.insert(event_id.clone(), (key, user_id));
-
-                let loc = EventLocation::Reaction(rel_id);
-                self.keys.insert(event_id, loc);
-            },
-            MessageLikeEvent::Redacted(_) => {
-                return;
-            },
-        }
     }
 
     /// Indicates whether this room has unread messages.
@@ -1009,53 +870,8 @@ impl RoomInfo {
         todo!()
     }
 
-    /// Insert a new message.
-    pub fn insert_message(&mut self, _msg: RoomMessageEvent) {
-        // let event_id = msg.event_id().to_owned();
-        // let key = todo!();
-        //
-        // let loc = EventLocation::Message(None, key.clone());
-        // self.keys.insert(event_id, loc);
-        // self.messages.insert_message(key, msg);
-        todo!()
-    }
-
-    fn insert_thread(&mut self, _msg: RoomMessageEvent, _thread_root: OwnedEventId) {
-        // let event_id = msg.event_id().to_owned();
-        // let key = todo!();
-        //
-        // let replies = self
-        //     .threads
-        //     .entry(thread_root.clone())
-        //     .or_insert_with(|| Messages::thread(thread_root.clone()));
-        // let loc = EventLocation::Message(Some(thread_root), key.clone());
-        // self.keys.insert(event_id, loc);
-        // replies.insert_message(key, msg);
-        todo!()
-    }
-
-    /// Insert a new message event.
-    pub fn insert(&mut self, msg: RoomMessageEvent) {
-        match msg {
-            RoomMessageEvent::Original(OriginalRoomMessageEvent {
-                content: RoomMessageEventContent { relates_to: Some(ref relates_to), .. },
-                ..
-            }) => {
-                match relates_to {
-                    Relation::Replacement(_) => todo!(),
-                    Relation::Thread(Thread { event_id, .. }) => {
-                        let event_id = event_id.clone();
-                        self.insert_thread(msg, event_id);
-                    },
-                    Relation::Reply { .. } => self.insert_message(msg),
-                    _ => self.insert_message(msg),
-                }
-            },
-            _ => self.insert_message(msg),
-        }
-    }
-
     /// Insert a new message event, and prepare for image-preview if it has an image attachment.
+    #[allow(unused)]
     pub fn insert_with_preview(
         &mut self,
         ev: RoomMessageEvent,
@@ -1064,52 +880,13 @@ impl RoomInfo {
         worker: &Requester,
     ) {
         // TODO: also register stickers
-        let source = source_from_event(&ev);
-        self.insert(ev);
+        let source = todo!();
 
-        if let Some((_, source)) = source {
+        if let Some(source) = source {
             if let Some(image_preview) = &settings.tunables.image_preview {
                 previews.register_preview(settings, source, image_preview.size, worker)
             }
         }
-    }
-
-    /// Indicates whether we've recently fetched scrollback for this room.
-    pub fn recently_fetched(&self) -> bool {
-        self.fetch_last.is_some_and(|i| i.elapsed() < ROOM_FETCH_DEBOUNCE)
-    }
-
-    fn clear_receipt(&mut self, thread: &ReceiptThread, user_id: &OwnedUserId) -> Option<()> {
-        let old_event_id =
-            self.user_receipts.get(thread).and_then(|receipts| receipts.get(user_id))?;
-        let old_thread = self.event_receipts.get_mut(thread)?;
-        let old_receipts = old_thread.get_mut(old_event_id)?;
-        old_receipts.remove(user_id);
-
-        if old_receipts.is_empty() {
-            old_thread.remove(old_event_id);
-        }
-        if old_thread.is_empty() {
-            self.event_receipts.remove(thread);
-        }
-
-        None
-    }
-
-    pub fn set_receipt(
-        &mut self,
-        thread: ReceiptThread,
-        user_id: OwnedUserId,
-        event_id: OwnedEventId,
-    ) {
-        self.clear_receipt(&thread, &user_id);
-        self.event_receipts
-            .entry(thread.clone())
-            .or_default()
-            .entry(event_id.clone())
-            .or_default()
-            .insert(user_id.clone());
-        self.user_receipts.entry(thread).or_default().insert(user_id, event_id);
     }
 
     pub fn fully_read(&mut self, _user_id: &UserId) {
@@ -1135,15 +912,6 @@ impl RoomInfo {
         //     self.set_receipt(thread, user_id.to_owned(), event_id.clone());
         // }
         todo!()
-    }
-
-    pub fn receipts<'a>(
-        &'a self,
-        user_id: &'a UserId,
-    ) -> impl Iterator<Item = (&'a ReceiptThread, &'a OwnedEventId)> + 'a {
-        self.user_receipts
-            .iter()
-            .filter_map(move |(t, rs)| rs.get(user_id).map(|r| (t, r)))
     }
 
     fn get_typers(&self) -> &[OwnedUserId] {
@@ -1305,69 +1073,6 @@ impl SyncInfo {
     }
 }
 
-static MESSAGE_NEED_TTL: u8 = 30;
-
-#[derive(Debug, PartialEq)]
-/// Load messages until the event is loaded or `ttl` loads are exceeded
-pub struct MessageNeed {
-    pub event_id: OwnedEventId,
-    pub ttl: u8,
-}
-
-#[derive(Default, Debug, PartialEq)]
-pub struct Need {
-    pub members: bool,
-    pub messages: Option<Vec<MessageNeed>>,
-}
-
-/// Things that need loading for different rooms.
-#[derive(Default)]
-pub struct RoomNeeds {
-    needs: HashMap<OwnedRoomId, Need>,
-}
-
-impl RoomNeeds {
-    /// Mark a room for needing to load members.
-    pub fn need_members(&mut self, room_id: OwnedRoomId) {
-        self.needs.entry(room_id).or_default().members = true;
-    }
-
-    /// Mark a room for needing to load messages.
-    pub fn need_messages(&mut self, room_id: OwnedRoomId) {
-        self.needs.entry(room_id).or_default().messages.get_or_insert_default();
-    }
-
-    /// Mark a room for needing to load messages until the given message is loaded or a retry limit
-    /// is exceeded.
-    pub fn need_message(&mut self, room_id: OwnedRoomId, event_id: OwnedEventId) {
-        let messages = &mut self.needs.entry(room_id).or_default().messages.get_or_insert_default();
-
-        messages.push(MessageNeed { event_id, ttl: MESSAGE_NEED_TTL });
-    }
-
-    pub fn need_messages_all(&mut self, room_id: OwnedRoomId, message_needs: Vec<MessageNeed>) {
-        self.needs
-            .entry(room_id)
-            .or_default()
-            .messages
-            .get_or_insert_default()
-            .extend(message_needs);
-    }
-
-    pub fn rooms(&self) -> usize {
-        self.needs.len()
-    }
-}
-
-impl IntoIterator for RoomNeeds {
-    type Item = (OwnedRoomId, Need);
-    type IntoIter = IntoIter<OwnedRoomId, Need>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.needs.into_iter()
-    }
-}
-
 #[derive(Default)]
 pub struct Rooms(CompletionMap<OwnedRoomId, RoomInfo>);
 
@@ -1380,14 +1085,7 @@ impl Rooms {
 
                 name: Default::default(),
                 tags: Default::default(),
-                keys: Default::default(),
-                event_receipts: Default::default(),
-                user_receipts: Default::default(),
-                reactions: Default::default(),
                 threads: Default::default(),
-                fetching: Default::default(),
-                fetch_id: Default::default(),
-                fetch_last: Default::default(),
                 users_typing: Default::default(),
                 display_names: Default::default(),
                 draw_last: Default::default(),
@@ -1428,9 +1126,6 @@ pub struct ChatStore {
 
     /// Settings for the current profile loaded from config file.
     pub settings: ApplicationSettings,
-
-    /// Set of rooms that need more messages loaded in their scrollback.
-    pub need_load: RoomNeeds,
 
     /// [CompletionMap] of Emoji shortcodes.
     pub emojis: CompletionMap<String, &'static Emoji>,
@@ -1474,7 +1169,6 @@ impl ChatStore {
             rooms: Default::default(),
             presences: Default::default(),
             verifications: Default::default(),
-            need_load: Default::default(),
             sync_info: Default::default(),
             draw_curr: None,
             ring_bell: false,
@@ -2014,69 +1708,6 @@ pub mod tests {
     use ratatui::style::Color;
 
     #[test]
-    fn multiple_identical_reactions() {
-        // let mut info = RoomInfo::default();
-        let mut info: RoomInfo = todo!();
-
-        let content = ReactionEventContent::new(Annotation::new(
-            owned_event_id!("$my_reaction"),
-            "🏠".to_owned(),
-        ));
-
-        for i in 0..3 {
-            let event_id = format!("$house_{i}");
-            info.insert_reaction(MessageLikeEvent::Original(
-                matrix_sdk::ruma::events::OriginalMessageLikeEvent {
-                    content: content.clone(),
-                    event_id: OwnedEventId::from_str(&event_id).unwrap(),
-                    sender: owned_user_id!("@foo:example.org"),
-                    origin_server_ts: MilliSecondsSinceUnixEpoch::now(),
-                    room_id: owned_room_id!("!foo:example.org"),
-                    unsigned: MessageLikeUnsigned::new(),
-                },
-            ));
-        }
-
-        let content = ReactionEventContent::new(Annotation::new(
-            owned_event_id!("$my_reaction"),
-            "🙂".to_owned(),
-        ));
-
-        for i in 0..2 {
-            let event_id = format!("$smile_{i}");
-            info.insert_reaction(MessageLikeEvent::Original(
-                matrix_sdk::ruma::events::OriginalMessageLikeEvent {
-                    content: content.clone(),
-                    event_id: OwnedEventId::from_str(&event_id).unwrap(),
-                    sender: owned_user_id!("@foo:example.org"),
-                    origin_server_ts: MilliSecondsSinceUnixEpoch::now(),
-                    room_id: owned_room_id!("!foo:example.org"),
-                    unsigned: MessageLikeUnsigned::new(),
-                },
-            ));
-        }
-
-        for i in 2..4 {
-            let event_id = format!("$smile_{i}");
-            info.insert_reaction(MessageLikeEvent::Original(
-                matrix_sdk::ruma::events::OriginalMessageLikeEvent {
-                    content: content.clone(),
-                    event_id: OwnedEventId::from_str(&event_id).unwrap(),
-                    sender: owned_user_id!("@bar:example.org"),
-                    origin_server_ts: MilliSecondsSinceUnixEpoch::now(),
-                    room_id: owned_room_id!("!foo:example.org"),
-                    unsigned: MessageLikeUnsigned::new(),
-                },
-            ));
-        }
-
-        assert_eq!(info.get_reactions(&owned_event_id!("$my_reaction")), vec![
-            ("🏠", 1),
-            ("🙂", 2)
-        ]);
-    }
-
-    #[test]
     fn test_typing_spans() {
         // let mut info = RoomInfo::default();
         let mut info: RoomInfo = todo!();
@@ -2152,21 +1783,6 @@ pub mod tests {
                 Span::from(" is typing...")
             ])
         );
-    }
-
-    #[test]
-    fn test_need_load() {
-        let room_id = TEST_ROOM1_ID.clone();
-
-        let mut need_load = RoomNeeds::default();
-
-        need_load.need_messages(room_id.clone());
-        need_load.need_members(room_id.clone());
-
-        assert_eq!(need_load.into_iter().collect::<Vec<(OwnedRoomId, Need)>>(), vec![(
-            room_id,
-            Need { members: true, messages: Some(Vec::new()) }
-        )],);
     }
 
     #[tokio::test]

--- a/src/base.rs
+++ b/src/base.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use emojis::Emoji;
+use matrix_sdk::sync::UnreadNotificationsCount;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ratatui::{
     buffer::Buffer,
@@ -810,13 +811,14 @@ impl ApplicationError for IambError {}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct UnreadInfo {
-    pub(crate) unread: bool,
+    pub(crate) notifications: u64,
+    pub(crate) highlights: u64,
     pub(crate) latest: Option<MessageTimeStamp>,
 }
 
 impl UnreadInfo {
     pub fn is_unread(&self) -> bool {
-        self.unread
+        self.notifications > 0 || self.highlights > 0
     }
 
     pub fn latest(&self) -> Option<&MessageTimeStamp> {
@@ -898,7 +900,16 @@ impl RoomInfo {
 
     /// Indicates whether this room has unread messages.
     pub fn unreads(&self, _settings: &ApplicationSettings) -> UnreadInfo {
-        todo!()
+        let UnreadNotificationsCount { highlight_count, notification_count } =
+            self.room().unread_notification_counts();
+
+        let latest = self.messages.last_message().map(|item| item.timestamp().into());
+
+        UnreadInfo {
+            notifications: self.room().num_unread_notifications().max(notification_count),
+            highlights: self.room().num_unread_mentions().max(highlight_count),
+            latest,
+        }
     }
 
     /// Insert a new message event, and prepare for image-preview if it has an image attachment.

--- a/src/base.rs
+++ b/src/base.rs
@@ -919,11 +919,11 @@ impl RoomInfo {
     }
 
     /// Indicates whether this room has unread messages.
-    pub fn unreads(&self, _settings: &ApplicationSettings) -> UnreadInfo {
+    pub fn unreads(&self, settings: &ApplicationSettings) -> UnreadInfo {
         let UnreadNotificationsCount { highlight_count, notification_count } =
             self.room().unread_notification_counts();
 
-        let latest = self.messages.last_message().map(|item| item.timestamp().into());
+        let latest = self.messages.last_message(settings).map(|item| item.timestamp().into());
 
         UnreadInfo {
             notifications: self.room().num_unread_notifications().max(notification_count),

--- a/src/base.rs
+++ b/src/base.rs
@@ -78,7 +78,7 @@ use crate::message::html::StyleTree;
 use crate::notifications::NotificationHandle;
 use crate::preview::PreviewManager;
 use crate::{
-    message::{MessageKey, MessageTimeStamp, Messages},
+    message::{MessageTimeStamp, Messages},
     worker::Requester,
     ApplicationSettings,
 };
@@ -915,11 +915,6 @@ impl RoomInfo {
         } else {
             Some(&mut self.messages)
         }
-    }
-
-    /// Map an event identifier to its [MessageKey].
-    pub fn get_message_key(&self, _event_id: &EventId) -> Option<&MessageKey> {
-        todo!()
     }
 
     /// Indicates whether this room has unread messages.

--- a/src/base.rs
+++ b/src/base.rs
@@ -1707,7 +1707,6 @@ fn complete_cmdbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
 }
 
 #[cfg(test)]
-#[allow(unused)]
 pub mod tests {
     use super::*;
     use crate::config::user_style_from_color;

--- a/src/base.rs
+++ b/src/base.rs
@@ -45,7 +45,7 @@ use matrix_sdk::{
                 RoomMessageEvent,
                 RoomMessageEventContent,
             },
-            room::redaction::{OriginalSyncRoomRedactionEvent, SyncRoomRedactionEvent},
+            room::redaction::OriginalSyncRoomRedactionEvent,
             tag::{TagName, Tags},
             MessageLikeEvent,
         },
@@ -1007,40 +1007,12 @@ impl RoomInfo {
     }
 
     pub fn redact(&mut self, ev: OriginalSyncRoomRedactionEvent, rules: &RedactionRules) {
-        let Some(redacts) = &ev.redacts else {
+        let _ = rules;
+        let Some(_redacts) = &ev.redacts else {
             return;
         };
 
-        match self.keys.get(redacts) {
-            None => return,
-            Some(EventLocation::State(key)) => {
-                if let Some(msg) = self.messages.get_mut(key) {
-                    let ev = SyncRoomRedactionEvent::Original(ev);
-                    msg.redact(ev, rules);
-                }
-            },
-            Some(EventLocation::Message(None, key)) => {
-                if let Some(msg) = self.messages.get_mut(key) {
-                    let ev = SyncRoomRedactionEvent::Original(ev);
-                    msg.redact(ev, rules);
-                }
-            },
-            Some(EventLocation::Message(Some(root), key)) => {
-                if let Some(thread) = self.threads.get_mut(root) {
-                    if let Some(msg) = thread.get_mut(key) {
-                        let ev = SyncRoomRedactionEvent::Original(ev);
-                        msg.redact(ev, rules);
-                    }
-                }
-            },
-            Some(EventLocation::Reaction(event_id)) => {
-                if let Some(reactions) = self.reactions.get_mut(event_id) {
-                    reactions.remove(redacts);
-                }
-
-                self.keys.remove(redacts);
-            },
-        }
+        todo!()
     }
 
     /// Insert a reaction to a message.
@@ -1168,10 +1140,10 @@ impl RoomInfo {
         self.insert(ev);
 
         if let Some((event_id, source)) = source {
-            if let (Some(msg), Some(image_preview)) =
+            if let (Some(_msg), Some(image_preview)) =
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
             {
-                msg.insert_image_preview(source.clone());
+                // msg.insert_image_preview(source.clone());
                 previews.register_preview(settings, source, image_preview.size, worker)
             }
         }

--- a/src/base.rs
+++ b/src/base.rs
@@ -46,7 +46,6 @@ use matrix_sdk::{
         RoomId,
         UserId,
     },
-    RoomState as MatrixRoomState,
 };
 
 use modalkit::{
@@ -828,7 +827,7 @@ impl UnreadInfo {
 /// Information about room's the user's joined.
 pub struct RoomInfo {
     /// The display name for this room.
-    pub name: Option<String>,
+    pub name: String,
 
     /// The tags placed on this room.
     pub tags: Option<Tags>,
@@ -852,6 +851,25 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
+    pub async fn new(
+        room: &MatrixRoom,
+        store: AsyncProgramStore,
+    ) -> Result<Self, matrix_sdk_ui::timeline::Error> {
+        let (messages, htmls) = Messages::new(room, None, store).await?;
+
+        Ok(Self {
+            messages,
+            htmls,
+
+            name: Default::default(),
+            tags: Default::default(),
+            threads: Default::default(),
+            users_typing: Default::default(),
+            display_names: Default::default(),
+            draw_last: Default::default(),
+        })
+    }
+
     #[inline]
     pub fn room(&self) -> &MatrixRoom {
         self.messages.timeline().room()
@@ -862,6 +880,14 @@ impl RoomInfo {
             self.threads.get(thread_root)
         } else {
             Some(&self.messages)
+        }
+    }
+
+    pub fn get_thread_mut(&mut self, root: Option<&EventId>) -> Option<&mut Messages> {
+        if let Some(thread_root) = root {
+            self.threads.get_mut(thread_root)
+        } else {
+            Some(&mut self.messages)
         }
     }
 
@@ -1086,6 +1112,14 @@ impl Rooms {
         self.0.get_mut(&room_id).expect("default value should have been inserted")
     }
 
+    pub fn insert(&mut self, room_id: OwnedRoomId, room: RoomInfo) -> Option<RoomInfo> {
+        self.0.insert(room_id, room)
+    }
+
+    pub fn get_mut(&mut self, room_id: &RoomId) -> Option<&mut RoomInfo> {
+        self.0.get_mut(room_id)
+    }
+
     pub fn get(&self, room_id: &RoomId) -> Option<&RoomInfo> {
         self.0.get(room_id)
     }
@@ -1169,22 +1203,22 @@ impl ChatStore {
     }
 
     /// Get a joined room.
-    pub fn get_joined_room(&self, room_id: &RoomId) -> Option<MatrixRoom> {
-        let room = self.worker.client.get_room(room_id)?;
-
-        if room.state() == MatrixRoomState::Joined {
-            Some(room)
-        } else {
-            None
-        }
+    pub fn get_joined_room(&self, _room_id: &RoomId) -> Option<MatrixRoom> {
+        todo!()
+        // let room = self.worker.client.get_room(room_id)?;
+        //
+        // if room.state() == MatrixRoomState::Joined {
+        //     Some(room)
+        // } else {
+        //     None
+        // }
     }
 
     /// Get the title for a room.
     pub fn get_room_title(&self, room_id: &RoomId) -> String {
         self.rooms
             .get(room_id)
-            .and_then(|i| i.name.as_ref())
-            .map(String::from)
+            .map(|i| i.name.clone())
             .unwrap_or_else(|| "Untitled Matrix Room".to_string())
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -849,10 +849,13 @@ pub struct RoomInfo {
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
 
+    /// Cache of html representation for messages in this room
     pub htmls: HashMap<TimelineEventItemId, StyleTree>,
 }
 
 impl RoomInfo {
+    /// This must be called while `store` is locked and must be inserted in the store before it is
+    /// unlocked.
     pub async fn new(
         room: &MatrixRoom,
         store: AsyncProgramStore,
@@ -1002,7 +1005,7 @@ impl RoomInfo {
 
     /// Create a [Rect] that displays what users are typing.
     pub fn render_typing(
-        &mut self,
+        &self,
         area: Rect,
         buf: &mut Buffer,
         settings: &ApplicationSettings,

--- a/src/base.rs
+++ b/src/base.rs
@@ -977,10 +977,10 @@ impl RoomInfo {
         let last = self.threads.get(thread_root).and_then(|t| Some(t.last_key_value()?.1));
 
         let msg = if let Some(last) = last {
-            &last.event
+            last.event()
         } else if let EventLocation::Message(_, key) = self.keys.get(thread_root)? {
             let msg = self.messages.get(key)?;
-            &msg.event
+            msg.event()
         } else {
             return None;
         };
@@ -1111,7 +1111,7 @@ impl RoomInfo {
             return;
         };
 
-        match &mut msg.event {
+        match msg.event_mut() {
             MessageEvent::Original(orig) => {
                 orig.content.apply_replacement(new_msgtype);
             },
@@ -1126,7 +1126,7 @@ impl RoomInfo {
             },
         }
 
-        msg.html = msg.event.html();
+        msg.set_html(msg.event().html());
     }
 
     pub fn insert_any_state(&mut self, msg: AnySyncStateEvent) {
@@ -1250,7 +1250,7 @@ impl RoomInfo {
             if let (Some(msg), Some(image_preview)) =
                 (self.get_event_mut(&event_id), &settings.tunables.image_preview)
             {
-                msg.image_preview = Some(source.clone());
+                msg.insert_image_preview(source.clone());
                 previews.register_preview(settings, source, image_preview.size, worker)
             }
         }

--- a/src/base.rs
+++ b/src/base.rs
@@ -1131,7 +1131,7 @@ impl RoomInfo {
 
     pub fn insert_any_state(&mut self, msg: AnySyncStateEvent) {
         let event_id = msg.event_id().to_owned();
-        let key = (msg.origin_server_ts().into(), event_id.clone());
+        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
 
         let loc = EventLocation::State(key.clone());
         self.keys.insert(event_id, loc);
@@ -1167,13 +1167,16 @@ impl RoomInfo {
         let last_receipt = std::cmp::max(last_receipt, last_unthreaded);
 
         match (last_message, last_receipt) {
-            (Some(((ts, _), _)), Some((read_ts, _))) => {
-                UnreadInfo { unread: ts > read_ts, latest: Some(*ts) }
+            (Some((key, _)), Some(read_key)) => {
+                UnreadInfo {
+                    unread: key.ts() > read_key.ts(),
+                    latest: Some(*key.ts()),
+                }
             },
-            (Some(((ts, _), _)), None) => {
+            (Some((key, _)), None) => {
                 // If we've never loaded/generated a room's receipt (example,
                 // a newly joined but never viewed room), show it as unread.
-                UnreadInfo { unread: true, latest: Some(*ts) }
+                UnreadInfo { unread: true, latest: Some(*key.ts()) }
             },
             (None, _) => UnreadInfo::default(),
         }
@@ -1182,7 +1185,7 @@ impl RoomInfo {
     /// Inserts events that couldn't be decrypted into the scrollback.
     pub fn insert_encrypted(&mut self, msg: RoomEncryptedEvent) {
         let event_id = msg.event_id().to_owned();
-        let key = (msg.origin_server_ts().into(), event_id.clone());
+        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
 
         self.keys.insert(event_id, EventLocation::Message(None, key.clone()));
         self.messages.insert(key, msg.into());
@@ -1191,7 +1194,7 @@ impl RoomInfo {
     /// Insert a new message.
     pub fn insert_message(&mut self, msg: RoomMessageEvent) {
         let event_id = msg.event_id().to_owned();
-        let key = (msg.origin_server_ts().into(), event_id.clone());
+        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
 
         let loc = EventLocation::Message(None, key.clone());
         self.keys.insert(event_id, loc);
@@ -1200,7 +1203,7 @@ impl RoomInfo {
 
     fn insert_thread(&mut self, msg: RoomMessageEvent, thread_root: OwnedEventId) {
         let event_id = msg.event_id().to_owned();
-        let key = (msg.origin_server_ts().into(), event_id.clone());
+        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
 
         let replies = self
             .threads
@@ -1292,11 +1295,11 @@ impl RoomInfo {
     }
 
     pub fn fully_read(&mut self, user_id: &UserId) {
-        let Some(((_, event_id), _)) = self.messages.last_key_value() else {
+        let Some((key, _)) = self.messages.last_key_value() else {
             return;
         };
 
-        self.set_receipt(ReceiptThread::Main, user_id.to_owned(), event_id.clone());
+        self.set_receipt(ReceiptThread::Main, user_id.to_owned(), key.event_id().to_owned());
 
         let newest = self
             .threads
@@ -1306,7 +1309,7 @@ impl RoomInfo {
 
                 messages
                     .last_key_value()
-                    .map(|((_, event_id), _)| (thread, event_id.to_owned()))
+                    .map(|(key, _)| (thread, key.event_id().to_owned()))
             })
             .collect::<Vec<_>>();
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -731,6 +731,10 @@ pub enum IambError {
     #[error("Matrix client error: {0}")]
     Matrix(#[from] matrix_sdk::Error),
 
+    /// A failure from the Timeline.
+    #[error("Room timeline error: {0}")]
+    Timeline(#[from] matrix_sdk_ui::timeline::Error),
+
     /// A failure in the sled storage.
     #[error("Matrix client storage error: {0}")]
     Store(#[from] matrix_sdk::StoreError),

--- a/src/base.rs
+++ b/src/base.rs
@@ -827,6 +827,8 @@ impl UnreadInfo {
     }
 }
 
+type UserWithName = (OwnedUserId, Option<String>);
+
 /// Information about room's the user's joined.
 pub struct RoomInfo {
     /// The tags placed on this room.
@@ -839,10 +841,7 @@ pub struct RoomInfo {
     threads: HashMap<OwnedEventId, Messages>,
 
     /// Users currently typing in this room, and when we received notification of them doing so.
-    pub users_typing: Option<(Instant, Vec<OwnedUserId>)>,
-
-    /// The display names for users in this room.
-    pub display_names: HashMap<OwnedUserId, String>,
+    pub users_typing: Option<(Instant, Vec<UserWithName>)>,
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
@@ -867,7 +866,6 @@ impl RoomInfo {
             tags: Default::default(),
             threads: Default::default(),
             users_typing: Default::default(),
-            display_names: Default::default(),
             draw_last: Default::default(),
         })
     }
@@ -977,7 +975,7 @@ impl RoomInfo {
         todo!()
     }
 
-    fn get_typers(&self) -> &[OwnedUserId] {
+    fn get_typers(&self) -> &[UserWithName] {
         if let Some((t, users)) = &self.users_typing {
             if t.elapsed() < Duration::from_secs(4) {
                 return users.as_ref();
@@ -996,13 +994,20 @@ impl RoomInfo {
         match n {
             0 => Line::from(vec![]),
             1 => {
-                let user = settings.get_user_span(typers[0].as_ref(), self);
+                let user_id = &typers[0].0;
+                let display_name = typers[0].1.as_deref();
+                let user = settings.get_user_span(user_id, display_name);
 
                 Line::from(vec![user, Span::from(" is typing...")])
             },
             2 => {
-                let user1 = settings.get_user_span(typers[0].as_ref(), self);
-                let user2 = settings.get_user_span(typers[1].as_ref(), self);
+                let user_id = &typers[0].0;
+                let display_name = typers[0].1.as_deref();
+                let user1 = settings.get_user_span(user_id, display_name);
+
+                let user_id = &typers[1].0;
+                let display_name = typers[1].1.as_deref();
+                let user2 = settings.get_user_span(user_id, display_name);
 
                 Line::from(vec![
                     user1,
@@ -1016,9 +1021,9 @@ impl RoomInfo {
         }
     }
 
-    /// Update typing information for this room.
-    pub fn set_typing(&mut self, user_ids: Vec<OwnedUserId>) {
-        self.users_typing = (Instant::now(), user_ids).into();
+    /// Update typing information for this room including the user display name.
+    pub fn set_typing(&mut self, users: Vec<UserWithName>) {
+        self.users_typing = (Instant::now(), users).into();
     }
 
     /// Create a [Rect] that displays what users are typing.
@@ -1135,7 +1140,6 @@ impl Rooms {
                 tags: Default::default(),
                 threads: Default::default(),
                 users_typing: Default::default(),
-                display_names: Default::default(),
                 draw_last: Default::default(),
                 htmls: Default::default(),
             });
@@ -1771,20 +1775,20 @@ pub mod tests {
         let settings = mock_settings();
 
         let users0 = vec![];
-        let users1 = vec![TEST_USER1.clone()];
-        let users2 = vec![TEST_USER1.clone(), TEST_USER2.clone()];
+        let users1 = vec![(TEST_USER1.clone(), None)];
+        let users2 = vec![(TEST_USER1.clone(), None), (TEST_USER2.clone(), None)];
         let users4 = vec![
-            TEST_USER1.clone(),
-            TEST_USER2.clone(),
-            TEST_USER3.clone(),
-            TEST_USER4.clone(),
+            (TEST_USER1.clone(), None),
+            (TEST_USER2.clone(), None),
+            (TEST_USER3.clone(), None),
+            (TEST_USER4.clone(), None),
         ];
         let users5 = vec![
-            TEST_USER1.clone(),
-            TEST_USER2.clone(),
-            TEST_USER3.clone(),
-            TEST_USER4.clone(),
-            TEST_USER5.clone(),
+            (TEST_USER1.clone(), None),
+            (TEST_USER2.clone(), None),
+            (TEST_USER3.clone(), None),
+            (TEST_USER4.clone(), None),
+            (TEST_USER5.clone(), None),
         ];
 
         // Nothing set.
@@ -1831,7 +1835,7 @@ pub mod tests {
         assert_eq!(info.get_typing_spans(&settings), Line::from("Many people are typing..."));
 
         // Test that USER5 gets rendered using the configured color and name.
-        info.set_typing(vec![TEST_USER5.clone()]);
+        info.set_typing(vec![(TEST_USER5.clone(), Some("USER 5".into()))]);
         assert!(info.users_typing.is_some());
         assert_eq!(
             info.get_typing_spans(&settings),

--- a/src/base.rs
+++ b/src/base.rs
@@ -930,29 +930,6 @@ pub struct RoomInfo {
     pub htmls: HashMap<TimelineEventItemId, StyleTree>,
 }
 
-impl Default for RoomInfo {
-    fn default() -> Self {
-        Self {
-            messages: Messages::main(),
-
-            name: Default::default(),
-            tags: Default::default(),
-            keys: Default::default(),
-            event_receipts: Default::default(),
-            user_receipts: Default::default(),
-            reactions: Default::default(),
-            threads: Default::default(),
-            fetching: Default::default(),
-            fetch_id: Default::default(),
-            fetch_last: Default::default(),
-            users_typing: Default::default(),
-            display_names: Default::default(),
-            draw_last: Default::default(),
-            htmls: Default::default(),
-        }
-    }
-}
-
 impl RoomInfo {
     pub fn get_thread(&self, root: Option<&EventId>) -> Option<&Messages> {
         if let Some(thread_root) = root {
@@ -1391,6 +1368,44 @@ impl IntoIterator for RoomNeeds {
     }
 }
 
+#[derive(Default)]
+pub struct Rooms(CompletionMap<OwnedRoomId, RoomInfo>);
+
+impl Rooms {
+    /// Get the [RoomInfo] for a given room identifier.
+    pub fn get_or_default(&mut self, room_id: OwnedRoomId) -> &mut RoomInfo {
+        if self.0.get(&room_id).is_none() {
+            self.0.insert(room_id.clone(), RoomInfo {
+                messages: Messages::main(),
+
+                name: Default::default(),
+                tags: Default::default(),
+                keys: Default::default(),
+                event_receipts: Default::default(),
+                user_receipts: Default::default(),
+                reactions: Default::default(),
+                threads: Default::default(),
+                fetching: Default::default(),
+                fetch_id: Default::default(),
+                fetch_last: Default::default(),
+                users_typing: Default::default(),
+                display_names: Default::default(),
+                draw_last: Default::default(),
+                htmls: Default::default(),
+            });
+        }
+        self.0.get_mut(&room_id).expect("default value should have been inserted")
+    }
+
+    pub fn get(&self, room_id: &RoomId) -> Option<&RoomInfo> {
+        self.0.get(room_id)
+    }
+
+    pub fn complete(&self, prefix: &str) -> Vec<OwnedRoomId> {
+        self.0.complete(prefix)
+    }
+}
+
 /// The main application state.
 pub struct ChatStore {
     /// `:`-commands
@@ -1400,7 +1415,7 @@ pub struct ChatStore {
     pub worker: Requester,
 
     /// Map of joined rooms.
-    pub rooms: CompletionMap<OwnedRoomId, RoomInfo>,
+    pub rooms: Rooms,
 
     /// Map of room names.
     pub names: CompletionMap<String, OwnedRoomId>,
@@ -1486,16 +1501,6 @@ impl ChatStore {
             .and_then(|i| i.name.as_ref())
             .map(String::from)
             .unwrap_or_else(|| "Untitled Matrix Room".to_string())
-    }
-
-    /// Get the [RoomInfo] for a given room identifier.
-    pub fn get_room_info(&mut self, room_id: OwnedRoomId) -> &mut RoomInfo {
-        self.rooms.get_or_default(room_id)
-    }
-
-    /// Set the name for a room.
-    pub fn set_room_name(&mut self, room_id: &RoomId, name: &str) {
-        self.rooms.get_or_default(room_id.to_owned()).name = name.to_string().into();
     }
 
     /// Insert a new E2EE verification.
@@ -1993,6 +1998,7 @@ fn complete_cmdbar(text: &EditRope, cursor: &mut Cursor, store: &ChatStore) -> V
 }
 
 #[cfg(test)]
+#[allow(unused)]
 pub mod tests {
     use super::*;
     use crate::config::user_style_from_color;
@@ -2009,7 +2015,8 @@ pub mod tests {
 
     #[test]
     fn multiple_identical_reactions() {
-        let mut info = RoomInfo::default();
+        // let mut info = RoomInfo::default();
+        let mut info: RoomInfo = todo!();
 
         let content = ReactionEventContent::new(Annotation::new(
             owned_event_id!("$my_reaction"),
@@ -2071,7 +2078,8 @@ pub mod tests {
 
     #[test]
     fn test_typing_spans() {
-        let mut info = RoomInfo::default();
+        // let mut info = RoomInfo::default();
+        let mut info: RoomInfo = todo!();
         let settings = mock_settings();
 
         let users0 = vec![];

--- a/src/base.rs
+++ b/src/base.rs
@@ -852,6 +852,11 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
+    #[inline]
+    pub fn room(&self) -> &MatrixRoom {
+        self.messages.timeline().room()
+    }
+
     pub fn get_thread(&self, root: Option<&EventId>) -> Option<&Messages> {
         if let Some(thread_root) = root {
             self.threads.get(thread_root)
@@ -1050,27 +1055,13 @@ fn picker_from_settings(settings: &ApplicationSettings) -> Option<Picker> {
 #[derive(Default)]
 pub struct SyncInfo {
     /// Spaces that the user is a member of.
-    pub spaces: Vec<Arc<(MatrixRoom, Option<Tags>)>>,
+    pub spaces: Vec<OwnedRoomId>,
 
     /// Rooms that the user is a member of.
-    pub rooms: Vec<Arc<(MatrixRoom, Option<Tags>)>>,
+    pub rooms: Vec<OwnedRoomId>,
 
     /// DMs that the user is a member of.
-    pub dms: Vec<Arc<(MatrixRoom, Option<Tags>)>>,
-}
-
-impl SyncInfo {
-    pub fn rooms(&self) -> impl Iterator<Item = &RoomId> {
-        self.rooms.iter().map(|r| r.0.room_id())
-    }
-
-    pub fn dms(&self) -> impl Iterator<Item = &RoomId> {
-        self.dms.iter().map(|r| r.0.room_id())
-    }
-
-    pub fn chats(&self) -> impl Iterator<Item = &RoomId> {
-        self.rooms().chain(self.dms())
-    }
+    pub dms: Vec<OwnedRoomId>,
 }
 
 #[derive(Default)]

--- a/src/base.rs
+++ b/src/base.rs
@@ -957,16 +957,6 @@ impl RoomInfo {
         }
     }
 
-    pub fn get_thread_mut(&mut self, root: Option<OwnedEventId>) -> &mut Messages {
-        if let Some(thread_root) = root {
-            self.threads
-                .entry(thread_root.clone())
-                .or_insert_with(|| Messages::thread(thread_root))
-        } else {
-            &mut self.messages
-        }
-    }
-
     /// Get the reactions and their counts for a message.
     pub fn get_reactions(&self, event_id: &EventId) -> Vec<(&str, usize)> {
         if let Some(reacts) = self.reactions.get(event_id) {
@@ -998,12 +988,7 @@ impl RoomInfo {
 
     /// Get an event for an identifier.
     pub fn get_event(&self, event_id: &EventId) -> Option<&Message> {
-        self.messages.get(self.get_message_key(event_id)?)
-    }
-
-    /// Get an event for an identifier as mutable.
-    pub fn get_event_mut(&mut self, event_id: &EventId) -> Option<&mut Message> {
-        self.messages.get_mut(self.keys.get(event_id)?.to_message_key()?)
+        self.messages.get_message(self.get_message_key(event_id)?)
     }
 
     pub fn redact(&mut self, ev: OriginalSyncRoomRedactionEvent, rules: &RedactionRules) {
@@ -1038,70 +1023,31 @@ impl RoomInfo {
     }
 
     /// Indicates whether this room has unread messages.
-    pub fn unreads(&self, settings: &ApplicationSettings) -> UnreadInfo {
-        let last_message = self.messages.last_key_value();
-
-        let last_receipt = self
-            .user_receipts
-            .get(&ReceiptThread::Main)
-            .and_then(|receipts| receipts.get(&settings.profile.user_id));
-        let last_receipt = last_receipt.as_ref().and_then(|event_id| {
-            match &self.keys.get(*event_id)? {
-                EventLocation::Message(_, key) | EventLocation::State(key) => Some(key),
-                EventLocation::Reaction(_) => None,
-            }
-        });
-
-        let last_unthreaded = self
-            .user_receipts
-            .get(&ReceiptThread::Unthreaded)
-            .and_then(|receipts| receipts.get(&settings.profile.user_id));
-        let last_unthreaded = last_unthreaded.as_ref().and_then(|event_id| {
-            match &self.keys.get(*event_id)? {
-                EventLocation::Message(_, key) | EventLocation::State(key) => Some(key),
-                EventLocation::Reaction(_) => None,
-            }
-        });
-
-        let last_receipt = std::cmp::max(last_receipt, last_unthreaded);
-
-        match (last_message, last_receipt) {
-            (Some((key, _)), Some(read_key)) => {
-                UnreadInfo {
-                    unread: key.ts() > read_key.ts(),
-                    latest: Some(*key.ts()),
-                }
-            },
-            (Some((key, _)), None) => {
-                // If we've never loaded/generated a room's receipt (example,
-                // a newly joined but never viewed room), show it as unread.
-                UnreadInfo { unread: true, latest: Some(*key.ts()) }
-            },
-            (None, _) => UnreadInfo::default(),
-        }
+    pub fn unreads(&self, _settings: &ApplicationSettings) -> UnreadInfo {
+        todo!()
     }
 
     /// Insert a new message.
-    pub fn insert_message(&mut self, msg: RoomMessageEvent) {
-        let event_id = msg.event_id().to_owned();
-        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
-
-        let loc = EventLocation::Message(None, key.clone());
-        self.keys.insert(event_id, loc);
+    pub fn insert_message(&mut self, _msg: RoomMessageEvent) {
+        // let event_id = msg.event_id().to_owned();
+        // let key = todo!();
+        //
+        // let loc = EventLocation::Message(None, key.clone());
+        // self.keys.insert(event_id, loc);
         // self.messages.insert_message(key, msg);
         todo!()
     }
 
-    fn insert_thread(&mut self, msg: RoomMessageEvent, thread_root: OwnedEventId) {
-        let event_id = msg.event_id().to_owned();
-        let key = MessageKey::new(msg.origin_server_ts().into(), event_id.clone());
-
+    fn insert_thread(&mut self, _msg: RoomMessageEvent, _thread_root: OwnedEventId) {
+        // let event_id = msg.event_id().to_owned();
+        // let key = todo!();
+        //
         // let replies = self
         //     .threads
         //     .entry(thread_root.clone())
         //     .or_insert_with(|| Messages::thread(thread_root.clone()));
-        let loc = EventLocation::Message(Some(thread_root), key.clone());
-        self.keys.insert(event_id, loc);
+        // let loc = EventLocation::Message(Some(thread_root), key.clone());
+        // self.keys.insert(event_id, loc);
         // replies.insert_message(key, msg);
         todo!()
     }
@@ -1139,11 +1085,8 @@ impl RoomInfo {
         let source = source_from_event(&ev);
         self.insert(ev);
 
-        if let Some((event_id, source)) = source {
-            if let (Some(_msg), Some(image_preview)) =
-                (self.get_event_mut(&event_id), &settings.tunables.image_preview)
-            {
-                // msg.insert_image_preview(source.clone());
+        if let Some((_, source)) = source {
+            if let Some(image_preview) = &settings.tunables.image_preview {
                 previews.register_preview(settings, source, image_preview.size, worker)
             }
         }
@@ -1187,28 +1130,29 @@ impl RoomInfo {
         self.user_receipts.entry(thread).or_default().insert(user_id, event_id);
     }
 
-    pub fn fully_read(&mut self, user_id: &UserId) {
-        let Some((key, _)) = self.messages.last_key_value() else {
-            return;
-        };
-
-        self.set_receipt(ReceiptThread::Main, user_id.to_owned(), key.event_id().to_owned());
-
-        let newest = self
-            .threads
-            .iter()
-            .filter_map(|(thread_id, messages)| {
-                let thread = ReceiptThread::Thread(thread_id.to_owned());
-
-                messages
-                    .last_key_value()
-                    .map(|(key, _)| (thread, key.event_id().to_owned()))
-            })
-            .collect::<Vec<_>>();
-
-        for (thread, event_id) in newest.into_iter() {
-            self.set_receipt(thread, user_id.to_owned(), event_id.clone());
-        }
+    pub fn fully_read(&mut self, _user_id: &UserId) {
+        // let Some((key, _)) = self.messages.last_key_value() else {
+        //     return;
+        // };
+        //
+        // self.set_receipt(ReceiptThread::Main, user_id.to_owned(), key.id().to_owned());
+        //
+        // let newest = self
+        //     .threads
+        //     .iter()
+        //     .filter_map(|(thread_id, messages)| {
+        //         let thread = ReceiptThread::Thread(thread_id.to_owned());
+        //
+        //         messages
+        //             .last_key_value()
+        //             .map(|(key, _)| (thread, key.id().to_owned()))
+        //     })
+        //     .collect::<Vec<_>>();
+        //
+        // for (thread, event_id) in newest.into_iter() {
+        //     self.set_receipt(thread, user_id.to_owned(), event_id.clone());
+        // }
+        todo!()
     }
 
     pub fn receipts<'a>(

--- a/src/base.rs
+++ b/src/base.rs
@@ -98,9 +98,6 @@ fn is_mxid_char(c: char) -> bool {
         ":-./@_#!".contains(c);
 }
 
-#[allow(unused)]
-const ROOM_FETCH_DEBOUNCE: Duration = Duration::from_secs(2);
-
 /// Empty type used solely to implement [ApplicationInfo].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IambInfo {}
@@ -869,6 +866,19 @@ impl RoomInfo {
             users_typing: Default::default(),
             draw_last: Default::default(),
         })
+    }
+
+    #[cfg(test)]
+    pub fn mock_new() -> Self {
+        Self {
+            messages: Messages::mock_new(),
+
+            htmls: Default::default(),
+            tags: Default::default(),
+            threads: Default::default(),
+            users_typing: Default::default(),
+            draw_last: Default::default(),
+        }
     }
 
     /// Create the thread if it didn't already exists.
@@ -1689,8 +1699,7 @@ pub mod tests {
 
     #[test]
     fn test_typing_spans() {
-        // let mut info = RoomInfo::default();
-        let mut info: RoomInfo = todo!();
+        let mut info = RoomInfo::mock_new();
         let settings = mock_settings();
 
         let users0 = vec![];

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -105,6 +105,17 @@ fn iamb_invite(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     return Ok(step);
 }
 
+fn iamb_invites(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    if !desc.arg.text.is_empty() {
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    let open = ctx.switch(OpenTarget::Application(IambId::InviteList));
+    let step = CommandStep::Continue(open, ctx.context.clone());
+
+    Ok(step)
+}
+
 fn iamb_keys(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     let mut args = desc.arg.strings()?;
 
@@ -745,6 +756,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "invite".into(),
         aliases: vec![],
         f: iamb_invite,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "invites".into(),
+        aliases: vec![],
+        f: iamb_invites,
     });
     cmds.add_command(ProgramCommand { name: "join".into(), aliases: vec![], f: iamb_join });
     cmds.add_command(ProgramCommand { name: "keys".into(), aliases: vec![], f: iamb_keys });

--- a/src/config.rs
+++ b/src/config.rs
@@ -489,12 +489,14 @@ pub struct Notifications {
 
 #[derive(Clone)]
 pub struct ImagePreviewValues {
+    pub lazy_load: bool,
     pub size: ImagePreviewSize,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
 #[derive(Clone, Default, Deserialize)]
 pub struct ImagePreview {
+    pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
@@ -502,13 +504,14 @@ pub struct ImagePreview {
 impl ImagePreview {
     fn values(self) -> ImagePreviewValues {
         ImagePreviewValues {
+            lazy_load: self.lazy_load.unwrap_or(true),
             size: self.size.unwrap_or_default(),
             protocol: self.protocol,
         }
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct ImagePreviewSize {
     pub width: usize,
     pub height: usize,
@@ -683,19 +686,17 @@ pub struct DirectoryValues {
     pub data: PathBuf,
     pub logs: PathBuf,
     pub downloads: Option<PathBuf>,
-    pub image_previews: PathBuf,
 }
 
 impl DirectoryValues {
     fn create_dir_all(&self) -> std::io::Result<()> {
         use std::fs::create_dir_all;
 
-        let Self { cache, data, logs, downloads, image_previews } = self;
+        let Self { cache, data, logs, downloads } = self;
 
         create_dir_all(cache)?;
         create_dir_all(data)?;
         create_dir_all(logs)?;
-        create_dir_all(image_previews)?;
 
         if let Some(downloads) = downloads {
             create_dir_all(downloads)?;
@@ -711,7 +712,6 @@ pub struct Directories {
     pub data: Option<String>,
     pub logs: Option<String>,
     pub downloads: Option<String>,
-    pub image_previews: Option<String>,
 }
 
 impl Directories {
@@ -721,7 +721,6 @@ impl Directories {
             data: self.data.or(other.data),
             logs: self.logs.or(other.logs),
             downloads: self.downloads.or(other.downloads),
-            image_previews: self.image_previews.or(other.image_previews),
         }
     }
 
@@ -776,20 +775,7 @@ impl Directories {
             })
             .or_else(dirs::download_dir);
 
-        let image_previews = self
-            .image_previews
-            .map(|dir| {
-                let dir = shellexpand::full(&dir)
-                    .expect("unable to expand shell variables in dirs.cache");
-                Path::new(dir.as_ref()).to_owned()
-            })
-            .unwrap_or_else(|| {
-                let mut dir = cache.clone();
-                dir.push("image_preview_downloads");
-                dir
-            });
-
-        DirectoryValues { cache, data, logs, downloads, image_previews }
+        DirectoryValues { cache, data, logs, downloads }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use std::process;
 use clap::Parser;
 use matrix_sdk::authentication::matrix::MatrixSession;
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
+use matrix_sdk_ui::timeline::TimelineItemContent;
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
 use ratatui::text::Span;
 use ratatui_image::picker::ProtocolType;
@@ -21,6 +22,8 @@ use tracing::Level;
 use url::Url;
 
 use modalkit::{env::vim::VimMode, key::TerminalKey, keybindings::InputKey};
+
+use crate::message::{Message, MessageItem, MessageKey};
 
 use super::base::{IambError, IambId, SortColumn, SortFieldRoom, SortFieldUser, SortOrder};
 
@@ -1080,6 +1083,27 @@ impl ApplicationSettings {
         };
 
         Span::styled(name, style)
+    }
+
+    pub fn filter_hidden_item(&self) -> impl Fn(&&Message) -> bool {
+        let show_state = self.tunables.state_event_display;
+
+        move |item| {
+            show_state ||
+                !matches!(
+                    item.content(),
+                    TimelineItemContent::MembershipChange(_) |
+                        TimelineItemContent::ProfileChange(_) |
+                        TimelineItemContent::OtherState(_) |
+                        TimelineItemContent::FailedToParseState { .. }
+                )
+        }
+    }
+
+    pub fn filter_hidden(&self) -> impl Fn(&(MessageKey, &MessageItem)) -> bool {
+        let filter = self.filter_hidden_item();
+
+        move |(_, item)| item.as_event().is_none_or(|item| filter(&item))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,6 +353,7 @@ fn merge_sorts(profile: SortOverrides, global: SortOverrides) -> SortOverrides {
         rooms: profile.rooms.or(global.rooms),
         spaces: profile.spaces.or(global.spaces),
         members: profile.members.or(global.members),
+        invites: profile.invites.or(global.invites),
     }
 }
 
@@ -527,6 +528,7 @@ pub struct SortValues {
     pub dms: Vec<SortColumn<SortFieldRoom>>,
     pub rooms: Vec<SortColumn<SortFieldRoom>>,
     pub spaces: Vec<SortColumn<SortFieldRoom>>,
+    pub invites: Vec<SortColumn<SortFieldRoom>>,
     pub members: Vec<SortColumn<SortFieldUser>>,
 }
 
@@ -536,6 +538,7 @@ pub struct SortOverrides {
     pub dms: Option<Vec<SortColumn<SortFieldRoom>>>,
     pub rooms: Option<Vec<SortColumn<SortFieldRoom>>>,
     pub spaces: Option<Vec<SortColumn<SortFieldRoom>>>,
+    pub invites: Option<Vec<SortColumn<SortFieldRoom>>>,
     pub members: Option<Vec<SortColumn<SortFieldUser>>>,
 }
 
@@ -545,9 +548,10 @@ impl SortOverrides {
         let chats = self.chats.unwrap_or_else(|| rooms.clone());
         let dms = self.dms.unwrap_or_else(|| rooms.clone());
         let spaces = self.spaces.unwrap_or_else(|| rooms.clone());
+        let invites = self.invites.unwrap_or_else(|| rooms.clone());
         let members = self.members.unwrap_or_else(|| Vec::from(DEFAULT_MEMBERS_SORT));
 
-        SortValues { rooms, members, chats, dms, spaces }
+        SortValues { rooms, members, chats, dms, spaces, invites }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,15 +22,7 @@ use url::Url;
 
 use modalkit::{env::vim::VimMode, key::TerminalKey, keybindings::InputKey};
 
-use super::base::{
-    IambError,
-    IambId,
-    RoomInfo,
-    SortColumn,
-    SortFieldRoom,
-    SortFieldUser,
-    SortOrder,
-};
+use super::base::{IambError, IambId, SortColumn, SortFieldRoom, SortFieldUser, SortOrder};
 
 type Macros = HashMap<VimModes, HashMap<Keys, Keys>>;
 
@@ -1061,7 +1053,11 @@ impl ApplicationSettings {
         user_style_from_color(self.get_user_color(user_id))
     }
 
-    pub fn get_user_span<'a>(&self, user_id: &'a UserId, info: &'a RoomInfo) -> Span<'a> {
+    pub fn get_user_span<'a>(
+        &self,
+        user_id: &'a UserId,
+        display_name: Option<&'a str>,
+    ) -> Span<'a> {
         let (color, name) = self.get_user_overrides(user_id);
 
         let color = color.unwrap_or_else(|| user_color(user_id.as_str()));
@@ -1071,8 +1067,8 @@ impl ApplicationSettings {
             (None, UserDisplayStyle::Username) => Cow::Borrowed(user_id.as_str()),
             (None, UserDisplayStyle::LocalPart) => Cow::Borrowed(user_id.localpart()),
             (None, UserDisplayStyle::DisplayName) => {
-                if let Some(display) = info.display_names.get(user_id) {
-                    Cow::Borrowed(display.as_str())
+                if let Some(display) = display_name {
+                    Cow::Borrowed(display)
                 } else {
                     Cow::Borrowed(user_id.as_str())
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -564,12 +564,6 @@ impl Application {
                 // Clear any notifications we displayed:
                 store.application.open_notifications.clear();
 
-                let receipt = if store.application.settings.tunables.read_receipt_send {
-                    ReceiptType::Read
-                } else {
-                    ReceiptType::ReadPrivate
-                };
-
                 let store = Weak::upgrade(&store.application.worker.store).unwrap();
                 tokio::spawn(async move {
                     let locked = store.lock().await;
@@ -579,7 +573,7 @@ impl Application {
                             .get_thread(None)
                             .unwrap()
                             .timeline()
-                            .mark_as_read(receipt.clone())
+                            .mark_as_read(ReceiptType::ReadPrivate)
                             .await;
                     }
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,9 +565,11 @@ impl Application {
                 store.application.open_notifications.clear();
 
                 for room_id in store.application.sync_info.chats() {
-                    if let Some(room) = store.application.rooms.get_mut(room_id) {
-                        room.fully_read(user_id);
-                    }
+                    store
+                        .application
+                        .rooms
+                        .get_or_default(room_id.to_owned())
+                        .fully_read(user_id);
                 }
 
                 None

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@
 #![allow(clippy::needless_return)]
 #![allow(clippy::result_large_err)]
 #![allow(clippy::bool_assert_comparison)]
+#![cfg_attr(test, allow(unused_imports, dead_code))]
+
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::fmt::Display;

--- a/src/main.rs
+++ b/src/main.rs
@@ -559,18 +559,16 @@ impl Application {
 
         let info = match action {
             IambAction::ClearUnreads => {
-                let user_id = &store.application.settings.profile.user_id;
-
                 // Clear any notifications we displayed:
                 store.application.open_notifications.clear();
 
-                for room_id in store.application.sync_info.chats() {
-                    store
-                        .application
-                        .rooms
+                let ChatStore { sync_info, rooms, settings, .. } = &mut store.application;
+
+                sync_info.rooms.iter().chain(sync_info.dms.iter()).for_each(|room_id| {
+                    rooms
                         .get_or_default(room_id.to_owned())
-                        .fully_read(user_id);
-                }
+                        .fully_read(&settings.profile.user_id);
+                });
 
                 None
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -568,13 +568,16 @@ impl Application {
                 tokio::spawn(async move {
                     let locked = store.lock().await;
 
-                    for (_, info) in locked.application.rooms.iter() {
-                        let _ = info
+                    for (room_id, info) in locked.application.rooms.iter() {
+                        if let Err(err) = info
                             .get_thread(None)
                             .unwrap()
                             .timeline()
                             .mark_as_read(ReceiptType::ReadPrivate)
-                            .await;
+                            .await
+                        {
+                            tracing::warn!(?room_id, "cannot mark room as read: {err}");
+                        };
                     }
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 //!
 //! Most rendering logic lives under the [windows] module, but [Matrix messages][message] have
 //! their own module.
+#![recursion_limit = "256"]
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::result_large_err)]
@@ -27,10 +28,10 @@ use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use matrix_sdk::crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
 use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;
 use matrix_sdk::ruma::OwnedUserId;
+use matrix_sdk_crypto::encrypt_room_key_export;
 use modalkit::keybindings::InputBindings;
 use rand::{distributions::Alphanumeric, Rng};
 use temp_dir::TempDir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,13 @@ use std::io::{stdout, BufWriter, Stdout, Write};
 use std::ops::DerefMut;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
 use matrix_sdk::crypto::encrypt_room_key_export;
 use matrix_sdk::ruma::api::client::error::ErrorKind;
+use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;
 use matrix_sdk::ruma::OwnedUserId;
 use modalkit::keybindings::InputBindings;
 use rand::{distributions::Alphanumeric, Rng};
@@ -562,12 +563,24 @@ impl Application {
                 // Clear any notifications we displayed:
                 store.application.open_notifications.clear();
 
-                let ChatStore { sync_info, rooms, settings, .. } = &mut store.application;
+                let receipt = if store.application.settings.tunables.read_receipt_send {
+                    ReceiptType::Read
+                } else {
+                    ReceiptType::ReadPrivate
+                };
 
-                sync_info.rooms.iter().chain(sync_info.dms.iter()).for_each(|room_id| {
-                    rooms
-                        .get_or_default(room_id.to_owned())
-                        .fully_read(&settings.profile.user_id);
+                let store = Weak::upgrade(&store.application.worker.store).unwrap();
+                tokio::spawn(async move {
+                    let locked = store.lock().await;
+
+                    for (_, info) in locked.application.rooms.iter() {
+                        let _ = info
+                            .get_thread(None)
+                            .unwrap()
+                            .timeline()
+                            .mark_as_read(receipt.clone())
+                            .await;
+                    }
                 });
 
                 None

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,14 +155,14 @@ fn config_tab_to_desc(
             let window = match window {
                 config::WindowPath::UserId(user_id) => {
                     let name = user_id.to_string();
-                    let room_id = worker.join_room(name.clone())?;
+                    let room_id = worker.join_room(name.clone())?.room_id().to_owned();
                     names.insert(name, room_id.clone());
                     IambId::Room(room_id, None)
                 },
                 config::WindowPath::RoomId(room_id) => IambId::Room(room_id, None),
                 config::WindowPath::AliasId(alias) => {
                     let name = alias.to_string();
-                    let room_id = worker.join_room(name.clone())?;
+                    let room_id = worker.join_room(name.clone())?.room_id().to_owned();
                     names.insert(name, room_id.clone());
                     IambId::Room(room_id, None)
                 },
@@ -654,7 +654,11 @@ impl Application {
         match action {
             HomeserverAction::CreateRoom(alias, vis, flags) => {
                 let client = &store.application.worker.client;
-                let room_id = create_room(client, alias, vis, flags).await?;
+                let room = create_room(client, alias, vis, flags).await?;
+                let room_id = room.room_id().to_owned();
+
+                store.application.join_room(room_id.to_string())?;
+
                 let room = IambId::Room(room_id, None);
                 let target = OpenTarget::Application(room);
                 let action = WindowAction::Switch(target);

--- a/src/message/compose.rs
+++ b/src/message/compose.rs
@@ -11,7 +11,7 @@ use nom::{
 use matrix_sdk::ruma::events::room::message::{
     EmoteMessageEventContent,
     MessageType,
-    RoomMessageEventContent,
+    RoomMessageEventContentWithoutRelation,
     TextMessageEventContent,
 };
 
@@ -170,12 +170,12 @@ fn text_to_message_content(input: String) -> TextMessageEventContent {
     }
 }
 
-pub fn text_to_message(input: String) -> RoomMessageEventContent {
+pub fn text_to_message(input: String) -> RoomMessageEventContentWithoutRelation {
     let msg = parse_slash_command(input.as_str())
         .and_then(|(input, slash)| slash.to_message(input))
         .unwrap_or_else(|_| MessageType::Text(text_to_message_content(input)));
 
-    RoomMessageEventContent::new(msg)
+    RoomMessageEventContentWithoutRelation::new(msg)
 }
 
 #[cfg(test)]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
+use image::DynamicImage;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -844,6 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
+    Loading(Option<DynamicImage>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }
@@ -1085,6 +1087,9 @@ impl Message {
                 ImageStatus::None => None,
                 ImageStatus::Downloading(image_preview_size) => {
                     placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                ImageStatus::Loading(_, image_preview_size) => {
+                    placeholder_frame(Some("Loading..."), width, image_preview_size)
                 },
                 ImageStatus::Loaded(backend) => {
                     proto = Some(backend);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
-use image::DynamicImage;
+use image::ImageReader;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use serde_json::json;
@@ -845,7 +845,7 @@ impl<'a> MessageFormatter<'a> {
 pub enum ImageStatus {
     None,
     Downloading(ImagePreviewSize),
-    Loading(Option<DynamicImage>, ImagePreviewSize),
+    Loading(Option<ImageReader<std::io::Cursor<Vec<u8>>>>, ImagePreviewSize),
     Loaded(Protocol),
     Error(String),
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -344,10 +344,23 @@ impl Messages {
             .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)))
             .collect();
 
+        let start_element = messages
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, item)| {
+                if item.as_event().is_some() {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
         let messages = Self {
             messages,
             timeline: timeline.into(),
-            start_element: 0,
+            start_element,
             thread,
             fetching: false,
         };

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
@@ -15,6 +16,8 @@ use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use matrix_sdk::ruma::UserId;
+use matrix_sdk_ui::timeline::TimelineItem;
+use matrix_sdk_ui::Timeline;
 use serde_json::json;
 use unicode_width::UnicodeWidthStr;
 
@@ -99,6 +102,7 @@ impl MessageKey {
 }
 
 pub struct Messages {
+    timeline: Timeline,
     messages: BTreeMap<MessageKey, Message>,
     thread: ReceiptThread,
 }
@@ -141,8 +145,10 @@ impl Messages {
         self.messages.range(range)
     }
 
+    #[allow(unused)]
     pub fn new(thread: ReceiptThread) -> Self {
-        Self { messages: Default::default(), thread }
+        let timeline = todo!();
+        Self { messages: Default::default(), thread, timeline }
     }
 
     pub fn main() -> Self {
@@ -777,7 +783,11 @@ impl<'a> MessageFormatter<'a> {
         previews: &'a PreviewManager,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
-            style.patch(settings.get_user_color(&msg.sender))
+            if let Some(user_id) = msg.sender() {
+                style.patch(settings.get_user_color(user_id))
+            } else {
+                style
+            }
         } else {
             style
         };
@@ -886,8 +896,9 @@ impl<'a> MessageFormatter<'a> {
 }
 
 pub struct Message {
+    item: Arc<TimelineItem>,
+
     event: MessageEvent,
-    sender: OwnedUserId,
     timestamp: MessageTimeStamp,
     downloaded: bool,
     html: Option<StyleTree>,
@@ -910,8 +921,8 @@ impl Message {
     pub fn event_mut(&mut self) -> &mut MessageEvent {
         &mut self.event
     }
-    pub fn sender(&self) -> &UserId {
-        &self.sender
+    pub fn sender(&self) -> Option<&UserId> {
+        self.item.as_event().map(|ev| ev.sender())
     }
     pub fn set_downloaded(&mut self) {
         self.downloaded = true;
@@ -923,13 +934,15 @@ impl Message {
         self.image_preview = Some(preview);
     }
 
+    #[allow(unused)]
     pub fn new(event: MessageEvent, sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
         let html = event.html();
         let downloaded = false;
+        let item = todo!();
 
         Message {
+            item,
             event,
-            sender,
             timestamp,
             downloaded,
             html,
@@ -991,8 +1004,10 @@ impl Message {
         }
 
         if settings.tunables.message_user_color {
-            let color = settings.get_user_color(&self.sender);
-            style = style.fg(color);
+            if let Some(user_id) = self.sender() {
+                let color = settings.get_user_color(user_id);
+                style = style.fg(color);
+            }
         }
 
         return style;
@@ -1178,7 +1193,9 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> Span<'a> {
-        settings.get_user_span(self.sender.as_ref(), info)
+        self.sender()
+            .map(|user_id| settings.get_user_span(user_id, info))
+            .unwrap_or_default()
     }
 
     fn show_sender<'a>(
@@ -1189,7 +1206,7 @@ impl Message {
         settings: &'a ApplicationSettings,
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev {
-            if self.sender == prev.sender &&
+            if self.sender() == prev.sender() &&
                 self.timestamp.same_day(&prev.timestamp) &&
                 !self.event.is_emote()
             {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -132,6 +132,9 @@ impl Messages {
     pub fn last_key_value(&self) -> Option<(&MessageKey, &Message)> {
         self.messages.last_key_value()
     }
+    pub fn last(&self) -> Option<&Message> {
+        self.messages.last_key_value().map(|(_, m)| m)
+    }
     pub fn last_mut(&mut self) -> Option<&mut Message> {
         self.messages.last_entry().map(|o| o.into_mut())
     }
@@ -909,6 +912,9 @@ pub struct Message {
 }
 
 impl Message {
+    pub fn item(&self) -> &Arc<TimelineItem> {
+        &self.item
+    }
     pub fn html(&self) -> Option<&StyleTree> {
         self.html.as_ref()
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -84,7 +84,7 @@ pub use html::TreeGenState;
 
 const MIN_MSG_LOAD: u16 = 50;
 
-type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
+pub(crate) type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageKey {
@@ -119,7 +119,7 @@ impl PartialOrd for MessageKey {
 fn handle_update(
     room_id: &RoomId,
     thread: Option<&EventId>,
-    update: VectorDiff<Arc<TimelineItem>>,
+    update: VectorDiff<Arc<MessageItem>>,
     store: &mut ProgramStore,
 ) {
     let ChatStore { rooms, settings, previews, worker, .. } = &mut store.application;
@@ -213,7 +213,7 @@ async fn handle_updates(
     room_id: OwnedRoomId,
     thread: Option<OwnedEventId>,
     store: AsyncProgramStore,
-    stream: impl futures::Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>,
+    stream: impl futures::Stream<Item = Vec<VectorDiff<Arc<MessageItem>>>>,
 ) {
     futures::pin_mut!(stream);
 
@@ -225,13 +225,20 @@ async fn handle_updates(
     }
 }
 
+#[cfg(not(test))]
+pub type MessageItem = TimelineItem;
+
+#[cfg(test)]
+pub type MessageItem = crate::tests::MockMessageItem;
+
 pub struct Messages {
+    #[cfg(not(test))]
     timeline: Arc<Timeline>,
 
     /// The thread root of the timeline
     thread: Option<OwnedEventId>,
 
-    messages: Vector<Arc<TimelineItem>>,
+    messages: Vector<Arc<MessageItem>>,
 
     /// This is the index of the first element in the vector when this object was created. This is
     /// used by [`MessageKey`] as a referenc because the vector can be extended in both directions.
@@ -242,9 +249,11 @@ pub struct Messages {
 }
 
 impl Messages {
+    #[cfg(not(test))]
     pub fn timeline(&self) -> &Arc<Timeline> {
         &self.timeline
     }
+
     pub fn get_message(&self, key: &MessageKey) -> Option<&Message> {
         let index = self.start_element.checked_add_signed(key.offset())?;
         let item = self.messages.get(index)?;
@@ -316,6 +325,7 @@ impl Messages {
 
     /// This must be called while `store` is locked and must be inserted in the store before it is
     /// unlocked.
+    #[cfg(not(test))]
     pub async fn new(
         room: &Room,
         thread: Option<OwnedEventId>,
@@ -388,6 +398,7 @@ impl Messages {
         }
     }
 
+    #[cfg(not(test))]
     pub fn paginate_backwards(&self, store: AsyncProgramStore) {
         let room_id = self.timeline().room().room_id().to_owned();
         let thread = self.thread.clone();
@@ -429,6 +440,37 @@ impl Messages {
     }
 }
 
+#[cfg(test)]
+impl Messages {
+    pub fn mock_new() -> Self {
+        Self {
+            thread: None,
+            messages: Vector::new(),
+            start_element: 0,
+            fetching: false,
+        }
+    }
+
+    pub fn set_messages(&mut self, messages: Vector<Arc<MessageItem>>) {
+        self.messages = messages;
+    }
+
+    pub async fn new(
+        _room: &Room,
+        _thread: Option<OwnedEventId>,
+        _store: AsyncProgramStore,
+    ) -> Result<(Self, HashMap<TimelineEventItemId, StyleTree>), matrix_sdk_ui::timeline::Error>
+    {
+        unimplemented!()
+    }
+    pub fn paginate_backwards(&self, _store: AsyncProgramStore) {
+        unimplemented!()
+    }
+    pub fn timeline(&self) -> &Arc<Timeline> {
+        unimplemented!()
+    }
+}
+
 pub struct MessagesRange<'a> {
     messages: &'a Messages,
     next: usize,
@@ -436,7 +478,7 @@ pub struct MessagesRange<'a> {
 }
 
 impl<'a> Iterator for MessagesRange<'a> {
-    type Item = (MessageKey, &'a TimelineItem);
+    type Item = (MessageKey, &'a MessageItem);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next > self.last {
@@ -1091,9 +1133,13 @@ impl<'a> MessageFormatter<'a> {
     }
 }
 
+#[cfg(not(test))]
 pub type Message = EventTimelineItem;
 
-impl MessageExt for Message {
+#[cfg(test)]
+pub type Message = crate::tests::MockMessage;
+
+impl MessageExt for EventTimelineItem {
     fn content(&self) -> &TimelineItemContent {
         self.content()
     }
@@ -1556,7 +1602,8 @@ pub mod tests {
 
     #[test]
     fn test_mc_to_key() {
-        let messages = mock_messages();
+        let mut messages = Messages::mock_new();
+        messages.set_messages(mock_messages());
         let mc1 = MessageCursor::from(MSG1_KEY.clone());
         let mc2 = MessageCursor::from(MSG2_KEY.clone());
         let mc3 = MessageCursor::from(MSG3_KEY.clone());
@@ -1582,14 +1629,14 @@ pub mod tests {
         assert_eq!(k6, MSG1_KEY.clone());
 
         // MessageCursor::latest() fails to convert for a room w/o messages.
-        // let messages_empty = Messages::new(ReceiptThread::Main);
-        // assert_eq!(mc6.to_key(&messages_empty), None);
-        todo!()
+        let messages_empty = Messages::mock_new();
+        assert_eq!(mc6.to_key(&messages_empty), None);
     }
 
     #[test]
     fn test_mc_to_from_cursor() {
-        let messages = mock_messages();
+        let mut messages = Messages::mock_new();
+        messages.set_messages(mock_messages());
         let mc1 = MessageCursor::from(MSG1_KEY.clone());
         let mc2 = MessageCursor::from(MSG2_KEY.clone());
         let mc3 = MessageCursor::from(MSG3_KEY.clone());

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -64,7 +64,6 @@ use crate::message::html::StyleTreeNode;
 use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
 use crate::util::TimelineDetailsExt;
-use crate::worker::Requester;
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -410,23 +409,33 @@ impl Messages {
             fetching: false,
         };
 
-        messages.paginate_backwards_count(store, 10);
+        messages.paginate_backwards_count(Arc::clone(&store), 10);
+
+        messages.register_image_previews(store);
 
         Ok((messages, htmls))
     }
 
-    /// This should be called closely after [`Self::new`].
-    pub fn register_image_previews(
-        &self,
-        settings: &ApplicationSettings,
-        previews: &mut PreviewManager,
-        worker: &Requester,
-    ) {
-        for (_, item) in self.range_messages(..) {
-            if let Some(source) = item.image_preview() {
-                previews.register_preview(settings, source, worker);
+    fn register_image_previews(&self, store: AsyncProgramStore) {
+        let room_id = self.timeline().room().room_id().to_owned();
+        let thread = self.thread.clone();
+
+        tokio::spawn(async move {
+            let mut locked = store.lock().await;
+            let ChatStore { rooms, settings, previews, worker, .. } = &mut locked.application;
+
+            let messages = rooms
+                .get(&room_id)
+                .expect("internal state inconsistent")
+                .get_thread(thread.as_deref())
+                .expect("internal state inconsistent");
+
+            for (_, item) in messages.range_messages(..) {
+                if let Some(source) = item.image_preview() {
+                    previews.register_preview(settings, source, worker);
+                }
             }
-        }
+        });
     }
 
     #[inline]
@@ -794,7 +803,7 @@ fn body_cow_msglike(content: &MsgLikeContent) -> Cow<'_, str> {
         MsgLikeKind::Message(message) => body_cow_content(message.msgtype()),
         MsgLikeKind::Sticker(sticker) => Cow::Owned(format!("Alt: {}", sticker.content().body)),
         MsgLikeKind::Poll(_) => {
-            // TODO: implement
+            // TODO: implement polls
             Cow::Borrowed("[Poll]")
         },
         MsgLikeKind::Redacted => Cow::Borrowed("[Redacted]"),

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -142,7 +142,7 @@ fn handle_update(
                 }
             }
         },
-        VectorDiff::Clear | VectorDiff::Remove { .. } => (),
+        VectorDiff::PopFront | VectorDiff::Clear | VectorDiff::Remove { .. } => (),
         _ => {
             unimplemented!("these vector operations aren't used by the sdk: {update:?}")
         },
@@ -191,6 +191,15 @@ fn handle_update(
                 messages.start_element = messages.start_element.saturating_sub(1);
             }
             if let Some(item) = messages.messages[*index].as_event() {
+                vec![item.identifier()]
+            } else {
+                vec![]
+            }
+        },
+        VectorDiff::PopFront => {
+            messages.start_element = messages.start_element.saturating_sub(1);
+
+            if let Some(item) = messages.messages.get(0).and_then(|msg| msg.as_event()) {
                 vec![item.identifier()]
             } else {
                 vec![]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -2,7 +2,6 @@
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::ops::{Bound, RangeBounds};
@@ -14,13 +13,13 @@ use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
+use matrix_sdk::ruma::UserId;
 use matrix_sdk_ui::eyeball_im::Vector;
 use matrix_sdk_ui::timeline::{
     EventTimelineItem,
     MsgLikeContent,
     MsgLikeKind,
     ReactionsByKeyBySender,
-    TimelineEventItemId,
     TimelineItem,
     TimelineItemContent,
     TimelineItemKind,
@@ -57,8 +56,9 @@ use crate::{
     util::{replace_emojis_in_str, space, space_span, take_width, wrapped_text},
 };
 
+pub(super) mod html;
+
 mod compose;
-mod html;
 mod printer;
 mod state;
 
@@ -101,7 +101,6 @@ impl PartialOrd for MessageKey {
 pub struct Messages {
     timeline: Timeline,
     messages: Vector<Arc<TimelineItem>>,
-    htmls: HashMap<TimelineEventItemId, StyleTree>,
 
     /// This is the index of the first element in the vector when this object was created. This is
     /// used by [`MessageKey`] as a referenc because the vector can be extended in both directions.
@@ -111,9 +110,6 @@ pub struct Messages {
 impl Messages {
     pub fn timeline(&self) -> &Timeline {
         &self.timeline
-    }
-    pub fn get_html(&self, id: &TimelineEventItemId) -> Option<&StyleTree> {
-        self.htmls.get(id)
     }
     pub fn get_message(&self, key: &MessageKey) -> Option<&Message> {
         let index = self.start_element.checked_add_signed(key.offset())?;
@@ -181,6 +177,7 @@ impl Messages {
 
     #[allow(unused)]
     fn new(_thread: ReceiptThread) -> Self {
+        let info: &mut RoomInfo = todo!();
         let timeline = todo!();
 
         let messages: Vector<Arc<TimelineItem>> = todo!();
@@ -188,10 +185,10 @@ impl Messages {
         let htmls = messages
             .iter()
             .filter_map(|item| item.as_event())
-            .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)))
-            .collect();
+            .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)));
+        info.htmls.extend(htmls);
 
-        Self { messages, htmls, timeline, start_element: 0 }
+        Self { messages, timeline, start_element: 0 }
     }
 
     pub fn main() -> Self {
@@ -269,14 +266,6 @@ const fn span_static(s: &'static str) -> Span<'static> {
     }
 }
 
-const BOLD_STYLE: Style = Style {
-    fg: None,
-    bg: None,
-    add_modifier: StyleModifier::BOLD,
-    sub_modifier: StyleModifier::empty(),
-    underline_color: None,
-};
-
 const TIME_GUTTER: usize = 12;
 const READ_GUTTER: usize = 5;
 const MIN_MSG_LEN: usize = 30;
@@ -351,19 +340,6 @@ impl MessageTimeStamp {
         let time = i64::from(self.0) / 1000;
         let time = DateTime::from_timestamp(time, 0).unwrap_or_default();
         time.into()
-    }
-
-    fn same_day(&self, other: &Self) -> bool {
-        let dt1 = self.as_datetime();
-        let dt2 = other.as_datetime();
-
-        dt1.date_naive() == dt2.date_naive()
-    }
-
-    fn show_date(&self) -> Option<Span<'static>> {
-        let time = self.as_datetime().format("%A, %B %d %Y").to_string();
-
-        Span::styled(time, BOLD_STYLE).into()
     }
 
     fn show_time(&self) -> Span<'static> {
@@ -619,9 +595,6 @@ pub struct MessageFormatter<'a> {
     /// How many columns to print.
     cols: MessageColumns,
 
-    /// The full, original width.
-    orig: usize,
-
     /// The width that the message contents need to fill.
     fill: usize,
 
@@ -630,9 +603,6 @@ pub struct MessageFormatter<'a> {
 
     /// The time the message was sent.
     time: Option<Span<'a>>,
-
-    /// The date the message was sent.
-    date: Option<Span<'a>>,
 
     /// The users who have read up to this message.
     read: Vec<OwnedUserId>,
@@ -645,15 +615,6 @@ impl<'a> MessageFormatter<'a> {
 
     #[inline]
     fn push_spans(&mut self, prev_line: Line<'a>, style: Style, text: &mut Text<'a>) {
-        if let Some(date) = self.date.take() {
-            let len = date.content.as_ref().len();
-            let padding = self.orig.saturating_sub(len);
-            let leading = space_span(padding / 2, Style::default());
-            let trailing = space_span(padding.saturating_sub(padding / 2), Style::default());
-
-            text.lines.push(Line::from(vec![leading, date, trailing]));
-        }
-
         let user_gutter_empty_span =
             space_span(self.settings.tunables.user_gutter_width, Style::default());
 
@@ -727,7 +688,6 @@ impl<'a> MessageFormatter<'a> {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-        thread: &'a Messages,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
             style.patch(settings.get_user_color(msg.sender()))
@@ -737,7 +697,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, previews, thread);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, true, info, settings, previews);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -917,16 +877,11 @@ pub trait MessageExt {
 
     fn get_render_format<'a>(
         &'a self,
-        prev: Option<&Message>,
+        prev_sender: Option<&UserId>,
         width: usize,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> MessageFormatter<'a> {
-        let orig = width;
-        let date = match &prev {
-            Some(prev) if prev.message_timestamp().same_day(&self.message_timestamp()) => None,
-            _ => self.message_timestamp().show_date(),
-        };
         let user_gutter = settings.tunables.user_gutter_width;
 
         if user_gutter + TIME_GUTTER + READ_GUTTER + MIN_MSG_LEN <= width &&
@@ -934,7 +889,7 @@ pub trait MessageExt {
         {
             let cols = MessageColumns::Four;
             let fill = width - user_gutter - TIME_GUTTER - READ_GUTTER;
-            let user = self.show_sender(prev, true, info, settings);
+            let user = self.show_sender(prev_sender, true, info, settings);
             let time = Some(self.message_timestamp().show_time());
             let read = self
                 .item()
@@ -944,31 +899,31 @@ pub trait MessageExt {
                 .map(|(user_id, _)| user_id.to_owned())
                 .collect();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter { settings, cols, fill, user, time, read }
         } else if user_gutter + TIME_GUTTER + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
-            let user = self.show_sender(prev, true, info, settings);
+            let user = self.show_sender(prev_sender, true, info, settings);
             let time = Some(self.message_timestamp().show_time());
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter { settings, cols, fill, user, time, read }
         } else if user_gutter + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Two;
             let fill = width - user_gutter;
-            let user = self.show_sender(prev, true, info, settings);
+            let user = self.show_sender(prev_sender, true, info, settings);
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter { settings, cols, fill, user, time, read }
         } else {
             let cols = MessageColumns::One;
             let fill = width.saturating_sub(2);
-            let user = self.show_sender(prev, false, info, settings);
+            let user = self.show_sender(prev_sender, false, info, settings);
             let time = None;
             let read = Vec::new();
 
-            MessageFormatter { settings, cols, orig, fill, user, date, time, read }
+            MessageFormatter { settings, cols, fill, user, time, read }
         }
     }
 
@@ -977,18 +932,17 @@ pub trait MessageExt {
     /// This will also get the image preview Protocol with an x/y offset.
     fn show_with_preview<'a>(
         &'a self,
-        prev: Option<&Message>,
+        prev_sender: Option<&UserId>,
         selected: bool,
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-        thread: &'a Messages,
     ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
         let width = vwctx.get_width();
 
         let style = self.get_render_style(selected, settings);
-        let mut fmt = self.get_render_format(prev, width, info, settings);
+        let mut fmt = self.get_render_format(prev_sender, width, info, settings);
         let mut text = Text::default();
         let width = fmt.width();
 
@@ -1000,19 +954,16 @@ pub trait MessageExt {
             .and_then(|e| info.get_event(&e));
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
-            fmt.push_in_reply(r, style, &mut text, info, settings, previews, thread)
+            fmt.push_in_reply(r, style, &mut text, info, settings, previews)
         });
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews, thread);
+        let (msg, proto) = self.show_msg(width, style, reply.is_some(), info, settings, previews);
 
         // Given our text so far, determine the image offset.
         let proto_main = proto.map(|p| {
             let y_off = text.lines.len() as u16;
             let x_off = fmt.cols.user_gutter_width(settings);
-            // Adjust y_off by 1 if a date was printed before the message to account for
-            // the extra line we're going to print.
-            let y_off = if fmt.date.is_some() { y_off + 1 } else { y_off };
             (p, x_off, y_off)
         });
 
@@ -1046,11 +997,11 @@ pub trait MessageExt {
         width: usize,
         style: Style,
         hide_reply: bool,
+        info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-        thread: &'a Messages,
     ) -> (Text<'a>, Option<&'a Protocol>) {
-        if let Some(html) = thread.get_html(&self.item().identifier()) {
+        if let Some(html) = info.get_html(&self.item().identifier()) {
             (html.to_text(width, style, hide_reply, settings), None)
         } else {
             let mut msg = self.body();
@@ -1092,16 +1043,13 @@ pub trait MessageExt {
 
     fn show_sender<'a>(
         &'a self,
-        prev: Option<&Message>,
+        prev_sender: Option<&UserId>,
         align_right: bool,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> Option<Span<'a>> {
-        if let Some(prev) = prev {
-            if self.item().sender() == prev.sender() &&
-                self.message_timestamp().same_day(&prev.message_timestamp()) &&
-                !self.is_emote()
-            {
+        if let Some(prev) = prev_sender {
+            if self.item().sender() == prev && !self.is_emote() {
                 return None;
             }
         }
@@ -1130,37 +1078,40 @@ impl TimelineItemExt for TimelineItem {
 pub trait TimelineItemExt {
     fn item(&self) -> &TimelineItem;
 
+    fn sender(&self) -> Option<&UserId> {
+        self.item().as_event().map(|event| event.sender())
+    }
+
     /// Render the message as a [Text] object for the terminal.
     ///
     /// This will also get the image preview Protocol with an x/y offset.
     fn show_with_preview<'a>(
         &'a self,
-        prev: Option<&Message>,
+        prev_sender: Option<&UserId>,
         selected: bool,
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-        thread: &'a Messages,
     ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
         match self.item().kind() {
             TimelineItemKind::Event(item) => {
-                item.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
+                item.show_with_preview(prev_sender, selected, vwctx, info, settings, previews)
             },
             TimelineItemKind::Virtual(_item) => todo!(),
         }
     }
+
     fn show<'a>(
         &'a self,
-        prev: Option<&Message>,
+        prev_sender: Option<&UserId>,
         selected: bool,
         vwctx: &ViewportContext<MessageCursor>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
-        thread: &'a Messages,
     ) -> Text<'a> {
-        self.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
+        self.show_with_preview(prev_sender, selected, vwctx, info, settings, previews)
             .0
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -271,7 +271,7 @@ impl Messages {
             .messages
             .len()
             .cast_signed()
-            .checked_sub_unsigned(self.start_element)?;
+            .checked_sub_unsigned(self.start_element + 1)?;
 
         MessageKey::new(offset, id).into()
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -30,6 +30,7 @@ use matrix_sdk_ui::timeline::{
     TimelineItemContent,
     TimelineItemKind,
     TimelineUniqueId,
+    VirtualTimelineItem,
 };
 use matrix_sdk_ui::Timeline;
 use unicode_width::UnicodeWidthStr;
@@ -259,13 +260,17 @@ impl Messages {
             Bound::Excluded(start) => self.start_element.saturating_add_signed(start.offset() + 1),
             Bound::Unbounded => 0,
         };
-        let last = match range.end_bound() {
+        let mut last = match range.end_bound() {
             Bound::Included(end) => self.start_element.saturating_add_signed(end.offset()).into(),
             Bound::Excluded(end) => {
                 self.start_element.saturating_add_signed(end.offset()).checked_sub(1)
             },
             Bound::Unbounded => self.messages.len().checked_sub(1),
         };
+
+        if last.is_some_and(|last| last >= self.messages.len()) {
+            last = self.messages.len().checked_sub(1);
+        }
 
         let last = match last {
             Some(last) => last,
@@ -301,6 +306,9 @@ impl Messages {
             .track_read_marker_and_receipts()
             .build()
             .await?;
+
+        // TODO: load in background
+        timeline.paginate_backwards(50).await?;
 
         let (messages, updates) = timeline.subscribe().await;
 
@@ -1073,7 +1081,7 @@ pub trait MessageExt {
         //     .reply_to()
         //     .or_else(|| self.thread_root())
         //     .and_then(|e| info.get_event(&e));
-        let reply: Option<&Message> = todo!();
+        let reply: Option<&Message> = None;
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
             fmt.push_in_reply(r, style, &mut text, info, settings, previews)
@@ -1220,7 +1228,22 @@ pub trait TimelineItemExt {
             TimelineItemKind::Event(item) => {
                 item.show_with_preview(prev_sender, selected, vwctx, info, settings, previews)
             },
-            TimelineItemKind::Virtual(_item) => todo!(),
+            TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
+                ("----------------------------".into(), [None, None])
+            },
+            TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart) => {
+                ("--- Timeline Start ---".into(), [None, None])
+            },
+            TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(date)) => {
+                let ts = MessageTimeStamp(date.0);
+                let time = ts.as_datetime().format("%A, %B %d %Y").to_string();
+                let padding = vwctx.get_width().saturating_sub(time.len());
+                let leading = space_span(padding / 2, Style::default());
+                let trailing = space_span(padding.saturating_sub(padding / 2), Style::default());
+                let time = Span::styled(time, Style::new().add_modifier(StyleModifier::BOLD));
+
+                (Line::from(vec![leading, time, trailing]).into(), [None, None])
+            },
         }
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -230,7 +230,7 @@ pub struct Messages {
 }
 
 impl Messages {
-    pub fn timeline(&self) -> &Timeline {
+    pub fn timeline(&self) -> &Arc<Timeline> {
         &self.timeline
     }
     pub fn get_message(&self, key: &MessageKey) -> Option<&Message> {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -58,10 +58,11 @@ use modalkit::editing::cursor::Cursor;
 use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
-use crate::base::{AsyncProgramStore, ProgramStore};
+use crate::base::{AsyncProgramStore, ChatStore, ProgramStore};
 use crate::config::ImagePreviewSize;
 use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
+use crate::worker::Requester;
 use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
@@ -119,7 +120,9 @@ fn handle_update(
     update: VectorDiff<Arc<TimelineItem>>,
     store: &mut ProgramStore,
 ) {
-    let Some(info) = store.application.rooms.get_mut(room_id) else {
+    let ChatStore { rooms, settings, previews, worker, .. } = &mut store.application;
+
+    let Some(info) = rooms.get_mut(room_id) else {
         tracing::warn!("received update for unknown room");
         return;
     };
@@ -132,6 +135,9 @@ fn handle_update(
             if let Some(item) = value.as_event() {
                 if let Some(html) = generate_html(item) {
                     info.htmls.insert(item.identifier(), html);
+                }
+                if let Some(source) = item.image_preview() {
+                    previews.register_preview(settings, source, worker);
                 }
             }
         },
@@ -349,6 +355,20 @@ impl Messages {
         messages.paginate_backwards(store);
 
         Ok((messages, htmls))
+    }
+
+    /// This should be called closely after [`Self::new`].
+    pub fn register_image_previews(
+        &self,
+        settings: &ApplicationSettings,
+        previews: &mut PreviewManager,
+        worker: &Requester,
+    ) {
+        for (_, item) in self.range_messages(..) {
+            if let Some(source) = item.image_preview() {
+                previews.register_preview(settings, source, worker);
+            }
+        }
     }
 
     pub fn paginate_backwards(&self, store: AsyncProgramStore) {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -249,9 +249,15 @@ pub struct Messages {
 }
 
 impl Messages {
-    #[cfg(not(test))]
     pub fn timeline(&self) -> &Arc<Timeline> {
-        &self.timeline
+        #[cfg(test)]
+        {
+            unimplemented!()
+        }
+        #[cfg(not(test))]
+        {
+            &self.timeline
+        }
     }
 
     pub fn get_message(&self, key: &MessageKey) -> Option<&Message> {
@@ -325,7 +331,7 @@ impl Messages {
 
     /// This must be called while `store` is locked and must be inserted in the store before it is
     /// unlocked.
-    #[cfg(not(test))]
+    #[cfg_attr(test, allow(unused, clippy::diverging_sub_expression))]
     pub async fn new(
         room: &Room,
         thread: Option<OwnedEventId>,
@@ -344,6 +350,10 @@ impl Messages {
             .await?;
 
         let (messages, updates) = timeline.subscribe().await;
+
+        #[cfg(test)]
+        let (messages, updates): (Vector<Arc<MessageItem>>, futures::stream::Empty<_>) =
+            unimplemented!();
 
         tokio::spawn(handle_updates(
             room.room_id().to_owned(),
@@ -372,8 +382,10 @@ impl Messages {
             .unwrap_or(0);
 
         let messages = Self {
-            messages,
+            #[cfg(not(test))]
             timeline: timeline.into(),
+
+            messages,
             start_element,
             thread,
             fetching: false,
@@ -398,11 +410,10 @@ impl Messages {
         }
     }
 
-    #[cfg(not(test))]
     pub fn paginate_backwards(&self, store: AsyncProgramStore) {
         let room_id = self.timeline().room().room_id().to_owned();
         let thread = self.thread.clone();
-        let timeline = Arc::clone(&self.timeline);
+        let timeline = Arc::clone(self.timeline());
 
         tokio::spawn(async move {
             if std::mem::replace(
@@ -453,21 +464,6 @@ impl Messages {
 
     pub fn set_messages(&mut self, messages: Vector<Arc<MessageItem>>) {
         self.messages = messages;
-    }
-
-    pub async fn new(
-        _room: &Room,
-        _thread: Option<OwnedEventId>,
-        _store: AsyncProgramStore,
-    ) -> Result<(Self, HashMap<TimelineEventItemId, StyleTree>), matrix_sdk_ui::timeline::Error>
-    {
-        unimplemented!()
-    }
-    pub fn paginate_backwards(&self, _store: AsyncProgramStore) {
-        unimplemented!()
-    }
-    pub fn timeline(&self) -> &Arc<Timeline> {
-        unimplemented!()
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -265,9 +265,28 @@ impl Messages {
         let item = self.messages.get(index)?;
 
         if item.unique_id() != key.id() {
-            // TODO: search messages around?
-            tracing::error!("key not found");
-            return None;
+            // This should only happen if the fully read marker moves, thereby shifting the
+            // timeline. Search a few messages around the indec to account for that. But if we
+            // search to many messages we might be trying to use the fully read marker at its new
+            // position.
+
+            let item = self
+                .messages
+                .iter()
+                .skip(index + 1)
+                .alternate_with_all(self.messages.iter().take(index.saturating_sub(1)).rev())
+                .take(4)
+                .find(|item| item.unique_id() == key.id());
+
+            if item.is_none() {
+                tracing::warn!(
+                    room_id = ?self.timeline().room().room_id(),
+                    id = ?key.id(),
+                    "message key not found in timeline"
+                );
+            }
+
+            return item.and_then(|item| item.as_event());
         }
 
         item.as_event()

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -539,7 +539,7 @@ impl MessageCursor {
         if let Some(key) = &self.key {
             Some(key.clone())
         } else {
-            Some(thread.last_key()?)
+            thread.range_messages(..).next_back().map(|(key, _)| key)
         }
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -136,6 +136,8 @@ fn handle_update(
             if let Some(item) = value.as_event() {
                 if let Some(html) = generate_html(item) {
                     info.htmls.insert(item.identifier(), html);
+                } else {
+                    info.htmls.remove(&item.identifier());
                 }
                 if let Some(source) = item.image_preview() {
                     previews.register_preview(settings, source, worker);
@@ -217,6 +219,7 @@ fn handle_update(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(store, stream))]
 async fn handle_updates(
     room_id: OwnedRoomId,
     thread: Option<OwnedEventId>,

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -144,14 +144,9 @@ impl Messages {
     }
 
     pub fn insert_message(&mut self, key: MessageKey, msg: impl Into<Message>) {
-        let event_id = key.event_id().to_owned();
         let msg = msg.into();
 
         self.messages.insert(key, msg);
-
-        // Remove any echo.
-        let key = MessageKey::new(MessageTimeStamp::LocalEcho, event_id);
-        let _ = self.messages.remove(&key);
     }
 }
 
@@ -233,13 +228,6 @@ fn placeholder_frame(
     Some(placeholder)
 }
 
-#[inline]
-fn millis_to_datetime(ms: UInt) -> DateTime<LocalTz> {
-    let time = i64::from(ms) / 1000;
-    let time = DateTime::from_timestamp(time, 0).unwrap_or_default();
-    time.into()
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum TimeStampIntError {
     #[error("Integer conversion error: {0}")]
@@ -249,18 +237,14 @@ pub enum TimeStampIntError {
     UIntError(<UInt as TryFrom<u64>>::Error),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum MessageTimeStamp {
-    OriginServer(UInt),
-    LocalEcho,
-}
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MessageTimeStamp(UInt);
 
 impl MessageTimeStamp {
     fn as_datetime(&self) -> DateTime<LocalTz> {
-        match self {
-            MessageTimeStamp::OriginServer(ms) => millis_to_datetime(*ms),
-            MessageTimeStamp::LocalEcho => LocalTz::now(),
-        }
+        let time = i64::from(self.0) / 1000;
+        let time = DateTime::from_timestamp(time, 0).unwrap_or_default();
+        time.into()
     }
 
     fn same_day(&self, other: &Self) -> bool {
@@ -270,62 +254,29 @@ impl MessageTimeStamp {
         dt1.date_naive() == dt2.date_naive()
     }
 
-    fn show_date(&self) -> Option<Span<'_>> {
+    fn show_date(&self) -> Option<Span<'static>> {
         let time = self.as_datetime().format("%A, %B %d %Y").to_string();
 
         Span::styled(time, BOLD_STYLE).into()
     }
 
-    fn show_time(&self) -> Option<Span<'_>> {
-        match self {
-            MessageTimeStamp::OriginServer(ms) => {
-                let time = millis_to_datetime(*ms).format("%T");
-                let time = format!("  [{time}]");
+    fn show_time(&self) -> Span<'static> {
+        let time = self.as_datetime().format("%T");
+        let time = format!("  [{time}]");
 
-                Span::raw(time).into()
-            },
-            MessageTimeStamp::LocalEcho => None,
-        }
-    }
-
-    fn is_local_echo(&self) -> bool {
-        matches!(self, MessageTimeStamp::LocalEcho)
-    }
-
-    pub fn as_millis(&self) -> Option<MilliSecondsSinceUnixEpoch> {
-        match self {
-            MessageTimeStamp::OriginServer(ms) => MilliSecondsSinceUnixEpoch(*ms).into(),
-            MessageTimeStamp::LocalEcho => None,
-        }
-    }
-}
-
-impl Ord for MessageTimeStamp {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (MessageTimeStamp::OriginServer(_), MessageTimeStamp::LocalEcho) => Ordering::Less,
-            (MessageTimeStamp::OriginServer(a), MessageTimeStamp::OriginServer(b)) => a.cmp(b),
-            (MessageTimeStamp::LocalEcho, MessageTimeStamp::OriginServer(_)) => Ordering::Greater,
-            (MessageTimeStamp::LocalEcho, MessageTimeStamp::LocalEcho) => Ordering::Equal,
-        }
-    }
-}
-
-impl PartialOrd for MessageTimeStamp {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+        Span::raw(time)
     }
 }
 
 impl From<UInt> for MessageTimeStamp {
     fn from(millis: UInt) -> Self {
-        MessageTimeStamp::OriginServer(millis)
+        Self(millis)
     }
 }
 
 impl From<MilliSecondsSinceUnixEpoch> for MessageTimeStamp {
     fn from(millis: MilliSecondsSinceUnixEpoch) -> Self {
-        MessageTimeStamp::OriginServer(millis.0)
+        Self(millis.0)
     }
 }
 
@@ -333,10 +284,7 @@ impl TryFrom<&MessageTimeStamp> for usize {
     type Error = TimeStampIntError;
 
     fn try_from(ts: &MessageTimeStamp) -> Result<Self, Self::Error> {
-        let n = match ts {
-            MessageTimeStamp::LocalEcho => 0,
-            MessageTimeStamp::OriginServer(u) => usize::try_from(u64::from(*u))?,
-        };
+        let n = usize::try_from(u64::from(ts.0))?;
 
         Ok(n)
     }
@@ -346,14 +294,10 @@ impl TryFrom<usize> for MessageTimeStamp {
     type Error = TimeStampIntError;
 
     fn try_from(u: usize) -> Result<Self, Self::Error> {
-        if u == 0 {
-            Ok(MessageTimeStamp::LocalEcho)
-        } else {
-            let n = u64::try_from(u)?;
-            let n = UInt::try_from(n).map_err(TimeStampIntError::UIntError)?;
+        let n = u64::try_from(u)?;
+        let n = UInt::try_from(n).map_err(TimeStampIntError::UIntError)?;
 
-            Ok(MessageTimeStamp::from(n))
-        }
+        Ok(Self::from(n))
     }
 }
 
@@ -793,8 +737,6 @@ impl<'a> MessageFormatter<'a> {
 
 pub struct Message {
     item: EventTimelineItem,
-
-    timestamp: MessageTimeStamp,
     downloaded: bool,
     html: Option<StyleTree>,
     image_preview: Option<MediaSource>,
@@ -807,9 +749,6 @@ impl Message {
     }
     pub fn html(&self) -> Option<&StyleTree> {
         self.html.as_ref()
-    }
-    pub fn set_html(&mut self, html: Option<StyleTree>) {
-        self.html = html;
     }
     pub fn body(&self) -> Cow<'_, str> {
         #[allow(unused)]
@@ -837,6 +776,9 @@ impl Message {
     pub fn insert_image_preview(&mut self, preview: MediaSource) {
         self.image_preview = Some(preview);
     }
+    pub fn timestamp(&self) -> MessageTimeStamp {
+        self.item().timestamp().into()
+    }
 
     pub fn is_emote(&self) -> bool {
         self.item()
@@ -845,19 +787,10 @@ impl Message {
             .is_some_and(|msg| matches!(msg.msgtype(), MessageType::Emote(_)))
     }
 
-    #[allow(unused)]
-    pub fn new(sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
-        let downloaded = false;
-        let item = todo!();
+    pub fn new(item: EventTimelineItem) -> Self {
         let html = generate_html(&item);
 
-        Message {
-            item,
-            timestamp,
-            downloaded,
-            html,
-            image_preview: None,
-        }
+        Message { item, downloaded: false, html, image_preview: None }
     }
 
     pub fn reply_to(&self) -> Option<OwnedEventId> {
@@ -875,7 +808,7 @@ impl Message {
             style = style.add_modifier(StyleModifier::REVERSED)
         }
 
-        if self.timestamp.is_local_echo() {
+        if self.item().is_local_echo() {
             style = style.add_modifier(StyleModifier::ITALIC);
         }
 
@@ -896,8 +829,8 @@ impl Message {
     ) -> MessageFormatter<'a> {
         let orig = width;
         let date = match &prev {
-            Some(prev) if prev.timestamp.same_day(&self.timestamp) => None,
-            _ => self.timestamp.show_date(),
+            Some(prev) if prev.timestamp().same_day(&self.timestamp()) => None,
+            _ => self.timestamp().show_date(),
         };
         let user_gutter = settings.tunables.user_gutter_width;
 
@@ -907,7 +840,7 @@ impl Message {
             let cols = MessageColumns::Four;
             let fill = width - user_gutter - TIME_GUTTER - READ_GUTTER;
             let user = self.show_sender(prev, true, info, settings);
-            let time = self.timestamp.show_time();
+            let time = Some(self.timestamp().show_time());
             let read = self
                 .item()
                 .read_receipts()
@@ -921,7 +854,7 @@ impl Message {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
             let user = self.show_sender(prev, true, info, settings);
-            let time = self.timestamp.show_time();
+            let time = Some(self.timestamp().show_time());
             let read = Vec::new();
 
             MessageFormatter { settings, cols, orig, fill, user, date, time, read }
@@ -1086,7 +1019,7 @@ impl Message {
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev {
             if self.sender() == prev.sender() &&
-                self.timestamp.same_day(&prev.timestamp) &&
+                self.timestamp().same_day(&prev.timestamp()) &&
                 !self.is_emote()
             {
                 return None;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -60,6 +60,7 @@ use ratatui_image::protocol::Protocol;
 
 use crate::base::{AsyncProgramStore, ChatStore, ProgramStore};
 use crate::config::ImagePreviewSize;
+use crate::message::html::StyleTreeNode;
 use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
 use crate::worker::Requester;
@@ -248,6 +249,7 @@ impl Messages {
 
         if item.unique_id() != key.id() {
             // TODO: search messages around?
+            tracing::error!("key not found");
             return None;
         }
 
@@ -765,7 +767,6 @@ fn body_cow_content(msgtype: &MessageType) -> Cow<'_, str> {
     Cow::Borrowed(s)
 }
 
-#[allow(unused)]
 fn generate_html(item: &EventTimelineItem) -> Option<StyleTree> {
     match item.content() {
         TimelineItemContent::MsgLike(content) => {
@@ -787,8 +788,18 @@ fn generate_html(item: &EventTimelineItem) -> Option<StyleTree> {
         TimelineItemContent::ProfileChange(change) => Some(html_profile(change)),
         TimelineItemContent::OtherState(change) => Some(html_state(change)),
 
-        TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
-        TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
+        TimelineItemContent::FailedToParseMessageLike { error, .. } => {
+            let msg = format!("[Failed to parse message: {error}]");
+            let text = StyleTreeNode::Text(Cow::Owned(msg));
+            let styled = StyleTreeNode::Style(Box::new(text), Style::new().fg(Color::Red));
+            Some(StyleTree { children: vec![styled] })
+        },
+        TimelineItemContent::FailedToParseState { error, .. } => {
+            let msg = format!("[Failed to parse state event: {error}]");
+            let text = StyleTreeNode::Text(Cow::Owned(msg));
+            let styled = StyleTreeNode::Style(Box::new(text), Style::new().fg(Color::Red));
+            Some(StyleTree { children: vec![styled] })
+        },
         TimelineItemContent::CallInvite | TimelineItemContent::RtcNotification => None,
     }
 }
@@ -1159,14 +1170,19 @@ pub trait MessageExt {
     fn is_edited(&self) -> bool;
 
     fn body(&self) -> Cow<'_, str> {
-        #[allow(unused)]
         match self.content() {
             TimelineItemContent::MsgLike(content) => body_cow_msglike(content),
             TimelineItemContent::MembershipChange(change) => body_cow_membership(change),
             TimelineItemContent::ProfileChange(change) => body_cow_profile(change),
             TimelineItemContent::OtherState(change) => body_cow_state(change),
-            TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
-            TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
+            TimelineItemContent::FailedToParseMessageLike { error, .. } => {
+                let msg = format!("[Failed to parse message: {error}]");
+                Cow::Owned(msg)
+            },
+            TimelineItemContent::FailedToParseState { error, .. } => {
+                let msg = format!("[Failed to parse state event: {error}]");
+                Cow::Owned(msg)
+            },
             TimelineItemContent::RtcNotification | TimelineItemContent::CallInvite => {
                 Cow::Borrowed("* started a call")
             },

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -4,13 +4,13 @@ use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
-use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::RangeBounds;
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use matrix_sdk::ruma::UserId;
@@ -22,31 +22,12 @@ use matrix_sdk_ui::timeline::{
     TimelineItemContent,
 };
 use matrix_sdk_ui::Timeline;
-use serde_json::json;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
-    events::{
-        room::{
-            encrypted::{
-                OriginalRoomEncryptedEvent,
-                RedactedRoomEncryptedEvent,
-                RoomEncryptedEvent,
-            },
-            message::{
-                FormattedBody,
-                MessageFormat,
-                MessageType,
-                OriginalRoomMessageEvent,
-                RedactedRoomMessageEvent,
-                RoomMessageEvent,
-                RoomMessageEventContent,
-            },
-            redaction::SyncRoomRedactionEvent,
-        },
-        AnySyncStateEvent,
-        RedactContent,
-        RedactedUnsigned,
+    events::room::{
+        message::{FormattedBody, MessageFormat, MessageType},
+        redaction::SyncRoomRedactionEvent,
     },
     EventId,
     MilliSecondsSinceUnixEpoch,
@@ -66,7 +47,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
-use crate::message::state::{body_cow_membership, body_cow_profile};
+use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
 use crate::{
     base::RoomInfo,
@@ -469,93 +450,6 @@ impl PartialOrd for MessageCursor {
     }
 }
 
-fn redaction_reason(ev: &SyncRoomRedactionEvent) -> Option<&str> {
-    let SyncRoomRedactionEvent::Original(ev) = ev else {
-        return None;
-    };
-
-    return ev.content.reason.as_deref();
-}
-
-fn redaction_unsigned(ev: SyncRoomRedactionEvent) -> RedactedUnsigned {
-    let reason = redaction_reason(&ev);
-    let redacted_because = json!({
-        "content": {
-            "reason": reason
-        },
-        "event_id": ev.event_id(),
-        "sender": ev.sender(),
-        "origin_server_ts": ev.origin_server_ts(),
-        "unsigned": {},
-    });
-    RedactedUnsigned::new(serde_json::from_value(redacted_because).unwrap())
-}
-
-#[derive(Clone)]
-pub enum MessageEvent {
-    EncryptedOriginal(Box<OriginalRoomEncryptedEvent>),
-    EncryptedRedacted(Box<RedactedRoomEncryptedEvent>),
-    Original(Box<OriginalRoomMessageEvent>),
-    Redacted(Box<RedactedRoomMessageEvent>),
-    State(Box<AnySyncStateEvent>),
-    Local(OwnedEventId, Box<RoomMessageEventContent>),
-}
-
-impl MessageEvent {
-    pub fn event_id(&self) -> &EventId {
-        match self {
-            MessageEvent::EncryptedOriginal(ev) => ev.event_id.as_ref(),
-            MessageEvent::EncryptedRedacted(ev) => ev.event_id.as_ref(),
-            MessageEvent::Original(ev) => ev.event_id.as_ref(),
-            MessageEvent::Redacted(ev) => ev.event_id.as_ref(),
-            MessageEvent::State(ev) => ev.event_id(),
-            MessageEvent::Local(event_id, _) => event_id.as_ref(),
-        }
-    }
-
-    pub fn html(&self) -> Option<StyleTree> {
-        let content = match self {
-            MessageEvent::EncryptedOriginal(_) => return None,
-            MessageEvent::EncryptedRedacted(_) => return None,
-            MessageEvent::Original(ev) => &ev.content,
-            MessageEvent::Redacted(_) => return None,
-            MessageEvent::State(ev) => return Some(html_state(ev)),
-            MessageEvent::Local(_, content) => content,
-        };
-
-        if let MessageType::Text(content) = &content.msgtype {
-            if let Some(FormattedBody { format: MessageFormat::Html, body }) = &content.formatted {
-                Some(parse_matrix_html(body.as_str()))
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    fn redact(&mut self, redaction: SyncRoomRedactionEvent, rules: &RedactionRules) {
-        match self {
-            MessageEvent::EncryptedOriginal(_) => return,
-            MessageEvent::EncryptedRedacted(_) => return,
-            MessageEvent::Redacted(_) => return,
-            MessageEvent::State(_) => return,
-            MessageEvent::Local(_, _) => return,
-            MessageEvent::Original(ev) => {
-                let redacted = RedactedRoomMessageEvent {
-                    content: ev.content.clone().redact(rules),
-                    event_id: ev.event_id.clone(),
-                    sender: ev.sender.clone(),
-                    origin_server_ts: ev.origin_server_ts,
-                    room_id: ev.room_id.clone(),
-                    unsigned: redaction_unsigned(redaction),
-                };
-                *self = MessageEvent::Redacted(Box::new(redacted));
-            },
-        }
-    }
-}
-
 /// Macro rule converting a File / Image / Audio / Video to its text content with the shape:
 /// `[Attached <type>: <content>[ (<human readable file size>)]]`
 macro_rules! display_file_to_text {
@@ -614,6 +508,34 @@ fn body_cow_content(msgtype: &MessageType) -> Cow<'_, str> {
     };
 
     Cow::Borrowed(s)
+}
+
+#[allow(unused)]
+fn generate_html(item: &EventTimelineItem) -> Option<StyleTree> {
+    match item.content() {
+        TimelineItemContent::MsgLike(content) => {
+            if let MsgLikeKind::Message(message) = &content.kind {
+                if let MessageType::Text(TextMessageEventContent {
+                    formatted: Some(FormattedBody { format: MessageFormat::Html, body }),
+                    ..
+                }) = message.msgtype()
+                {
+                    Some(parse_matrix_html(body))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        },
+        TimelineItemContent::MembershipChange(change) => Some(html_membership(change)),
+        TimelineItemContent::ProfileChange(change) => Some(html_profile(change)),
+        TimelineItemContent::OtherState(change) => Some(html_state(change)),
+
+        TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
+        TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
+        TimelineItemContent::CallInvite | TimelineItemContent::CallNotify => None,
+    }
 }
 
 enum MessageColumns {
@@ -872,7 +794,6 @@ impl<'a> MessageFormatter<'a> {
 pub struct Message {
     item: EventTimelineItem,
 
-    event: MessageEvent,
     timestamp: MessageTimeStamp,
     downloaded: bool,
     html: Option<StyleTree>,
@@ -904,12 +825,6 @@ impl Message {
             },
         }
     }
-    pub fn event(&self) -> &MessageEvent {
-        &self.event
-    }
-    pub fn event_mut(&mut self) -> &mut MessageEvent {
-        &mut self.event
-    }
     pub fn sender(&self) -> &UserId {
         self.item().sender()
     }
@@ -931,14 +846,13 @@ impl Message {
     }
 
     #[allow(unused)]
-    pub fn new(event: MessageEvent, sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
-        let html = event.html();
+    pub fn new(sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
         let downloaded = false;
         let item = todo!();
+        let html = generate_html(&item);
 
         Message {
             item,
-            event,
             timestamp,
             downloaded,
             html,
@@ -1193,69 +1107,11 @@ impl Message {
         Span::styled(sender, style).into()
     }
 
+    #[allow(unused)]
     pub fn redact(&mut self, redaction: SyncRoomRedactionEvent, rules: &RedactionRules) {
-        self.event_mut().redact(redaction, rules);
         self.html = None;
         self.downloaded = false;
         self.image_preview = None;
-    }
-}
-
-impl From<RoomEncryptedEvent> for Message {
-    fn from(event: RoomEncryptedEvent) -> Self {
-        let timestamp = event.origin_server_ts().into();
-        let user_id = event.sender().to_owned();
-        let content = match event {
-            RoomEncryptedEvent::Original(ev) => MessageEvent::EncryptedOriginal(ev.into()),
-            RoomEncryptedEvent::Redacted(ev) => MessageEvent::EncryptedRedacted(ev.into()),
-        };
-
-        Message::new(content, user_id, timestamp)
-    }
-}
-
-impl From<OriginalRoomMessageEvent> for Message {
-    fn from(event: OriginalRoomMessageEvent) -> Self {
-        let timestamp = event.origin_server_ts.into();
-        let user_id = event.sender.clone();
-        let content = MessageEvent::Original(event.into());
-
-        Message::new(content, user_id, timestamp)
-    }
-}
-
-impl From<RedactedRoomMessageEvent> for Message {
-    fn from(event: RedactedRoomMessageEvent) -> Self {
-        let timestamp = event.origin_server_ts.into();
-        let user_id = event.sender.clone();
-        let content = MessageEvent::Redacted(event.into());
-
-        Message::new(content, user_id, timestamp)
-    }
-}
-
-impl From<RoomMessageEvent> for Message {
-    fn from(event: RoomMessageEvent) -> Self {
-        match event {
-            RoomMessageEvent::Original(ev) => ev.into(),
-            RoomMessageEvent::Redacted(ev) => ev.into(),
-        }
-    }
-}
-
-impl From<AnySyncStateEvent> for Message {
-    fn from(event: AnySyncStateEvent) -> Self {
-        let timestamp = event.origin_server_ts().into();
-        let user_id = event.sender().to_owned();
-        let event = MessageEvent::State(event.into());
-
-        Message::new(event, user_id, timestamp)
-    }
-}
-
-impl Display for Message {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.body())
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1123,7 +1123,7 @@ impl MessageExt for Message {
     }
 
     fn is_edited(&self) -> bool {
-        self.latest_edit_json().is_some()
+        self.content().as_message().is_some_and(|msg| msg.is_edited())
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -391,7 +391,7 @@ impl Messages {
             fetching: false,
         };
 
-        messages.paginate_backwards(store);
+        messages.paginate_backwards_count(store, 10);
 
         Ok((messages, htmls))
     }
@@ -410,7 +410,12 @@ impl Messages {
         }
     }
 
+    #[inline]
     pub fn paginate_backwards(&self, store: AsyncProgramStore) {
+        self.paginate_backwards_count(store, MIN_MSG_LOAD);
+    }
+
+    fn paginate_backwards_count(&self, store: AsyncProgramStore, num_events: u16) {
         let room_id = self.timeline().room().room_id().to_owned();
         let thread = self.thread.clone();
         let timeline = Arc::clone(self.timeline());
@@ -432,7 +437,7 @@ impl Messages {
                 return;
             }
 
-            if let Err(err) = timeline.paginate_backwards(MIN_MSG_LOAD).await {
+            if let Err(err) = timeline.paginate_backwards(num_events).await {
                 tracing::warn!(?room_id, ?thread, "error while loading message history: {err}");
                 return;
             }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -6,7 +6,8 @@ use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
-use std::ops::{Deref, DerefMut};
+use std::iter::FusedIterator;
+use std::ops::RangeBounds;
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
@@ -96,25 +97,51 @@ impl MessageKey {
     }
 }
 
-pub struct Messages(BTreeMap<MessageKey, Message>, pub ReceiptThread);
-
-impl Deref for Messages {
-    type Target = BTreeMap<MessageKey, Message>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Messages {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+pub struct Messages {
+    messages: BTreeMap<MessageKey, Message>,
+    thread: ReceiptThread,
 }
 
 impl Messages {
+    pub fn receipt_thread(&self) -> &ReceiptThread {
+        &self.thread
+    }
+    pub fn len(&self) -> usize {
+        self.messages.len()
+    }
+    pub fn get(&self, key: &MessageKey) -> Option<&Message> {
+        self.messages.get(key)
+    }
+    pub fn get_mut(&mut self, key: &MessageKey) -> Option<&mut Message> {
+        self.messages.get_mut(key)
+    }
+    pub fn insert(&mut self, key: MessageKey, value: Message) -> Option<Message> {
+        self.messages.insert(key, value)
+    }
+    pub fn first_key_value(&self) -> Option<(&MessageKey, &Message)> {
+        self.messages.first_key_value()
+    }
+    pub fn last_key_value(&self) -> Option<(&MessageKey, &Message)> {
+        self.messages.last_key_value()
+    }
+    pub fn last_mut(&mut self) -> Option<&mut Message> {
+        self.messages.last_entry().map(|o| o.into_mut())
+    }
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (&MessageKey, &Message)> + FusedIterator + ExactSizeIterator
+    {
+        self.messages.iter()
+    }
+    pub fn range(
+        &self,
+        range: impl RangeBounds<MessageKey>,
+    ) -> std::collections::btree_map::Range<'_, MessageKey, Message> {
+        self.messages.range(range)
+    }
+
     pub fn new(thread: ReceiptThread) -> Self {
-        Self(Default::default(), thread)
+        Self { messages: Default::default(), thread }
     }
 
     pub fn main() -> Self {
@@ -129,11 +156,11 @@ impl Messages {
         let event_id = key.event_id().to_owned();
         let msg = msg.into();
 
-        self.0.insert(key, msg);
+        self.messages.insert(key, msg);
 
         // Remove any echo.
         let key = MessageKey::new(MessageTimeStamp::LocalEcho, event_id);
-        let _ = self.0.remove(&key);
+        let _ = self.messages.remove(&key);
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -78,7 +78,23 @@ pub use html::TreeGenState;
 
 type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 
-pub type MessageKey = (MessageTimeStamp, OwnedEventId);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MessageKey {
+    ts: MessageTimeStamp,
+    id: OwnedEventId,
+}
+
+impl MessageKey {
+    pub const fn new(ts: MessageTimeStamp, id: OwnedEventId) -> Self {
+        Self { ts, id }
+    }
+    pub fn event_id(&self) -> &EventId {
+        &self.id
+    }
+    pub fn ts(&self) -> &MessageTimeStamp {
+        &self.ts
+    }
+}
 
 pub struct Messages(BTreeMap<MessageKey, Message>, pub ReceiptThread);
 
@@ -110,13 +126,13 @@ impl Messages {
     }
 
     pub fn insert_message(&mut self, key: MessageKey, msg: impl Into<Message>) {
-        let event_id = key.1.clone();
+        let event_id = key.event_id().to_owned();
         let msg = msg.into();
 
         self.0.insert(key, msg);
 
         // Remove any echo.
-        let key = (MessageTimeStamp::LocalEcho, event_id);
+        let key = MessageKey::new(MessageTimeStamp::LocalEcho, event_id);
         let _ = self.0.remove(&key);
     }
 }
@@ -356,30 +372,27 @@ impl MessageCursor {
         let ev_term = OwnedEventId::try_from("$").ok()?;
 
         let ts_start = MessageTimeStamp::try_from(cursor.get_y()).ok()?;
-        let start = (ts_start, ev_term);
+        let start = MessageKey::new(ts_start, ev_term);
 
-        for ((ts, event_id), _) in thread.range(&start..) {
-            if hash_event_id(event_id)? == ev_hash {
-                return Self::from((*ts, event_id.clone())).into();
+        for (key, _) in thread.range(&start..) {
+            if hash_event_id(key.event_id())? == ev_hash {
+                return Self::from(key.clone()).into();
             }
 
-            if ts > &ts_start {
+            if key.ts() > &ts_start {
                 break;
             }
         }
 
         // If we can't find the cursor, then go to the nearest timestamp.
-        thread
-            .range(start..)
-            .next()
-            .map(|((ts, ev), _)| Self::from((*ts, ev.clone())))
+        thread.range(start..).next().map(|(key, _)| Self::from(key.clone()))
     }
 
     pub fn to_cursor(&self, thread: &Messages) -> Option<Cursor> {
-        let (ts, event_id) = self.to_key(thread)?;
+        let key = self.to_key(thread)?;
 
-        let y = usize::try_from(ts).ok()?;
-        let x = hash_event_id(event_id)?;
+        let y = usize::try_from(key.ts()).ok()?;
+        let x = hash_event_id(key.event_id())?;
 
         Cursor::new(y, x).into()
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -852,10 +852,6 @@ pub trait MessageExt {
         Some(self.item().content().as_msglike()?.in_reply_to.as_ref()?.event_id.clone())
     }
 
-    fn thread_root(&self) -> Option<OwnedEventId> {
-        self.item().content().as_msglike()?.thread_root.clone()
-    }
-
     fn get_render_style(&self, selected: bool, settings: &ApplicationSettings) -> Style {
         let mut style = Style::default();
 
@@ -930,6 +926,7 @@ pub trait MessageExt {
     /// Render the message as a [Text] object for the terminal.
     ///
     /// This will also get the image preview Protocol with an x/y offset.
+    #[allow(unused)]
     fn show_with_preview<'a>(
         &'a self,
         prev_sender: Option<&UserId>,
@@ -948,10 +945,11 @@ pub trait MessageExt {
 
         // Show the message that this one replied to, if any.
         // TODO: use `InReplyToDetails::event`
-        let reply = self
-            .reply_to()
-            .or_else(|| self.thread_root())
-            .and_then(|e| info.get_event(&e));
+        // let reply = self
+        //     .reply_to()
+        //     .or_else(|| self.thread_root())
+        //     .and_then(|e| info.get_event(&e));
+        let reply: Option<&Message> = todo!();
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
             fmt.push_in_reply(r, style, &mut text, info, settings, previews)

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -299,15 +299,30 @@ impl Messages {
 
         item.as_event()
     }
-    pub fn first_key(&self) -> Option<MessageKey> {
-        let id = self.messages.front()?.unique_id().to_owned();
+
+    pub fn first_key(&self, settings: &ApplicationSettings) -> Option<MessageKey> {
+        let filter = settings.filter_hidden_item();
+        let id = self
+            .messages
+            .iter()
+            .find(|item| item.as_event().is_none_or(|item| filter(&item)))?
+            .unique_id()
+            .to_owned();
 
         let offset = 0isize.checked_sub_unsigned(self.start_element)?;
 
         MessageKey::new(offset, id).into()
     }
-    pub fn last_key(&self) -> Option<MessageKey> {
-        let id = self.messages.back()?.unique_id().to_owned();
+
+    pub fn last_key(&self, settings: &ApplicationSettings) -> Option<MessageKey> {
+        let filter = settings.filter_hidden_item();
+        let id = self
+            .messages
+            .iter()
+            .filter(|item| item.as_event().is_none_or(|item| filter(&item)))
+            .next_back()?
+            .unique_id()
+            .to_owned();
 
         let offset = self
             .messages
@@ -317,10 +332,28 @@ impl Messages {
 
         MessageKey::new(offset, id).into()
     }
-    pub fn last_message(&self) -> Option<&Message> {
-        self.messages.iter().filter_map(|item| item.as_event()).next_back()
+
+    pub fn last_message(&self, settings: &ApplicationSettings) -> Option<&Message> {
+        self.messages
+            .iter()
+            .filter_map(|item| item.as_event())
+            .filter(settings.filter_hidden_item())
+            .next_back()
     }
-    pub fn range(&self, range: impl RangeBounds<MessageKey>) -> MessagesRange {
+
+    pub fn range(
+        &self,
+        range: impl RangeBounds<MessageKey>,
+        settings: &ApplicationSettings,
+    ) -> impl DoubleEndedIterator<Item = (MessageKey, &MessageItem)> {
+        self.range_filtered(range, settings.filter_hidden())
+    }
+
+    pub fn range_filtered<F: FnMut(&(MessageKey, &MessageItem)) -> bool>(
+        &self,
+        range: impl RangeBounds<MessageKey>,
+        filter: F,
+    ) -> std::iter::Filter<MessagesRange, F> {
         let mut next = match range.start_bound() {
             Bound::Included(start) => self.start_element.saturating_add_signed(start.offset()),
             Bound::Excluded(start) => self.start_element.saturating_add_signed(start.offset() + 1),
@@ -346,13 +379,15 @@ impl Messages {
             },
         };
 
-        MessagesRange { messages: self, next, last }
+        MessagesRange { messages: self, next, last }.filter(filter)
     }
+
     pub fn range_messages(
         &self,
         range: impl RangeBounds<MessageKey>,
+        settings: &ApplicationSettings,
     ) -> impl DoubleEndedIterator<Item = (MessageKey, &Message)> {
-        self.range(range)
+        self.range(range, settings)
             .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
     }
 
@@ -439,7 +474,7 @@ impl Messages {
                 .get_thread(thread.as_deref())
                 .expect("internal state inconsistent");
 
-            for (_, item) in messages.range_messages(..) {
+            for (_, item) in messages.range_messages(.., settings) {
                 if let Some(source) = item.image_preview() {
                     previews.register_preview(settings, source, worker);
                 }
@@ -712,22 +747,32 @@ impl MessageCursor {
         MessageCursor::default()
     }
 
-    pub fn to_key<'a>(&'a self, thread: &'a Messages) -> Option<MessageKey> {
+    pub fn to_key<'a>(
+        &'a self,
+        thread: &'a Messages,
+        settings: &ApplicationSettings,
+    ) -> Option<MessageKey> {
         if let Some(key) = &self.key {
             Some(key.clone())
         } else {
-            thread.range_messages(..).next_back().map(|(key, _)| key)
+            thread.range_messages(.., settings).next_back().map(|(key, _)| key)
         }
     }
 
-    pub fn from_cursor(cursor: &Cursor, thread: &Messages) -> Option<Self> {
+    pub fn from_cursor(
+        cursor: &Cursor,
+        thread: &Messages,
+        settings: &ApplicationSettings,
+    ) -> Option<Self> {
         let ev_hash = cursor.get_x();
         let ev_term = TimelineUniqueId(String::new());
 
         let offset_start = isize::MIN.wrapping_add_unsigned(cursor.get_y());
         let start = MessageKey::new(offset_start, ev_term);
 
-        let iter = thread.range(&start..).alternate_with_all(thread.range(..&start).rev());
+        let iter = thread
+            .range(&start.., settings)
+            .alternate_with_all(thread.range(..&start, settings).rev());
         for (key, _) in iter {
             if hash_event_id(key.id())? == ev_hash {
                 return Self::from(key.to_owned()).into();
@@ -739,11 +784,14 @@ impl MessageCursor {
         }
 
         // If we can't find the cursor, then go to the nearest timestamp.
-        thread.range(start..).next().map(|(key, _)| Self::from(key.clone()))
+        thread
+            .range(start.., settings)
+            .next()
+            .map(|(key, _)| Self::from(key.clone()))
     }
 
-    pub fn to_cursor(&self, thread: &Messages) -> Option<Cursor> {
-        let key = self.to_key(thread)?;
+    pub fn to_cursor(&self, thread: &Messages, settings: &ApplicationSettings) -> Option<Cursor> {
+        let key = self.to_key(thread, settings)?;
 
         let y = key.offset().abs_diff(isize::MIN);
         let x = hash_event_id(key.id())?;
@@ -1640,6 +1688,7 @@ pub mod tests {
 
     #[test]
     fn test_mc_to_key() {
+        let settings = mock_settings();
         let mut messages = Messages::mock_new();
         messages.set_messages(mock_messages());
         let mc1 = MessageCursor::from(MSG1_KEY.clone());
@@ -1649,12 +1698,12 @@ pub mod tests {
         let mc5 = MessageCursor::from(MSG5_KEY.clone());
         let mc6 = MessageCursor::latest();
 
-        let k1 = mc1.to_key(&messages).unwrap();
-        let k2 = mc2.to_key(&messages).unwrap();
-        let k3 = mc3.to_key(&messages).unwrap();
-        let k4 = mc4.to_key(&messages).unwrap();
-        let k5 = mc5.to_key(&messages).unwrap();
-        let k6 = mc6.to_key(&messages).unwrap();
+        let k1 = mc1.to_key(&messages, &settings).unwrap();
+        let k2 = mc2.to_key(&messages, &settings).unwrap();
+        let k3 = mc3.to_key(&messages, &settings).unwrap();
+        let k4 = mc4.to_key(&messages, &settings).unwrap();
+        let k5 = mc5.to_key(&messages, &settings).unwrap();
+        let k6 = mc6.to_key(&messages, &settings).unwrap();
 
         // These should all be equal to their MSGN_KEYs.
         assert_eq!(k1, MSG1_KEY.clone());
@@ -1668,11 +1717,12 @@ pub mod tests {
 
         // MessageCursor::latest() fails to convert for a room w/o messages.
         let messages_empty = Messages::mock_new();
-        assert_eq!(mc6.to_key(&messages_empty), None);
+        assert_eq!(mc6.to_key(&messages_empty, &settings), None);
     }
 
     #[test]
     fn test_mc_to_from_cursor() {
+        let settings = mock_settings();
         let mut messages = Messages::mock_new();
         messages.set_messages(mock_messages());
         let mc1 = MessageCursor::from(MSG1_KEY.clone());
@@ -1683,9 +1733,9 @@ pub mod tests {
         let mc6 = MessageCursor::latest();
 
         let identity = |mc: &MessageCursor| {
-            let c = mc.to_cursor(&messages).unwrap();
+            let c = mc.to_cursor(&messages, &settings).unwrap();
 
-            MessageCursor::from_cursor(&c, &messages).unwrap()
+            MessageCursor::from_cursor(&c, &messages, &settings).unwrap()
         };
 
         // These should all convert to a Cursor and back to the original value.

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -24,6 +24,7 @@ use matrix_sdk_ui::timeline::{
     MsgLikeKind,
     ReactionsByKeyBySender,
     RoomExt,
+    TimelineDetails,
     TimelineEventItemId,
     TimelineFocus,
     TimelineItem,
@@ -893,7 +894,7 @@ impl<'a> MessageFormatter<'a> {
         let width = self.width();
         let w = width.saturating_sub(2);
         let (mut replied, proto) = msg.show_msg(w, reply_style, true, info, settings, previews);
-        let mut sender = msg.sender_span(info, self.settings);
+        let mut sender = msg.sender_span(self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
 
@@ -1070,7 +1071,6 @@ pub trait MessageExt {
         &'a self,
         prev_sender: Option<&UserId>,
         width: usize,
-        info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> MessageFormatter<'a> {
         let user_gutter = settings.tunables.user_gutter_width;
@@ -1080,7 +1080,7 @@ pub trait MessageExt {
         {
             let cols = MessageColumns::Four;
             let fill = width - user_gutter - TIME_GUTTER - READ_GUTTER;
-            let user = self.show_sender(prev_sender, true, info, settings);
+            let user = self.show_sender(prev_sender, true, settings);
             let time = Some(self.message_timestamp().show_time());
             let read = self
                 .item()
@@ -1094,7 +1094,7 @@ pub trait MessageExt {
         } else if user_gutter + TIME_GUTTER + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
-            let user = self.show_sender(prev_sender, true, info, settings);
+            let user = self.show_sender(prev_sender, true, settings);
             let time = Some(self.message_timestamp().show_time());
             let read = Vec::new();
 
@@ -1102,7 +1102,7 @@ pub trait MessageExt {
         } else if user_gutter + MIN_MSG_LEN <= width {
             let cols = MessageColumns::Two;
             let fill = width - user_gutter;
-            let user = self.show_sender(prev_sender, true, info, settings);
+            let user = self.show_sender(prev_sender, true, settings);
             let time = None;
             let read = Vec::new();
 
@@ -1110,7 +1110,7 @@ pub trait MessageExt {
         } else {
             let cols = MessageColumns::One;
             let fill = width.saturating_sub(2);
-            let user = self.show_sender(prev_sender, false, info, settings);
+            let user = self.show_sender(prev_sender, false, settings);
             let time = None;
             let read = Vec::new();
 
@@ -1134,7 +1134,7 @@ pub trait MessageExt {
         let width = vwctx.get_width();
 
         let style = self.get_render_style(selected, settings);
-        let mut fmt = self.get_render_format(prev_sender, width, info, settings);
+        let mut fmt = self.get_render_format(prev_sender, width, settings);
         let mut text = Text::default();
         let width = fmt.width();
 
@@ -1226,19 +1226,20 @@ pub trait MessageExt {
         }
     }
 
-    fn sender_span<'a>(
-        &'a self,
-        info: &'a RoomInfo,
-        settings: &'a ApplicationSettings,
-    ) -> Span<'a> {
-        settings.get_user_span(self.item().sender(), info)
+    fn sender_span<'a>(&'a self, settings: &'a ApplicationSettings) -> Span<'a> {
+        let name = if let TimelineDetails::Ready(profile) = self.item().sender_profile() {
+            profile.display_name.as_deref()
+        } else {
+            None
+        };
+
+        settings.get_user_span(self.item().sender(), name)
     }
 
     fn show_sender<'a>(
         &'a self,
         prev_sender: Option<&UserId>,
         align_right: bool,
-        info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev_sender {
@@ -1247,7 +1248,7 @@ pub trait MessageExt {
             }
         }
 
-        let Span { content, style } = self.sender_span(info, settings);
+        let Span { content, style } = self.sender_span(settings);
         let user_gutter = settings.tunables.user_gutter_width;
         let ((truncated, width), _) = take_width(content, user_gutter - 2);
         let padding = user_gutter - 2 - width;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -2,6 +2,7 @@
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::ops::{Bound, RangeBounds};
@@ -9,17 +10,22 @@ use std::sync::Arc;
 
 use alternating_iter::AlternatingExt;
 use chrono::{DateTime, Local as LocalTz};
+use futures::StreamExt;
 use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::UserId;
-use matrix_sdk_ui::eyeball_im::Vector;
+use matrix_sdk::ruma::{EventId, OwnedRoomId, RoomId, UserId};
+use matrix_sdk::Room;
+use matrix_sdk_ui::eyeball_im::{Vector, VectorDiff};
 use matrix_sdk_ui::timeline::{
     EventTimelineItem,
     MsgLikeContent,
     MsgLikeKind,
     ReactionsByKeyBySender,
+    RoomExt,
+    TimelineEventItemId,
+    TimelineFocus,
     TimelineItem,
     TimelineItemContent,
     TimelineItemKind,
@@ -46,6 +52,7 @@ use modalkit::editing::cursor::Cursor;
 use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
+use crate::base::{AsyncProgramStore, ProgramStore};
 use crate::config::ImagePreviewSize;
 use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
@@ -95,6 +102,109 @@ impl Ord for MessageKey {
 impl PartialOrd for MessageKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+fn handle_update(
+    room_id: &RoomId,
+    thread: Option<&EventId>,
+    update: VectorDiff<Arc<TimelineItem>>,
+    store: &mut ProgramStore,
+) {
+    let Some(info) = store.application.rooms.get_mut(room_id) else {
+        tracing::warn!("received update for unknown room");
+        return;
+    };
+
+    match &update {
+        VectorDiff::PushFront { value } |
+        VectorDiff::PushBack { value } |
+        VectorDiff::Insert { value, .. } |
+        VectorDiff::Set { value, .. } => {
+            if let Some(item) = value.as_event() {
+                if let Some(html) = generate_html(item) {
+                    info.htmls.insert(item.identifier(), html);
+                }
+            }
+        },
+        _ => {
+            unimplemented!("these vector operations aren't used by the sdk")
+        },
+    }
+
+    let Some(messages) = info.get_thread_mut(thread) else {
+        tracing::warn!("received update for unknown thread");
+        return;
+    };
+
+    let remove_htmls: Vec<_> = match &update {
+        VectorDiff::Clear => {
+            messages.start_element = 0;
+            messages
+                .messages
+                .iter()
+                .filter_map(|item| item.as_event())
+                .map(|item| item.identifier())
+                .collect()
+        },
+        VectorDiff::PushFront { .. } => {
+            messages.start_element += 1;
+            vec![]
+        },
+        VectorDiff::PushBack { .. } => vec![],
+        VectorDiff::Insert { index, .. } => {
+            if *index <= messages.start_element {
+                messages.start_element += 1;
+            }
+            vec![]
+        },
+        VectorDiff::Set { index, value } => {
+            match (messages.messages[*index].as_event(), value.as_event()) {
+                (Some(old), Some(new)) => {
+                    if old.identifier() != new.identifier() {
+                        vec![old.identifier()]
+                    } else {
+                        vec![]
+                    }
+                },
+                _ => vec![],
+            }
+        },
+        VectorDiff::Remove { index } => {
+            if *index <= messages.start_element {
+                messages.start_element = messages.start_element.saturating_sub(1);
+            }
+            if let Some(item) = messages.messages[*index].as_event() {
+                vec![item.identifier()]
+            } else {
+                vec![]
+            }
+        },
+        _ => {
+            unimplemented!("these vector operations aren't used by the sdk")
+        },
+    };
+
+    update.apply(&mut messages.messages);
+
+    for id in remove_htmls {
+        info.htmls.remove(&id);
+    }
+}
+
+async fn handle_updates(
+    room_id: OwnedRoomId,
+    thread: Option<OwnedEventId>,
+    store: AsyncProgramStore,
+    stream: impl futures::Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>,
+) {
+    futures::pin_mut!(stream);
+
+    while let Some(updates) = stream.next().await {
+        let mut locked = store.lock().await;
+        for update in updates {
+            handle_update(&room_id, thread.as_deref(), update, &mut locked);
+        }
     }
 }
 
@@ -175,28 +285,42 @@ impl Messages {
             .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
     }
 
-    #[allow(unused)]
-    fn new(_thread: ReceiptThread) -> Self {
-        let info: &mut RoomInfo = todo!();
-        let timeline = todo!();
+    pub async fn new(
+        room: &Room,
+        thread: Option<OwnedEventId>,
+        store: AsyncProgramStore,
+    ) -> Result<(Self, HashMap<TimelineEventItemId, StyleTree>), matrix_sdk_ui::timeline::Error>
+    {
+        let focus = match thread.clone() {
+            Some(root_event_id) => TimelineFocus::Thread { root_event_id },
+            None => TimelineFocus::Live { hide_threaded_events: true },
+        };
+        let timeline = room
+            .timeline_builder()
+            .with_focus(focus)
+            .track_read_marker_and_receipts()
+            .build()
+            .await?;
 
-        let messages: Vector<Arc<TimelineItem>> = todo!();
+        let (messages, updates) = timeline.subscribe().await;
+
+        tokio::spawn(handle_updates(room.room_id().to_owned(), thread, store, updates));
 
         let htmls = messages
             .iter()
             .filter_map(|item| item.as_event())
-            .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)));
-        info.htmls.extend(htmls);
+            .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)))
+            .collect();
 
-        Self { messages, timeline, start_element: 0 }
+        Ok((Self { messages, timeline, start_element: 0 }, htmls))
     }
 
     pub fn main() -> Self {
-        Self::new(ReceiptThread::Main)
+        todo!()
     }
 
-    pub fn thread(root: OwnedEventId) -> Self {
-        Self::new(ReceiptThread::Thread(root))
+    pub fn thread(_root: OwnedEventId) -> Self {
+        todo!()
     }
 }
 
@@ -1206,8 +1330,9 @@ pub mod tests {
         assert_eq!(k6, MSG1_KEY.clone());
 
         // MessageCursor::latest() fails to convert for a room w/o messages.
-        let messages_empty = Messages::new(ReceiptThread::Main);
-        assert_eq!(mc6.to_key(&messages_empty), None);
+        // let messages_empty = Messages::new(ReceiptThread::Main);
+        // assert_eq!(mc6.to_key(&messages_empty), None);
+        todo!()
     }
 
     #[test]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -2,30 +2,35 @@
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
-use std::ops::RangeBounds;
+use std::ops::{Bound, RangeBounds};
+use std::sync::Arc;
 
+use alternating_iter::AlternatingExt;
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::UserId;
+use matrix_sdk_ui::eyeball_im::Vector;
 use matrix_sdk_ui::timeline::{
     EventTimelineItem,
     MsgLikeContent,
     MsgLikeKind,
     ReactionsByKeyBySender,
+    TimelineEventItemId,
+    TimelineItem,
     TimelineItemContent,
+    TimelineItemKind,
+    TimelineUniqueId,
 };
 use matrix_sdk_ui::Timeline;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
     events::room::message::{FormattedBody, MessageFormat, MessageType},
-    EventId,
     MilliSecondsSinceUnixEpoch,
     OwnedEventId,
     OwnedUserId,
@@ -63,81 +68,130 @@ pub use html::TreeGenState;
 
 type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageKey {
-    ts: MessageTimeStamp,
-    id: OwnedEventId,
+    offset: isize,
+    id: TimelineUniqueId,
 }
 
 impl MessageKey {
-    pub const fn new(ts: MessageTimeStamp, id: OwnedEventId) -> Self {
-        Self { ts, id }
+    pub const fn new(offset: isize, id: TimelineUniqueId) -> Self {
+        Self { offset, id }
     }
-    pub fn event_id(&self) -> &EventId {
+    pub fn id(&self) -> &TimelineUniqueId {
         &self.id
     }
-    pub fn ts(&self) -> &MessageTimeStamp {
-        &self.ts
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+}
+
+impl Ord for MessageKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.offset.cmp(&other.offset)
+    }
+}
+
+impl PartialOrd for MessageKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
 pub struct Messages {
     timeline: Timeline,
-    messages: BTreeMap<MessageKey, Message>,
-    thread: ReceiptThread,
-    htmls: HashMap<OwnedEventId, StyleTree>,
+    messages: Vector<Arc<TimelineItem>>,
+    htmls: HashMap<TimelineEventItemId, StyleTree>,
+
+    /// This is the index of the first element in the vector when this object was created. This is
+    /// used by [`MessageKey`] as a referenc because the vector can be extended in both directions.
+    start_element: usize,
 }
 
 impl Messages {
     pub fn timeline(&self) -> &Timeline {
         &self.timeline
     }
-    pub fn get_html(&self, event_id: Option<&EventId>) -> Option<&StyleTree> {
-        self.htmls.get(event_id?)
+    pub fn get_html(&self, id: &TimelineEventItemId) -> Option<&StyleTree> {
+        self.htmls.get(id)
     }
-    pub fn receipt_thread(&self) -> &ReceiptThread {
-        &self.thread
+    pub fn get_message(&self, key: &MessageKey) -> Option<&Message> {
+        let index = self.start_element.checked_add_signed(key.offset())?;
+        let item = self.messages.get(index)?;
+
+        if item.unique_id() != key.id() {
+            // TODO: search messages around?
+            return None;
+        }
+
+        item.as_event()
     }
-    pub fn len(&self) -> usize {
-        self.messages.len()
+    pub fn first_key(&self) -> Option<MessageKey> {
+        let id = self.messages.front()?.unique_id().to_owned();
+
+        let offset = 0isize.checked_sub_unsigned(self.start_element)?;
+
+        MessageKey::new(offset, id).into()
     }
-    pub fn get(&self, key: &MessageKey) -> Option<&Message> {
-        self.messages.get(key)
+    pub fn last_key(&self) -> Option<MessageKey> {
+        let id = self.messages.back()?.unique_id().to_owned();
+
+        let offset = self
+            .messages
+            .len()
+            .cast_signed()
+            .checked_sub_unsigned(self.start_element)?;
+
+        MessageKey::new(offset, id).into()
     }
-    pub fn get_mut(&mut self, key: &MessageKey) -> Option<&mut Message> {
-        self.messages.get_mut(key)
+    pub fn last_message(&self) -> Option<&Message> {
+        self.messages.iter().filter_map(|item| item.as_event()).next_back()
     }
-    pub fn insert(&mut self, key: MessageKey, value: Message) -> Option<Message> {
-        self.messages.insert(key, value)
+    pub fn range(&self, range: impl RangeBounds<MessageKey>) -> MessagesRange {
+        let mut next = match range.start_bound() {
+            Bound::Included(start) => self.start_element.saturating_add_signed(start.offset()),
+            Bound::Excluded(start) => self.start_element.saturating_add_signed(start.offset() + 1),
+            Bound::Unbounded => 0,
+        };
+        let last = match range.end_bound() {
+            Bound::Included(end) => self.start_element.saturating_add_signed(end.offset()).into(),
+            Bound::Excluded(end) => {
+                self.start_element.saturating_add_signed(end.offset()).checked_sub(1)
+            },
+            Bound::Unbounded => self.messages.len().checked_sub(1),
+        };
+
+        let last = match last {
+            Some(last) => last,
+            None => {
+                next = 1;
+                0
+            },
+        };
+
+        MessagesRange { messages: self, next, last }
     }
-    pub fn first_key_value(&self) -> Option<(&MessageKey, &Message)> {
-        self.messages.first_key_value()
-    }
-    pub fn last_key_value(&self) -> Option<(&MessageKey, &Message)> {
-        self.messages.last_key_value()
-    }
-    pub fn last(&self) -> Option<&Message> {
-        self.messages.last_key_value().map(|(_, m)| m)
-    }
-    pub fn last_mut(&mut self) -> Option<&mut Message> {
-        self.messages.last_entry().map(|o| o.into_mut())
-    }
-    pub fn range(
+    pub fn range_messages(
         &self,
         range: impl RangeBounds<MessageKey>,
-    ) -> std::collections::btree_map::Range<'_, MessageKey, Message> {
-        self.messages.range(range)
+    ) -> impl DoubleEndedIterator<Item = (MessageKey, &Message)> {
+        self.range(range)
+            .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
     }
 
     #[allow(unused)]
-    fn new(thread: ReceiptThread) -> Self {
+    fn new(_thread: ReceiptThread) -> Self {
         let timeline = todo!();
-        Self {
-            messages: Default::default(),
-            htmls: Default::default(),
-            thread,
-            timeline,
-        }
+
+        let messages: Vector<Arc<TimelineItem>> = todo!();
+
+        let htmls = messages
+            .iter()
+            .filter_map(|item| item.as_event())
+            .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)))
+            .collect();
+
+        Self { messages, htmls, timeline, start_element: 0 }
     }
 
     pub fn main() -> Self {
@@ -147,13 +201,60 @@ impl Messages {
     pub fn thread(root: OwnedEventId) -> Self {
         Self::new(ReceiptThread::Thread(root))
     }
+}
 
-    pub fn insert_message(&mut self, key: MessageKey, msg: impl Into<Message>) {
-        let msg = msg.into();
+pub struct MessagesRange<'a> {
+    messages: &'a Messages,
+    next: usize,
+    last: usize,
+}
 
-        self.messages.insert(key, msg);
+impl<'a> Iterator for MessagesRange<'a> {
+    type Item = (MessageKey, &'a TimelineItem);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next > self.last {
+            return None;
+        }
+
+        let item = &self.messages.messages[self.next];
+
+        let offset = self.next.cast_signed().checked_sub_unsigned(self.messages.start_element)?;
+        let key = MessageKey::new(offset, item.unique_id().to_owned());
+
+        self.next += 1;
+
+        Some((key, &**item))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = (self.last + 1).saturating_sub(self.next);
+
+        (size, Some(size))
     }
 }
+
+impl DoubleEndedIterator for MessagesRange<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.next > self.last {
+            return None;
+        }
+
+        let item = &self.messages.messages[self.last];
+
+        let offset = self.last.cast_signed().checked_sub_unsigned(self.messages.start_element)?;
+        let key = MessageKey::new(offset, item.unique_id().to_owned());
+
+        if self.last == 0 {
+            self.next = 1;
+        } else {
+            self.last -= 1;
+        }
+
+        Some((key, &**item))
+    }
+}
+
+impl ExactSizeIterator for MessagesRange<'_> {}
 
 const fn span_static(s: &'static str) -> Span<'static> {
     Span {
@@ -194,8 +295,8 @@ fn hash_finish_usize(hasher: DefaultHasher) -> Option<usize> {
     }
 }
 
-/// Hash an [EventId] into a [usize].
-fn hash_event_id(event_id: &EventId) -> Option<usize> {
+/// Hash an [`TimelineUniqueId`] into a [usize].
+fn hash_event_id(event_id: &TimelineUniqueId) -> Option<usize> {
     let mut hasher = DefaultHasher::new();
     event_id.hash(&mut hasher);
     hash_finish_usize(hasher)
@@ -308,9 +409,9 @@ impl TryFrom<usize> for MessageTimeStamp {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct MessageCursor {
-    /// When timestamp is None, the corner is determined by moving backwards from
+    /// When `key` is None, the corner is determined by moving backwards from
     /// the most recently received message.
-    pub timestamp: Option<MessageKey>,
+    pub key: Option<MessageKey>,
 
     /// A row within the [Text] representation of a [Message].
     pub text_row: usize,
@@ -318,7 +419,7 @@ pub struct MessageCursor {
 
 impl MessageCursor {
     pub fn new(timestamp: MessageKey, text_row: usize) -> Self {
-        MessageCursor { timestamp: Some(timestamp), text_row }
+        MessageCursor { key: Some(timestamp), text_row }
     }
 
     /// Get a cursor that refers to the most recent message.
@@ -326,27 +427,28 @@ impl MessageCursor {
         MessageCursor::default()
     }
 
-    pub fn to_key<'a>(&'a self, thread: &'a Messages) -> Option<&'a MessageKey> {
-        if let Some(ref key) = self.timestamp {
-            Some(key)
+    pub fn to_key<'a>(&'a self, thread: &'a Messages) -> Option<MessageKey> {
+        if let Some(key) = &self.key {
+            Some(key.clone())
         } else {
-            Some(thread.last_key_value()?.0)
+            Some(thread.last_key()?)
         }
     }
 
     pub fn from_cursor(cursor: &Cursor, thread: &Messages) -> Option<Self> {
         let ev_hash = cursor.get_x();
-        let ev_term = OwnedEventId::try_from("$").ok()?;
+        let ev_term = TimelineUniqueId(String::new());
 
-        let ts_start = MessageTimeStamp::try_from(cursor.get_y()).ok()?;
-        let start = MessageKey::new(ts_start, ev_term);
+        let offset_start = isize::MIN.wrapping_add_unsigned(cursor.get_y());
+        let start = MessageKey::new(offset_start, ev_term);
 
-        for (key, _) in thread.range(&start..) {
-            if hash_event_id(key.event_id())? == ev_hash {
-                return Self::from(key.clone()).into();
+        let iter = thread.range(&start..).alternate_with_all(thread.range(..&start).rev());
+        for (key, _) in iter {
+            if hash_event_id(key.id())? == ev_hash {
+                return Self::from(key.to_owned()).into();
             }
 
-            if key.ts() > &ts_start {
+            if key.offset() > offset_start {
                 break;
             }
         }
@@ -358,8 +460,8 @@ impl MessageCursor {
     pub fn to_cursor(&self, thread: &Messages) -> Option<Cursor> {
         let key = self.to_key(thread)?;
 
-        let y = usize::try_from(key.ts()).ok()?;
-        let x = hash_event_id(key.event_id())?;
+        let y = key.offset().abs_diff(isize::MIN);
+        let x = hash_event_id(key.id())?;
 
         Cursor::new(y, x).into()
     }
@@ -367,19 +469,19 @@ impl MessageCursor {
 
 impl From<Option<MessageKey>> for MessageCursor {
     fn from(key: Option<MessageKey>) -> Self {
-        MessageCursor { timestamp: key, text_row: 0 }
+        MessageCursor { key, text_row: 0 }
     }
 }
 
 impl From<MessageKey> for MessageCursor {
     fn from(key: MessageKey) -> Self {
-        MessageCursor { timestamp: Some(key), text_row: 0 }
+        MessageCursor { key: Some(key), text_row: 0 }
     }
 }
 
 impl Ord for MessageCursor {
     fn cmp(&self, other: &Self) -> Ordering {
-        match (&self.timestamp, &other.timestamp) {
+        match (&self.key, &other.key) {
             (None, None) => self.text_row.cmp(&other.text_row),
             (None, Some(_)) => Ordering::Greater,
             (Some(_), None) => Ordering::Less,
@@ -766,9 +868,7 @@ pub trait MessageExt {
             },
         }
     }
-    fn sender(&self) -> &UserId {
-        self.item().sender()
-    }
+
     fn image_preview(&self) -> Option<&MediaSource> {
         if let MessageType::Image(c) = self.item().content().as_message()?.msgtype() {
             Some(&c.source)
@@ -776,6 +876,7 @@ pub trait MessageExt {
             None
         }
     }
+
     fn message_timestamp(&self) -> MessageTimeStamp {
         self.item().timestamp().into()
     }
@@ -807,7 +908,7 @@ pub trait MessageExt {
         }
 
         if settings.tunables.message_user_color {
-            let color = settings.get_user_color(self.sender());
+            let color = settings.get_user_color(self.item().sender());
             style = style.fg(color);
         }
 
@@ -940,20 +1041,6 @@ pub trait MessageExt {
         (text, [proto_main, proto_reply])
     }
 
-    fn show<'a>(
-        &'a self,
-        prev: Option<&Message>,
-        selected: bool,
-        vwctx: &ViewportContext<MessageCursor>,
-        info: &'a RoomInfo,
-        settings: &'a ApplicationSettings,
-        previews: &'a PreviewManager,
-        thread: &'a Messages,
-    ) -> Text<'a> {
-        self.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
-            .0
-    }
-
     fn show_msg<'a>(
         &'a self,
         width: usize,
@@ -963,7 +1050,7 @@ pub trait MessageExt {
         previews: &'a PreviewManager,
         thread: &'a Messages,
     ) -> (Text<'a>, Option<&'a Protocol>) {
-        if let Some(html) = thread.get_html(self.item().event_id()) {
+        if let Some(html) = thread.get_html(&self.item().identifier()) {
             (html.to_text(width, style, hide_reply, settings), None)
         } else {
             let mut msg = self.body();
@@ -1000,7 +1087,7 @@ pub trait MessageExt {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> Span<'a> {
-        settings.get_user_span(self.sender(), info)
+        settings.get_user_span(self.item().sender(), info)
     }
 
     fn show_sender<'a>(
@@ -1011,7 +1098,7 @@ pub trait MessageExt {
         settings: &'a ApplicationSettings,
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev {
-            if self.sender() == prev.sender() &&
+            if self.item().sender() == prev.sender() &&
                 self.message_timestamp().same_day(&prev.message_timestamp()) &&
                 !self.is_emote()
             {
@@ -1031,6 +1118,50 @@ pub trait MessageExt {
         };
 
         Span::styled(sender, style).into()
+    }
+}
+
+impl TimelineItemExt for TimelineItem {
+    fn item(&self) -> &TimelineItem {
+        self
+    }
+}
+
+pub trait TimelineItemExt {
+    fn item(&self) -> &TimelineItem;
+
+    /// Render the message as a [Text] object for the terminal.
+    ///
+    /// This will also get the image preview Protocol with an x/y offset.
+    fn show_with_preview<'a>(
+        &'a self,
+        prev: Option<&Message>,
+        selected: bool,
+        vwctx: &ViewportContext<MessageCursor>,
+        info: &'a RoomInfo,
+        settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
+        thread: &'a Messages,
+    ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
+        match self.item().kind() {
+            TimelineItemKind::Event(item) => {
+                item.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
+            },
+            TimelineItemKind::Virtual(_item) => todo!(),
+        }
+    }
+    fn show<'a>(
+        &'a self,
+        prev: Option<&Message>,
+        selected: bool,
+        vwctx: &ViewportContext<MessageCursor>,
+        info: &'a RoomInfo,
+        settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
+        thread: &'a Messages,
+    ) -> Text<'a> {
+        self.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
+            .0
     }
 }
 
@@ -1116,14 +1247,14 @@ pub mod tests {
         let k6 = mc6.to_key(&messages).unwrap();
 
         // These should all be equal to their MSGN_KEYs.
-        assert_eq!(k1, &MSG1_KEY.clone());
-        assert_eq!(k2, &MSG2_KEY.clone());
-        assert_eq!(k3, &MSG3_KEY.clone());
-        assert_eq!(k4, &MSG4_KEY.clone());
-        assert_eq!(k5, &MSG5_KEY.clone());
+        assert_eq!(k1, MSG1_KEY.clone());
+        assert_eq!(k2, MSG2_KEY.clone());
+        assert_eq!(k3, MSG3_KEY.clone());
+        assert_eq!(k4, MSG4_KEY.clone());
+        assert_eq!(k5, MSG5_KEY.clone());
 
         // MessageCursor::latest() turns into the largest key (our local echo message).
-        assert_eq!(k6, &MSG1_KEY.clone());
+        assert_eq!(k6, MSG1_KEY.clone());
 
         // MessageCursor::latest() fails to convert for a room w/o messages.
         let messages_empty = Messages::new(ReceiptThread::Main);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -63,6 +63,7 @@ use crate::config::ImagePreviewSize;
 use crate::message::html::StyleTreeNode;
 use crate::message::state::{body_cow_membership, body_cow_profile, html_membership, html_profile};
 use crate::preview::{ImageStatus, PreviewManager};
+use crate::util::TimelineDetailsExt;
 use crate::worker::Requester;
 use crate::{
     base::RoomInfo,
@@ -1390,7 +1391,7 @@ pub trait MessageExt {
     }
 
     fn sender_span<'a>(&'a self, settings: &'a ApplicationSettings) -> Span<'a> {
-        let name = if let TimelineDetails::Ready(profile) = self.sender_profile() {
+        let name = if let Some(profile) = self.sender_profile().ready() {
             profile.display_name.as_deref()
         } else {
             None

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -14,6 +14,7 @@ use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
+use matrix_sdk::ruma::UserId;
 use serde_json::json;
 use unicode_width::UnicodeWidthStr;
 
@@ -885,15 +886,43 @@ impl<'a> MessageFormatter<'a> {
 }
 
 pub struct Message {
-    pub event: MessageEvent,
-    pub sender: OwnedUserId,
-    pub timestamp: MessageTimeStamp,
-    pub downloaded: bool,
-    pub html: Option<StyleTree>,
-    pub image_preview: Option<MediaSource>,
+    event: MessageEvent,
+    sender: OwnedUserId,
+    timestamp: MessageTimeStamp,
+    downloaded: bool,
+    html: Option<StyleTree>,
+    image_preview: Option<MediaSource>,
 }
 
 impl Message {
+    pub fn html(&self) -> Option<&StyleTree> {
+        self.html.as_ref()
+    }
+    pub fn set_html(&mut self, html: Option<StyleTree>) {
+        self.html = html;
+    }
+    pub fn body(&self) -> Cow<'_, str> {
+        self.event.body()
+    }
+    pub fn event(&self) -> &MessageEvent {
+        &self.event
+    }
+    pub fn event_mut(&mut self) -> &mut MessageEvent {
+        &mut self.event
+    }
+    pub fn sender(&self) -> &UserId {
+        &self.sender
+    }
+    pub fn set_downloaded(&mut self) {
+        self.downloaded = true;
+    }
+    pub fn image_preview(&self) -> Option<&MediaSource> {
+        self.image_preview.as_ref()
+    }
+    pub fn insert_image_preview(&mut self, preview: MediaSource) {
+        self.image_preview = Some(preview);
+    }
+
     pub fn new(event: MessageEvent, sender: OwnedUserId, timestamp: MessageTimeStamp) -> Self {
         let html = event.html();
         let downloaded = false;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -30,6 +30,7 @@ use matrix_sdk_ui::timeline::{
     TimelineItem,
     TimelineItemContent,
     TimelineItemKind,
+    TimelineReadReceiptTracking,
     TimelineUniqueId,
     VirtualTimelineItem,
 };
@@ -315,7 +316,7 @@ impl Messages {
         let timeline = room
             .timeline_builder()
             .with_focus(focus)
-            .track_read_marker_and_receipts()
+            .track_read_marker_and_receipts(TimelineReadReceiptTracking::AllEvents)
             .build()
             .await?;
 
@@ -696,6 +697,9 @@ fn body_cow_msglike(content: &MsgLikeContent) -> Cow<'_, str> {
         },
         MsgLikeKind::Redacted => Cow::Borrowed("[Redacted]"),
         MsgLikeKind::UnableToDecrypt(_) => Cow::Borrowed("[Unable to decrypt message]"),
+        MsgLikeKind::Other(other) => {
+            Cow::Owned(format!("[Unsupported event: {}]", other.event_type()))
+        },
     }
 }
 
@@ -749,7 +753,7 @@ fn generate_html(item: &EventTimelineItem) -> Option<StyleTree> {
 
         TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
         TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
-        TimelineItemContent::CallInvite | TimelineItemContent::CallNotify => None,
+        TimelineItemContent::CallInvite | TimelineItemContent::RtcNotification => None,
     }
 }
 
@@ -1011,7 +1015,7 @@ pub trait MessageExt {
             TimelineItemContent::OtherState(change) => body_cow_state(change),
             TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
             TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
-            TimelineItemContent::CallInvite | TimelineItemContent::CallNotify => {
+            TimelineItemContent::RtcNotification | TimelineItemContent::CallInvite => {
                 Cow::Borrowed("* started a call")
             },
         }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -12,16 +12,18 @@ use alternating_iter::AlternatingExt;
 use chrono::{DateTime, Local as LocalTz};
 use futures::StreamExt;
 use humansize::{format_size, DECIMAL};
-use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::receipt::{Receipt, ReceiptThread};
 use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::{EventId, OwnedRoomId, RoomId, UserId};
 use matrix_sdk::Room;
 use matrix_sdk_ui::eyeball_im::{Vector, VectorDiff};
 use matrix_sdk_ui::timeline::{
+    EmbeddedEvent,
     EventTimelineItem,
     MsgLikeContent,
     MsgLikeKind,
+    Profile,
     ReactionsByKeyBySender,
     RoomExt,
     TimelineDetails,
@@ -35,6 +37,7 @@ use matrix_sdk_ui::timeline::{
     VirtualTimelineItem,
 };
 use matrix_sdk_ui::Timeline;
+use ratatui::style::Color;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
@@ -874,21 +877,68 @@ impl<'a> MessageFormatter<'a> {
 
     fn push_in_reply(
         &mut self,
-        msg: &'a Message,
+        msg: &'a TimelineDetails<Box<EmbeddedEvent>>,
         style: Style,
         text: &mut Text<'a>,
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
     ) -> Option<ProtocolPreview<'a>> {
+        let width = self.width();
+        let w = width.saturating_sub(2);
+
+        let msg = match msg {
+            TimelineDetails::Unavailable => {
+                let msg = "Message not loaded";
+                let trailing = w.saturating_sub(msg.len());
+                let line = Line::from(vec![
+                    Span::styled(" ", style),
+                    Span::styled(THICK_VERTICAL, style),
+                    Span::styled(msg, style),
+                    space_span(trailing, style),
+                ]);
+
+                self.push_spans(line, style, text);
+
+                return None;
+            },
+            TimelineDetails::Pending => {
+                let msg = "Message loading";
+                let trailing = w.saturating_sub(msg.len());
+                let line = Line::from(vec![
+                    Span::styled(" ", style),
+                    Span::styled(THICK_VERTICAL, style),
+                    Span::styled(msg, style),
+                    space_span(trailing, style),
+                ]);
+
+                self.push_spans(line, style, text);
+
+                return None;
+            },
+            TimelineDetails::Error(error) => {
+                let style = style.patch(Style::new().fg(Color::Red));
+                let msg = error.to_string();
+                let mut error = wrapped_text(msg, w, style);
+
+                for line in error.lines.iter_mut() {
+                    line.spans.insert(0, Span::styled(THICK_VERTICAL, style));
+                    line.spans.insert(0, Span::styled(" ", style));
+                }
+
+                self.push_text(error, style, text);
+
+                return None;
+            },
+            TimelineDetails::Ready(msg) => msg,
+        };
+
         let reply_style = if settings.tunables.message_user_color {
             style.patch(settings.get_user_color(msg.sender()))
         } else {
             style
         };
 
-        let width = self.width();
-        let w = width.saturating_sub(2);
         let (mut replied, proto) = msg.show_msg(w, reply_style, true, info, settings, previews);
         let mut sender = msg.sender_span(self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
@@ -999,16 +1049,83 @@ pub type Message = EventTimelineItem;
 
 impl MessageExt for Message {
     #[inline]
-    fn item(&self) -> &EventTimelineItem {
-        self
+    fn content(&self) -> &TimelineItemContent {
+        self.content()
+    }
+
+    #[inline]
+    fn sender(&self) -> &UserId {
+        self.sender()
+    }
+
+    #[inline]
+    fn sender_profile(&self) -> &TimelineDetails<Profile> {
+        self.sender_profile()
+    }
+
+    #[inline]
+    fn message_timestamp(&self) -> MessageTimeStamp {
+        self.timestamp().into()
+    }
+
+    #[inline]
+    fn identifier(&self) -> TimelineEventItemId {
+        self.identifier()
+    }
+
+    #[inline]
+    fn is_local_echo(&self) -> bool {
+        self.is_local_echo()
+    }
+
+    #[inline]
+    fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)> {
+        self.read_receipts().iter()
+    }
+}
+
+impl MessageExt for EmbeddedEvent {
+    fn content(&self) -> &TimelineItemContent {
+        &self.content
+    }
+
+    fn sender(&self) -> &UserId {
+        &self.sender
+    }
+
+    fn sender_profile(&self) -> &TimelineDetails<Profile> {
+        &self.sender_profile
+    }
+
+    fn message_timestamp(&self) -> MessageTimeStamp {
+        self.timestamp.into()
+    }
+
+    fn identifier(&self) -> TimelineEventItemId {
+        self.identifier.clone()
+    }
+
+    fn is_local_echo(&self) -> bool {
+        false
+    }
+
+    fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)> {
+        vec![].into_iter()
     }
 }
 
 pub trait MessageExt {
-    fn item(&self) -> &EventTimelineItem;
+    fn content(&self) -> &TimelineItemContent;
+    fn sender(&self) -> &UserId;
+    fn sender_profile(&self) -> &TimelineDetails<Profile>;
+    fn message_timestamp(&self) -> MessageTimeStamp;
+    fn identifier(&self) -> TimelineEventItemId;
+    fn is_local_echo(&self) -> bool;
+    fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)>;
+
     fn body(&self) -> Cow<'_, str> {
         #[allow(unused)]
-        match self.item().content() {
+        match self.content() {
             TimelineItemContent::MsgLike(content) => body_cow_msglike(content),
             TimelineItemContent::MembershipChange(change) => body_cow_membership(change),
             TimelineItemContent::ProfileChange(change) => body_cow_profile(change),
@@ -1022,26 +1139,21 @@ pub trait MessageExt {
     }
 
     fn image_preview(&self) -> Option<&MediaSource> {
-        if let MessageType::Image(c) = self.item().content().as_message()?.msgtype() {
+        if let MessageType::Image(c) = self.content().as_message()?.msgtype() {
             Some(&c.source)
         } else {
             None
         }
     }
 
-    fn message_timestamp(&self) -> MessageTimeStamp {
-        self.item().timestamp().into()
-    }
-
     fn is_emote(&self) -> bool {
-        self.item()
-            .content()
+        self.content()
             .as_message()
             .is_some_and(|msg| matches!(msg.msgtype(), MessageType::Emote(_)))
     }
 
     fn reply_to(&self) -> Option<OwnedEventId> {
-        Some(self.item().content().as_msglike()?.in_reply_to.as_ref()?.event_id.clone())
+        Some(self.content().as_msglike()?.in_reply_to.as_ref()?.event_id.clone())
     }
 
     fn get_render_style(&self, selected: bool, settings: &ApplicationSettings) -> Style {
@@ -1051,12 +1163,12 @@ pub trait MessageExt {
             style = style.add_modifier(StyleModifier::REVERSED)
         }
 
-        if self.item().is_local_echo() {
+        if self.is_local_echo() {
             style = style.add_modifier(StyleModifier::ITALIC);
         }
 
         if settings.tunables.message_user_color {
-            let color = settings.get_user_color(self.item().sender());
+            let color = settings.get_user_color(self.sender());
             style = style.fg(color);
         }
 
@@ -1079,9 +1191,7 @@ pub trait MessageExt {
             let user = self.show_sender(prev_sender, true, settings);
             let time = Some(self.message_timestamp().show_time());
             let read = self
-                .item()
                 .read_receipts()
-                .iter()
                 .filter(|(_, receipt)| !matches!(receipt.thread, ReceiptThread::Unthreaded))
                 .map(|(user_id, _)| user_id.to_owned())
                 .collect();
@@ -1117,7 +1227,6 @@ pub trait MessageExt {
     /// Render the message as a [Text] object for the terminal.
     ///
     /// This will also get the image preview Protocol with an x/y offset.
-    #[allow(unused)]
     fn show_with_preview<'a>(
         &'a self,
         prev_sender: Option<&UserId>,
@@ -1135,12 +1244,11 @@ pub trait MessageExt {
         let width = fmt.width();
 
         // Show the message that this one replied to, if any.
-        // TODO: use `InReplyToDetails::event`
-        // let reply = self
-        //     .reply_to()
-        //     .or_else(|| self.thread_root())
-        //     .and_then(|e| info.get_event(&e));
-        let reply: Option<&Message> = None;
+        let reply = self
+            .content()
+            .as_msglike()
+            .and_then(|msg| msg.in_reply_to.as_ref())
+            .map(|details| &details.event);
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
             fmt.push_in_reply(r, style, &mut text, info, settings, previews)
@@ -1164,16 +1272,13 @@ pub trait MessageExt {
         }
 
         if settings.tunables.reaction_display {
-            if let Some(msg) = self.item().content().as_msglike() {
+            if let Some(msg) = self.content().as_msglike() {
                 fmt.push_reactions(&msg.reactions, style, &mut text);
             }
         }
 
-        if let Some(thread) = self
-            .item()
-            .content()
-            .as_msglike()
-            .and_then(|msg| msg.thread_summary.as_ref())
+        if let Some(thread) =
+            self.content().as_msglike().and_then(|msg| msg.thread_summary.as_ref())
         {
             fmt.push_thread_reply_count(thread.num_replies, &mut text);
         }
@@ -1190,7 +1295,7 @@ pub trait MessageExt {
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
     ) -> (Text<'a>, Option<&'a Protocol>) {
-        if let Some(html) = info.get_html(&self.item().identifier()) {
+        if let Some(html) = info.get_html(&self.identifier()) {
             (html.to_text(width, style, hide_reply, settings), None)
         } else {
             let mut msg = self.body();
@@ -1223,13 +1328,13 @@ pub trait MessageExt {
     }
 
     fn sender_span<'a>(&'a self, settings: &'a ApplicationSettings) -> Span<'a> {
-        let name = if let TimelineDetails::Ready(profile) = self.item().sender_profile() {
+        let name = if let TimelineDetails::Ready(profile) = self.sender_profile() {
             profile.display_name.as_deref()
         } else {
             None
         };
 
-        settings.get_user_span(self.item().sender(), name)
+        settings.get_user_span(self.sender(), name)
     }
 
     fn show_sender<'a>(
@@ -1239,7 +1344,7 @@ pub trait MessageExt {
         settings: &'a ApplicationSettings,
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev_sender {
-            if self.item().sender() == prev && !self.is_emote() {
+            if self.sender() == prev && !self.is_emote() {
                 return None;
             }
         }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::ops::RangeBounds;
@@ -12,7 +12,6 @@ use humansize::{format_size, DECIMAL};
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::message::TextMessageEventContent;
 use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use matrix_sdk::ruma::UserId;
 use matrix_sdk_ui::timeline::{
     EventTimelineItem,
@@ -25,10 +24,7 @@ use matrix_sdk_ui::Timeline;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
-    events::room::{
-        message::{FormattedBody, MessageFormat, MessageType},
-        redaction::SyncRoomRedactionEvent,
-    },
+    events::room::message::{FormattedBody, MessageFormat, MessageType},
     EventId,
     MilliSecondsSinceUnixEpoch,
     OwnedEventId,
@@ -89,11 +85,15 @@ pub struct Messages {
     timeline: Timeline,
     messages: BTreeMap<MessageKey, Message>,
     thread: ReceiptThread,
+    htmls: HashMap<OwnedEventId, StyleTree>,
 }
 
 impl Messages {
     pub fn timeline(&self) -> &Timeline {
         &self.timeline
+    }
+    pub fn get_html(&self, event_id: Option<&EventId>) -> Option<&StyleTree> {
+        self.htmls.get(event_id?)
     }
     pub fn receipt_thread(&self) -> &ReceiptThread {
         &self.thread
@@ -132,7 +132,12 @@ impl Messages {
     #[allow(unused)]
     fn new(thread: ReceiptThread) -> Self {
         let timeline = todo!();
-        Self { messages: Default::default(), thread, timeline }
+        Self {
+            messages: Default::default(),
+            htmls: Default::default(),
+            thread,
+            timeline,
+        }
     }
 
     pub fn main() -> Self {
@@ -506,7 +511,7 @@ impl MessageColumns {
     }
 }
 
-struct MessageFormatter<'a> {
+pub struct MessageFormatter<'a> {
     settings: &'a ApplicationSettings,
 
     /// How many columns to print.
@@ -620,6 +625,7 @@ impl<'a> MessageFormatter<'a> {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
+        thread: &'a Messages,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
             style.patch(settings.get_user_color(msg.sender()))
@@ -629,7 +635,7 @@ impl<'a> MessageFormatter<'a> {
 
         let width = self.width();
         let w = width.saturating_sub(2);
-        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, previews);
+        let (mut replied, proto) = msg.show_msg(w, reply_style, true, settings, previews, thread);
         let mut sender = msg.sender_span(info, self.settings);
         let sender_width = UnicodeWidthStr::width(sender.content.as_ref());
         let trailing = w.saturating_sub(sender_width + 1);
@@ -735,22 +741,18 @@ impl<'a> MessageFormatter<'a> {
     }
 }
 
-pub struct Message {
-    item: EventTimelineItem,
-    downloaded: bool,
-    html: Option<StyleTree>,
-    image_preview: Option<MediaSource>,
+pub type Message = EventTimelineItem;
+
+impl MessageExt for Message {
+    #[inline]
+    fn item(&self) -> &EventTimelineItem {
+        self
+    }
 }
 
-impl Message {
-    #[inline]
-    pub fn item(&self) -> &EventTimelineItem {
-        &self.item
-    }
-    pub fn html(&self) -> Option<&StyleTree> {
-        self.html.as_ref()
-    }
-    pub fn body(&self) -> Cow<'_, str> {
+pub trait MessageExt {
+    fn item(&self) -> &EventTimelineItem;
+    fn body(&self) -> Cow<'_, str> {
         #[allow(unused)]
         match self.item().content() {
             TimelineItemContent::MsgLike(content) => body_cow_msglike(content),
@@ -764,40 +766,32 @@ impl Message {
             },
         }
     }
-    pub fn sender(&self) -> &UserId {
+    fn sender(&self) -> &UserId {
         self.item().sender()
     }
-    pub fn set_downloaded(&mut self) {
-        self.downloaded = true;
+    fn image_preview(&self) -> Option<&MediaSource> {
+        if let MessageType::Image(c) = self.item().content().as_message()?.msgtype() {
+            Some(&c.source)
+        } else {
+            None
+        }
     }
-    pub fn image_preview(&self) -> Option<&MediaSource> {
-        self.image_preview.as_ref()
-    }
-    pub fn insert_image_preview(&mut self, preview: MediaSource) {
-        self.image_preview = Some(preview);
-    }
-    pub fn timestamp(&self) -> MessageTimeStamp {
+    fn message_timestamp(&self) -> MessageTimeStamp {
         self.item().timestamp().into()
     }
 
-    pub fn is_emote(&self) -> bool {
+    fn is_emote(&self) -> bool {
         self.item()
             .content()
             .as_message()
             .is_some_and(|msg| matches!(msg.msgtype(), MessageType::Emote(_)))
     }
 
-    pub fn new(item: EventTimelineItem) -> Self {
-        let html = generate_html(&item);
-
-        Message { item, downloaded: false, html, image_preview: None }
-    }
-
-    pub fn reply_to(&self) -> Option<OwnedEventId> {
+    fn reply_to(&self) -> Option<OwnedEventId> {
         Some(self.item().content().as_msglike()?.in_reply_to.as_ref()?.event_id.clone())
     }
 
-    pub fn thread_root(&self) -> Option<OwnedEventId> {
+    fn thread_root(&self) -> Option<OwnedEventId> {
         self.item().content().as_msglike()?.thread_root.clone()
     }
 
@@ -829,8 +823,8 @@ impl Message {
     ) -> MessageFormatter<'a> {
         let orig = width;
         let date = match &prev {
-            Some(prev) if prev.timestamp().same_day(&self.timestamp()) => None,
-            _ => self.timestamp().show_date(),
+            Some(prev) if prev.message_timestamp().same_day(&self.message_timestamp()) => None,
+            _ => self.message_timestamp().show_date(),
         };
         let user_gutter = settings.tunables.user_gutter_width;
 
@@ -840,7 +834,7 @@ impl Message {
             let cols = MessageColumns::Four;
             let fill = width - user_gutter - TIME_GUTTER - READ_GUTTER;
             let user = self.show_sender(prev, true, info, settings);
-            let time = Some(self.timestamp().show_time());
+            let time = Some(self.message_timestamp().show_time());
             let read = self
                 .item()
                 .read_receipts()
@@ -854,7 +848,7 @@ impl Message {
             let cols = MessageColumns::Three;
             let fill = width - user_gutter - TIME_GUTTER;
             let user = self.show_sender(prev, true, info, settings);
-            let time = Some(self.timestamp().show_time());
+            let time = Some(self.message_timestamp().show_time());
             let read = Vec::new();
 
             MessageFormatter { settings, cols, orig, fill, user, date, time, read }
@@ -880,7 +874,7 @@ impl Message {
     /// Render the message as a [Text] object for the terminal.
     ///
     /// This will also get the image preview Protocol with an x/y offset.
-    pub fn show_with_preview<'a>(
+    fn show_with_preview<'a>(
         &'a self,
         prev: Option<&Message>,
         selected: bool,
@@ -888,6 +882,7 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
+        thread: &'a Messages,
     ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
         let width = vwctx.get_width();
 
@@ -904,11 +899,11 @@ impl Message {
             .and_then(|e| info.get_event(&e));
         let proto_reply = reply.as_ref().and_then(|r| {
             // Format the reply header, push it into the `Text` buffer, and get any image.
-            fmt.push_in_reply(r, style, &mut text, info, settings, previews)
+            fmt.push_in_reply(r, style, &mut text, info, settings, previews, thread)
         });
 
         // Now show the message contents, and the inlined reply if we couldn't find it above.
-        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews);
+        let (msg, proto) = self.show_msg(width, style, reply.is_some(), settings, previews, thread);
 
         // Given our text so far, determine the image offset.
         let proto_main = proto.map(|p| {
@@ -945,7 +940,7 @@ impl Message {
         (text, [proto_main, proto_reply])
     }
 
-    pub fn show<'a>(
+    fn show<'a>(
         &'a self,
         prev: Option<&Message>,
         selected: bool,
@@ -953,8 +948,10 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
+        thread: &'a Messages,
     ) -> Text<'a> {
-        self.show_with_preview(prev, selected, vwctx, info, settings, previews).0
+        self.show_with_preview(prev, selected, vwctx, info, settings, previews, thread)
+            .0
     }
 
     fn show_msg<'a>(
@@ -964,8 +961,9 @@ impl Message {
         hide_reply: bool,
         settings: &'a ApplicationSettings,
         previews: &'a PreviewManager,
+        thread: &'a Messages,
     ) -> (Text<'a>, Option<&'a Protocol>) {
-        if let Some(html) = &self.html {
+        if let Some(html) = thread.get_html(self.item().event_id()) {
             (html.to_text(width, style, hide_reply, settings), None)
         } else {
             let mut msg = self.body();
@@ -973,26 +971,21 @@ impl Message {
                 msg = Cow::Owned(replace_emojis_in_str(msg.as_ref()));
             }
 
-            if self.downloaded {
-                msg.to_mut().push_str(" \u{2705}");
-            }
-
             let mut proto = None;
-            let placeholder =
-                match self.image_preview.as_ref().and_then(|source| previews.get(source)) {
-                    None => None,
-                    Some(ImageStatus::Queued(image_preview_size)) => {
-                        placeholder_frame(Some("Queued..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Downloading(image_preview_size)) => {
-                        placeholder_frame(Some("Downloading..."), width, image_preview_size)
-                    },
-                    Some(ImageStatus::Loaded(backend)) => {
-                        proto = Some(backend);
-                        placeholder_frame(Some("No Space..."), width, &backend.area().into())
-                    },
-                    Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
-                };
+            let placeholder = match self.image_preview().and_then(|source| previews.get(source)) {
+                None => None,
+                Some(ImageStatus::Queued(image_preview_size)) => {
+                    placeholder_frame(Some("Queued..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Downloading(image_preview_size)) => {
+                    placeholder_frame(Some("Downloading..."), width, image_preview_size)
+                },
+                Some(ImageStatus::Loaded(backend)) => {
+                    proto = Some(backend);
+                    placeholder_frame(Some("No Space..."), width, &backend.area().into())
+                },
+                Some(ImageStatus::Error(err)) => Some(format!("[Image error: {err}]\n")),
+            };
 
             if let Some(placeholder) = placeholder {
                 msg.to_mut().insert_str(0, &placeholder);
@@ -1019,7 +1012,7 @@ impl Message {
     ) -> Option<Span<'a>> {
         if let Some(prev) = prev {
             if self.sender() == prev.sender() &&
-                self.timestamp().same_day(&prev.timestamp()) &&
+                self.message_timestamp().same_day(&prev.message_timestamp()) &&
                 !self.is_emote()
             {
                 return None;
@@ -1038,13 +1031,6 @@ impl Message {
         };
 
         Span::styled(sender, style).into()
-    }
-
-    #[allow(unused)]
-    pub fn redact(&mut self, redaction: SyncRoomRedactionEvent, rules: &RedactionRules) {
-        self.html = None;
-        self.downloaded = false;
-        self.image_preview = None;
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -143,8 +143,9 @@ fn handle_update(
                 }
             }
         },
+        VectorDiff::Clear | VectorDiff::Remove { .. } => (),
         _ => {
-            unimplemented!("these vector operations aren't used by the sdk")
+            unimplemented!("these vector operations aren't used by the sdk: {update:?}")
         },
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1068,39 +1068,36 @@ impl<'a> MessageFormatter<'a> {
 pub type Message = EventTimelineItem;
 
 impl MessageExt for Message {
-    #[inline]
     fn content(&self) -> &TimelineItemContent {
         self.content()
     }
 
-    #[inline]
     fn sender(&self) -> &UserId {
         self.sender()
     }
 
-    #[inline]
     fn sender_profile(&self) -> &TimelineDetails<Profile> {
         self.sender_profile()
     }
 
-    #[inline]
     fn message_timestamp(&self) -> MessageTimeStamp {
         self.timestamp().into()
     }
 
-    #[inline]
     fn identifier(&self) -> TimelineEventItemId {
         self.identifier()
     }
 
-    #[inline]
     fn is_local_echo(&self) -> bool {
         self.is_local_echo()
     }
 
-    #[inline]
     fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)> {
         self.read_receipts().iter()
+    }
+
+    fn is_edited(&self) -> bool {
+        self.latest_edit_json().is_some()
     }
 }
 
@@ -1132,6 +1129,10 @@ impl MessageExt for EmbeddedEvent {
     fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)> {
         vec![].into_iter()
     }
+
+    fn is_edited(&self) -> bool {
+        false
+    }
 }
 
 pub trait MessageExt {
@@ -1142,6 +1143,7 @@ pub trait MessageExt {
     fn identifier(&self) -> TimelineEventItemId;
     fn is_local_echo(&self) -> bool;
     fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)>;
+    fn is_edited(&self) -> bool;
 
     fn body(&self) -> Cow<'_, str> {
         #[allow(unused)]
@@ -1289,6 +1291,17 @@ pub trait MessageExt {
         if text.lines.is_empty() {
             // If there was nothing in the body, just show an empty message.
             fmt.push_spans(space_span(width, style).into(), style, &mut text);
+        }
+
+        if self.is_edited() {
+            fmt.push_spans(
+                Line::from(vec![
+                    Span::styled("(edited)", style.fg(Color::Gray)),
+                    space_span(fmt.width() - 8, style),
+                ]),
+                style,
+                &mut text,
+            );
         }
 
         if settings.tunables.reaction_display {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -386,14 +386,6 @@ impl Messages {
                 .fetching = false;
         });
     }
-
-    pub fn main() -> Self {
-        todo!()
-    }
-
-    pub fn thread(_root: OwnedEventId) -> Self {
-        todo!()
-    }
 }
 
 pub struct MessagesRange<'a> {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -108,6 +108,9 @@ pub struct Messages {
 }
 
 impl Messages {
+    pub fn timeline(&self) -> &Timeline {
+        &self.timeline
+    }
     pub fn receipt_thread(&self) -> &ReceiptThread {
         &self.thread
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -6,9 +6,7 @@ use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
-use std::iter::FusedIterator;
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
 use chrono::{DateTime, Local as LocalTz};
 use humansize::{format_size, DECIMAL};
@@ -16,14 +14,19 @@ use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::room_version_rules::RedactionRules;
 use matrix_sdk::ruma::UserId;
-use matrix_sdk_ui::timeline::TimelineItem;
+use matrix_sdk_ui::timeline::{
+    EventTimelineItem,
+    MsgLikeContent,
+    MsgLikeKind,
+    ReactionsByKeyBySender,
+    TimelineItemContent,
+};
 use matrix_sdk_ui::Timeline;
 use serde_json::json;
 use unicode_width::UnicodeWidthStr;
 
 use matrix_sdk::ruma::{
     events::{
-        relation::Thread,
         room::{
             encrypted::{
                 OriginalRoomEncryptedEvent,
@@ -36,7 +39,6 @@ use matrix_sdk::ruma::{
                 MessageType,
                 OriginalRoomMessageEvent,
                 RedactedRoomMessageEvent,
-                Relation,
                 RoomMessageEvent,
                 RoomMessageEventContent,
             },
@@ -64,6 +66,7 @@ use modalkit::prelude::*;
 use ratatui_image::protocol::Protocol;
 
 use crate::config::ImagePreviewSize;
+use crate::message::state::{body_cow_membership, body_cow_profile};
 use crate::preview::{ImageStatus, PreviewManager};
 use crate::{
     base::RoomInfo,
@@ -138,12 +141,6 @@ impl Messages {
     pub fn last_mut(&mut self) -> Option<&mut Message> {
         self.messages.last_entry().map(|o| o.into_mut())
     }
-    pub fn iter(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (&MessageKey, &Message)> + FusedIterator + ExactSizeIterator
-    {
-        self.messages.iter()
-    }
     pub fn range(
         &self,
         range: impl RangeBounds<MessageKey>,
@@ -152,7 +149,7 @@ impl Messages {
     }
 
     #[allow(unused)]
-    pub fn new(thread: ReceiptThread) -> Self {
+    fn new(thread: ReceiptThread) -> Self {
         let timeline = todo!();
         Self { messages: Default::default(), thread, timeline }
     }
@@ -516,35 +513,6 @@ impl MessageEvent {
         }
     }
 
-    pub fn content(&self) -> Option<&RoomMessageEventContent> {
-        match self {
-            MessageEvent::EncryptedOriginal(_) => None,
-            MessageEvent::Original(ev) => Some(&ev.content),
-            MessageEvent::EncryptedRedacted(_) => None,
-            MessageEvent::Redacted(_) => None,
-            MessageEvent::State(_) => None,
-            MessageEvent::Local(_, content) => Some(content),
-        }
-    }
-
-    pub fn is_emote(&self) -> bool {
-        matches!(
-            self.content(),
-            Some(RoomMessageEventContent { msgtype: MessageType::Emote(_), .. })
-        )
-    }
-
-    pub fn body(&self) -> Cow<'_, str> {
-        match self {
-            MessageEvent::EncryptedOriginal(_) => "[Unable to decrypt message]".into(),
-            MessageEvent::Original(ev) => body_cow_content(&ev.content),
-            MessageEvent::EncryptedRedacted(ev) => body_cow_reason(&ev.unsigned),
-            MessageEvent::Redacted(ev) => body_cow_reason(&ev.unsigned),
-            MessageEvent::State(ev) => body_cow_state(ev),
-            MessageEvent::Local(_, content) => body_cow_content(content),
-        }
-    }
-
     pub fn html(&self) -> Option<StyleTree> {
         let content = match self {
             MessageEvent::EncryptedOriginal(_) => return None,
@@ -609,8 +577,21 @@ macro_rules! display_file_to_text {
     };
 }
 
-fn body_cow_content(content: &RoomMessageEventContent) -> Cow<'_, str> {
-    let s = match &content.msgtype {
+fn body_cow_msglike(content: &MsgLikeContent) -> Cow<'_, str> {
+    match &content.kind {
+        MsgLikeKind::Message(message) => body_cow_content(message.msgtype()),
+        MsgLikeKind::Sticker(sticker) => Cow::Owned(format!("Alt: {}", sticker.content().body)),
+        MsgLikeKind::Poll(_) => {
+            // TODO: implement
+            Cow::Borrowed("[Poll]")
+        },
+        MsgLikeKind::Redacted => Cow::Borrowed("[Redacted]"),
+        MsgLikeKind::UnableToDecrypt(_) => Cow::Borrowed("[Unable to decrypt message]"),
+    }
+}
+
+fn body_cow_content(msgtype: &MessageType) -> Cow<'_, str> {
+    let s = match msgtype {
         MessageType::Text(content) => content.body.as_str(),
         MessageType::VerificationRequest(_) => "[Verification Request]",
         MessageType::Emote(content) => content.body.as_ref(),
@@ -629,24 +610,10 @@ fn body_cow_content(content: &RoomMessageEventContent) -> Cow<'_, str> {
         MessageType::Video(content) => {
             display_file_to_text!(Video, content);
         },
-        _ => content.body(),
+        _ => msgtype.body(),
     };
 
     Cow::Borrowed(s)
-}
-
-fn body_cow_reason(unsigned: &RedactedUnsigned) -> Cow<'_, str> {
-    let reason = unsigned
-        .redacted_because
-        .deserialize()
-        .ok()
-        .and_then(|ev| ev.content.reason);
-
-    if let Some(r) = reason {
-        Cow::Owned(format!("[Redacted: {r:?}]"))
-    } else {
-        Cow::Borrowed("[Redacted]")
-    }
 }
 
 enum MessageColumns {
@@ -789,11 +756,7 @@ impl<'a> MessageFormatter<'a> {
         previews: &'a PreviewManager,
     ) -> Option<ProtocolPreview<'a>> {
         let reply_style = if settings.tunables.message_user_color {
-            if let Some(user_id) = msg.sender() {
-                style.patch(settings.get_user_color(user_id))
-            } else {
-                style
-            }
+            style.patch(settings.get_user_color(msg.sender()))
         } else {
             style
         };
@@ -837,12 +800,17 @@ impl<'a> MessageFormatter<'a> {
         proto
     }
 
-    fn push_reactions(&mut self, counts: Vec<(&'a str, usize)>, style: Style, text: &mut Text<'a>) {
+    fn push_reactions(
+        &mut self,
+        reactions: &'a ReactionsByKeyBySender,
+        style: Style,
+        text: &mut Text<'a>,
+    ) {
         let mut emojis = printer::TextPrinter::new(self.width(), style, false, self.settings);
-        let mut reactions = 0;
+        let mut n_pushed = 0;
 
-        for (key, count) in counts {
-            if reactions != 0 {
+        for (key, counts) in reactions.iter() {
+            if n_pushed != 0 {
                 emojis.push_str(" ", style);
             }
 
@@ -867,18 +835,18 @@ impl<'a> MessageFormatter<'a> {
             emojis.push_str("[", style);
             emojis.push_str(name, style);
             emojis.push_str(" ", style);
-            emojis.push_span_nobreak(Span::styled(count.to_string(), style));
+            emojis.push_span_nobreak(Span::styled(counts.len().to_string(), style));
             emojis.push_str("]", style);
 
-            reactions += 1;
+            n_pushed += 1;
         }
 
-        if reactions > 0 {
+        if n_pushed > 0 {
             self.push_text(emojis.finish(), style, text);
         }
     }
 
-    fn push_thread_reply_count(&mut self, len: usize, text: &mut Text<'a>) {
+    fn push_thread_reply_count(&mut self, len: u32, text: &mut Text<'a>) {
         if len == 0 {
             return;
         }
@@ -902,7 +870,7 @@ impl<'a> MessageFormatter<'a> {
 }
 
 pub struct Message {
-    item: Arc<TimelineItem>,
+    item: EventTimelineItem,
 
     event: MessageEvent,
     timestamp: MessageTimeStamp,
@@ -912,7 +880,8 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn item(&self) -> &Arc<TimelineItem> {
+    #[inline]
+    pub fn item(&self) -> &EventTimelineItem {
         &self.item
     }
     pub fn html(&self) -> Option<&StyleTree> {
@@ -922,7 +891,18 @@ impl Message {
         self.html = html;
     }
     pub fn body(&self) -> Cow<'_, str> {
-        self.event.body()
+        #[allow(unused)]
+        match self.item().content() {
+            TimelineItemContent::MsgLike(content) => body_cow_msglike(content),
+            TimelineItemContent::MembershipChange(change) => body_cow_membership(change),
+            TimelineItemContent::ProfileChange(change) => body_cow_profile(change),
+            TimelineItemContent::OtherState(change) => body_cow_state(change),
+            TimelineItemContent::FailedToParseMessageLike { event_type, error } => todo!(),
+            TimelineItemContent::FailedToParseState { event_type, state_key, error } => todo!(),
+            TimelineItemContent::CallInvite | TimelineItemContent::CallNotify => {
+                Cow::Borrowed("* started a call")
+            },
+        }
     }
     pub fn event(&self) -> &MessageEvent {
         &self.event
@@ -930,8 +910,8 @@ impl Message {
     pub fn event_mut(&mut self) -> &mut MessageEvent {
         &mut self.event
     }
-    pub fn sender(&self) -> Option<&UserId> {
-        self.item.as_event().map(|ev| ev.sender())
+    pub fn sender(&self) -> &UserId {
+        self.item().sender()
     }
     pub fn set_downloaded(&mut self) {
         self.downloaded = true;
@@ -941,6 +921,13 @@ impl Message {
     }
     pub fn insert_image_preview(&mut self, preview: MediaSource) {
         self.image_preview = Some(preview);
+    }
+
+    pub fn is_emote(&self) -> bool {
+        self.item()
+            .content()
+            .as_message()
+            .is_some_and(|msg| matches!(msg.msgtype(), MessageType::Emote(_)))
     }
 
     #[allow(unused)]
@@ -960,45 +947,11 @@ impl Message {
     }
 
     pub fn reply_to(&self) -> Option<OwnedEventId> {
-        let content = match &self.event {
-            MessageEvent::EncryptedOriginal(_) => return None,
-            MessageEvent::EncryptedRedacted(_) => return None,
-            MessageEvent::Local(_, content) => content,
-            MessageEvent::Original(ev) => &ev.content,
-            MessageEvent::Redacted(_) => return None,
-            MessageEvent::State(_) => return None,
-        };
-
-        match &content.relates_to {
-            Some(Relation::Reply { in_reply_to }) => Some(in_reply_to.event_id.clone()),
-            Some(Relation::Thread(Thread {
-                in_reply_to: Some(in_reply_to),
-                is_falling_back: false,
-                ..
-            })) => Some(in_reply_to.event_id.clone()),
-            Some(_) | None => None,
-        }
+        Some(self.item().content().as_msglike()?.in_reply_to.as_ref()?.event_id.clone())
     }
 
     pub fn thread_root(&self) -> Option<OwnedEventId> {
-        let content = match &self.event {
-            MessageEvent::EncryptedOriginal(_) => return None,
-            MessageEvent::EncryptedRedacted(_) => return None,
-            MessageEvent::Local(_, content) => content,
-            MessageEvent::Original(ev) => &ev.content,
-            MessageEvent::Redacted(_) => return None,
-            MessageEvent::State(_) => return None,
-        };
-
-        match &content.relates_to {
-            Some(Relation::Thread(Thread {
-                event_id,
-                in_reply_to: Some(in_reply_to),
-                is_falling_back: true,
-                ..
-            })) if event_id == &in_reply_to.event_id => Some(event_id.clone()),
-            Some(_) | None => None,
-        }
+        self.item().content().as_msglike()?.thread_root.clone()
     }
 
     fn get_render_style(&self, selected: bool, settings: &ApplicationSettings) -> Style {
@@ -1013,10 +966,8 @@ impl Message {
         }
 
         if settings.tunables.message_user_color {
-            if let Some(user_id) = self.sender() {
-                let color = settings.get_user_color(user_id);
-                style = style.fg(color);
-            }
+            let color = settings.get_user_color(self.sender());
+            style = style.fg(color);
         }
 
         return style;
@@ -1043,12 +994,12 @@ impl Message {
             let fill = width - user_gutter - TIME_GUTTER - READ_GUTTER;
             let user = self.show_sender(prev, true, info, settings);
             let time = self.timestamp.show_time();
-            let read = info
-                .event_receipts
-                .values()
-                .filter_map(|receipts| receipts.get(self.event.event_id()))
-                .flat_map(|read| read.iter())
-                .map(|user_id| user_id.to_owned())
+            let read = self
+                .item()
+                .read_receipts()
+                .iter()
+                .filter(|(_, receipt)| !matches!(receipt.thread, ReceiptThread::Unthreaded))
+                .map(|(user_id, _)| user_id.to_owned())
                 .collect();
 
             MessageFormatter { settings, cols, orig, fill, user, date, time, read }
@@ -1099,6 +1050,7 @@ impl Message {
         let width = fmt.width();
 
         // Show the message that this one replied to, if any.
+        // TODO: use `InReplyToDetails::event`
         let reply = self
             .reply_to()
             .or_else(|| self.thread_root())
@@ -1129,12 +1081,18 @@ impl Message {
         }
 
         if settings.tunables.reaction_display {
-            let reactions = info.get_reactions(self.event.event_id());
-            fmt.push_reactions(reactions, style, &mut text);
+            if let Some(msg) = self.item().content().as_msglike() {
+                fmt.push_reactions(&msg.reactions, style, &mut text);
+            }
         }
 
-        if let Some(thread) = info.get_thread(Some(self.event.event_id())) {
-            fmt.push_thread_reply_count(thread.len(), &mut text);
+        if let Some(thread) = self
+            .item()
+            .content()
+            .as_msglike()
+            .and_then(|msg| msg.thread_summary.as_ref())
+        {
+            fmt.push_thread_reply_count(thread.num_replies, &mut text);
         }
 
         (text, [proto_main, proto_reply])
@@ -1163,7 +1121,7 @@ impl Message {
         if let Some(html) = &self.html {
             (html.to_text(width, style, hide_reply, settings), None)
         } else {
-            let mut msg = self.event.body();
+            let mut msg = self.body();
             if settings.tunables.message_shortcode_display {
                 msg = Cow::Owned(replace_emojis_in_str(msg.as_ref()));
             }
@@ -1202,9 +1160,7 @@ impl Message {
         info: &'a RoomInfo,
         settings: &'a ApplicationSettings,
     ) -> Span<'a> {
-        self.sender()
-            .map(|user_id| settings.get_user_span(user_id, info))
-            .unwrap_or_default()
+        settings.get_user_span(self.sender(), info)
     }
 
     fn show_sender<'a>(
@@ -1217,7 +1173,7 @@ impl Message {
         if let Some(prev) = prev {
             if self.sender() == prev.sender() &&
                 self.timestamp.same_day(&prev.timestamp) &&
-                !self.event.is_emote()
+                !self.is_emote()
             {
                 return None;
             }
@@ -1238,7 +1194,7 @@ impl Message {
     }
 
     pub fn redact(&mut self, redaction: SyncRoomRedactionEvent, rules: &RedactionRules) {
-        self.event.redact(redaction, rules);
+        self.event_mut().redact(redaction, rules);
         self.html = None;
         self.downloaded = false;
         self.image_preview = None;
@@ -1299,7 +1255,7 @@ impl From<AnySyncStateEvent> for Message {
 
 impl Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.event.body())
+        write!(f, "{}", self.body())
     }
 }
 
@@ -1532,78 +1488,78 @@ pub mod tests {
     #[test]
     fn test_display_attachment_size() {
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+            body_cow_content(&MessageType::Image(
                 ImageMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::default()))
-            ))),
+            )),
             "[Attached Image: Alt text]".to_string()
         );
 
         let mut info = ImageInfo::default();
         info.size = Some(442630_u32.into());
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+            body_cow_content(&MessageType::Image(
                 ImageMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::new(info)))
-            ))),
+            )),
             "[Attached Image: Alt text (442.63 kB)]".to_string()
         );
 
         let mut info = ImageInfo::default();
         info.size = Some(12_u32.into());
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::Image(
+            body_cow_content(&MessageType::Image(
                 ImageMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::new(info)))
-            ))),
+            )),
             "[Attached Image: Alt text (12 B)]".to_string()
         );
 
         let mut info = AudioInfo::default();
         info.size = Some(4294967295_u32.into());
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::Audio(
+            body_cow_content(&MessageType::Audio(
                 AudioMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::new(info)))
-            ))),
+            )),
             "[Attached Audio: Alt text (4.29 GB)]".to_string()
         );
 
         let mut info = FileInfo::default();
         info.size = Some(4426300_u32.into());
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::File(
+            body_cow_content(&MessageType::File(
                 FileMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::new(info)))
-            ))),
+            )),
             "[Attached File: Alt text (4.43 MB)]".to_string()
         );
 
         let mut info = VideoInfo::default();
         info.size = Some(44000_u32.into());
         assert_eq!(
-            body_cow_content(&RoomMessageEventContent::new(MessageType::Video(
+            body_cow_content(&MessageType::Video(
                 VideoMessageEventContent::plain(
                     "Alt text".to_string(),
                     "mxc://matrix.org/jDErsDugkNlfavzLTjJNUKAH".into()
                 )
                 .info(Some(Box::new(info)))
-            ))),
+            )),
             "[Attached Video: Alt text (44 kB)]".to_string()
         );
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -74,6 +74,8 @@ pub use self::compose::text_to_message;
 use self::state::{body_cow_state, html_state};
 pub use html::TreeGenState;
 
+const MIN_MSG_LOAD: u16 = 50;
+
 type ProtocolPreview<'a> = (&'a Protocol, u16, u16);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,12 +212,19 @@ async fn handle_updates(
 }
 
 pub struct Messages {
-    timeline: Timeline,
+    timeline: Arc<Timeline>,
+
+    /// The thread root of the timeline
+    thread: Option<OwnedEventId>,
+
     messages: Vector<Arc<TimelineItem>>,
 
     /// This is the index of the first element in the vector when this object was created. This is
     /// used by [`MessageKey`] as a referenc because the vector can be extended in both directions.
     start_element: usize,
+
+    /// Whether more history is currently being loaded.
+    pub fetching: bool,
 }
 
 impl Messages {
@@ -290,6 +299,8 @@ impl Messages {
             .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
     }
 
+    /// This must be called while `store` is locked and must be inserted in the store before it is
+    /// unlocked.
     pub async fn new(
         room: &Room,
         thread: Option<OwnedEventId>,
@@ -307,12 +318,14 @@ impl Messages {
             .build()
             .await?;
 
-        // TODO: load in background
-        timeline.paginate_backwards(50).await?;
-
         let (messages, updates) = timeline.subscribe().await;
 
-        tokio::spawn(handle_updates(room.room_id().to_owned(), thread, store, updates));
+        tokio::spawn(handle_updates(
+            room.room_id().to_owned(),
+            thread.clone(),
+            Arc::clone(&store),
+            updates,
+        ));
 
         let htmls = messages
             .iter()
@@ -320,7 +333,57 @@ impl Messages {
             .filter_map(|item| generate_html(item).map(|html| (item.identifier(), html)))
             .collect();
 
-        Ok((Self { messages, timeline, start_element: 0 }, htmls))
+        let messages = Self {
+            messages,
+            timeline: timeline.into(),
+            start_element: 0,
+            thread,
+            fetching: false,
+        };
+
+        messages.paginate_backwards(store);
+
+        Ok((messages, htmls))
+    }
+
+    pub fn paginate_backwards(&self, store: AsyncProgramStore) {
+        let room_id = self.timeline().room().room_id().to_owned();
+        let thread = self.thread.clone();
+        let timeline = Arc::clone(&self.timeline);
+
+        tokio::spawn(async move {
+            if std::mem::replace(
+                &mut store
+                    .lock()
+                    .await
+                    .application
+                    .rooms
+                    .get_mut(&room_id)
+                    .expect("internal state inconsistent")
+                    .get_thread_mut(thread.as_deref())
+                    .expect("internal state inconsistent")
+                    .fetching,
+                true,
+            ) {
+                return;
+            }
+
+            if let Err(err) = timeline.paginate_backwards(MIN_MSG_LOAD).await {
+                tracing::warn!(?room_id, ?thread, "error while loading message history: {err}");
+                return;
+            }
+
+            store
+                .lock()
+                .await
+                .application
+                .rooms
+                .get_mut(&room_id)
+                .expect("internal state inconsistent")
+                .get_thread_mut(thread.as_deref())
+                .expect("internal state inconsistent")
+                .fetching = false;
+        });
     }
 
     pub fn main() -> Self {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1590,7 +1590,7 @@ pub trait TimelineItemExt {
                 item.show_with_preview(prev_sender, selected, vwctx, info, settings, previews)
             },
             TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
-                ("----------------------------".into(), [None, None])
+                ("-".repeat(vwctx.get_width()).into(), [None, None])
             },
             TimelineItemKind::Virtual(VirtualTimelineItem::TimelineStart) => {
                 ("--- Timeline Start ---".into(), [None, None])

--- a/src/message/state.rs
+++ b/src/message/state.rs
@@ -2,15 +2,18 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use matrix_sdk::ruma::{
-    events::{
-        room::member::MembershipChange,
-        AnyFullStateEventContent,
-        AnySyncStateEvent,
-        FullStateEventContent,
-    },
-    OwnedRoomId,
-    UserId,
+use matrix_sdk::ruma::events::{
+    AnyFullStateEventContent,
+    AnySyncStateEvent,
+    FullStateEventContent,
+};
+use matrix_sdk::ruma::{OwnedRoomId, UserId};
+use matrix_sdk_ui::timeline::{
+    AnyOtherFullStateEventContent,
+    MemberProfileChange,
+    MembershipChange,
+    OtherState,
+    RoomMembershipChange,
 };
 
 use super::html::{StyleTree, StyleTreeNode};
@@ -22,9 +25,102 @@ fn bold(s: impl Into<Cow<'static, str>>) -> StyleTreeNode {
     StyleTreeNode::Style(Box::new(text), bold)
 }
 
-pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
-    let event = match ev.content() {
-        AnyFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Original {
+pub fn body_cow_membership(change: &RoomMembershipChange) -> Cow<'static, str> {
+    let user = change.user_id();
+    let change = match change.change() {
+        None => {
+            format!("* changed {user} in unknown ways")
+        },
+        Some(MembershipChange::None) => {
+            format!("* did nothing to {user}")
+        },
+        Some(MembershipChange::Error) => {
+            format!("* failed to calculate membership change to {user}")
+        },
+        Some(MembershipChange::NotImplemented) => {
+            format!("* changed {user} in unknown ways")
+        },
+
+        Some(MembershipChange::Joined) => {
+            return Cow::Borrowed("* joined the room");
+        },
+        Some(MembershipChange::Left) => {
+            return Cow::Borrowed("* left the room");
+        },
+        Some(MembershipChange::Banned) => {
+            format!("* banned {user} from the room")
+        },
+        Some(MembershipChange::Unbanned) => {
+            format!("* unbanned {user} from the room")
+        },
+        Some(MembershipChange::Kicked) => {
+            format!("* kicked {user} from the room")
+        },
+        Some(MembershipChange::Invited) => {
+            format!("* invited {user} to the room")
+        },
+        Some(MembershipChange::KickedAndBanned) => {
+            format!("* kicked and banned {user} from the room")
+        },
+        Some(MembershipChange::InvitationAccepted) => {
+            return Cow::Borrowed("* accepted an invitation to join the room");
+        },
+        Some(MembershipChange::InvitationRejected) => {
+            return Cow::Borrowed("* rejected an invitation to join the room");
+        },
+        Some(MembershipChange::InvitationRevoked) => {
+            format!("* revoked an invitation for {user} to join the room")
+        },
+        Some(MembershipChange::Knocked) => {
+            return Cow::Borrowed("* would like to join the room");
+        },
+        Some(MembershipChange::KnockAccepted) => {
+            format!("* accepted the room knock from {user}")
+        },
+        Some(MembershipChange::KnockRetracted) => {
+            return Cow::Borrowed("* retracted their room knock");
+        },
+        Some(MembershipChange::KnockDenied) => {
+            format!("* rejected the room knock from {user}")
+        },
+    };
+
+    Cow::Owned(change)
+}
+
+pub fn body_cow_profile(change: &MemberProfileChange) -> Cow<'static, str> {
+    match (change.displayname_change(), change.avatar_url_change()) {
+        (Some(change), avatar_change) => {
+            let mut m = match (&change.old, &change.new) {
+                (None, Some(new)) => Cow::Owned(format!("* set their display name to {new:?}")),
+                (Some(old), Some(new)) => {
+                    Cow::Owned(format!("* changed their display name from {old} to {new}"))
+                },
+                (Some(_), None) => Cow::Borrowed("* unset their display name"),
+                (None, None) => Cow::Borrowed("* made an unknown change to their display name"),
+            };
+
+            if avatar_change.is_some() {
+                m.to_mut().push_str(" and changed their user avatar");
+            }
+
+            m
+        },
+        (None, Some(change)) => {
+            match (&change.old, &change.new) {
+                (None, Some(_)) => Cow::Borrowed("* added a user avatar"),
+                (Some(_), Some(_)) => Cow::Borrowed("* changed their user avatar"),
+                (Some(_), None) => Cow::Borrowed("* removed their user avatar"),
+                (None, None) => Cow::Borrowed("* made an unknown change to their user avatar"),
+            }
+        },
+        (None, None) => Cow::Borrowed("* changed their user profile"),
+    }
+}
+
+pub fn body_cow_state(change: &OtherState) -> Cow<'static, str> {
+    let event = match change.content() {
+        AnyOtherFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -42,7 +138,7 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
 
             m
         },
-        AnyFullStateEventContent::PolicyRuleServer(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::PolicyRuleServer(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -60,7 +156,7 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
 
             m
         },
-        AnyFullStateEventContent::PolicyRuleUser(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::PolicyRuleUser(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -78,8 +174,9 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
 
             m
         },
-        AnyFullStateEventContent::RoomAliases(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomAliases(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             let mut m = String::from("* set the room aliases to: ");
 
@@ -93,16 +190,16 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
 
             m
         },
-        AnyFullStateEventContent::RoomAvatar(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomAvatar(FullStateEventContent::Original {
             content,
             prev_content,
         }) => {
             let prev_url = prev_content.as_ref().and_then(|p| p.url.as_ref());
 
-            match (prev_url, content.url) {
+            match (prev_url, &content.url) {
                 (None, Some(_)) => return Cow::Borrowed("* added a room avatar"),
                 (Some(old), Some(new)) => {
-                    if old != &new {
+                    if old != new {
                         return Cow::Borrowed("* replaced the room avatar");
                     }
 
@@ -112,7 +209,7 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
                 (None, None) => return Cow::Borrowed("* updated the room avatar state"),
             }
         },
-        AnyFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Original {
             content,
             prev_content,
         }) => {
@@ -138,8 +235,9 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
                 },
             }
         },
-        AnyFullStateEventContent::RoomCreate(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomCreate(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             if content.federate {
                 return Cow::Borrowed("* created a federated room");
@@ -147,16 +245,18 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
                 return Cow::Borrowed("* created a non-federated room");
             }
         },
-        AnyFullStateEventContent::RoomEncryption(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomEncryption(FullStateEventContent::Original {
+            ..
+        }) => {
             return Cow::Borrowed("* updated the encryption settings for the room");
         },
-        AnyFullStateEventContent::RoomGuestAccess(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomGuestAccess(FullStateEventContent::Original {
             content,
             ..
         }) => {
             format!("* set guest access for the room to {:?}", content.guest_access.as_str())
         },
-        AnyFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -165,144 +265,40 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
                 content.history_visibility.as_str()
             )
         },
-        AnyFullStateEventContent::RoomJoinRules(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Original {
             content,
             ..
         }) => {
             format!("* update the join rules for the room to {:?}", content.join_rule.as_str())
         },
-        AnyFullStateEventContent::RoomMember(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomName(FullStateEventContent::Original {
             content,
-            prev_content,
+            ..
         }) => {
-            let Ok(state_key) = UserId::parse(ev.state_key()) else {
-                return Cow::Owned(format!(
-                    "* failed to calculate membership change for {:?}",
-                    ev.state_key()
-                ));
-            };
-
-            let prev_details = prev_content.as_ref().map(|p| p.details());
-            let change = content.membership_change(prev_details, ev.sender(), &state_key);
-
-            match change {
-                MembershipChange::None => {
-                    format!("* did nothing to {state_key}")
-                },
-                MembershipChange::Error => {
-                    format!("* failed to calculate membership change to {state_key}")
-                },
-                MembershipChange::Joined => {
-                    return Cow::Borrowed("* joined the room");
-                },
-                MembershipChange::Left => {
-                    return Cow::Borrowed("* left the room");
-                },
-                MembershipChange::Banned => {
-                    format!("* banned {state_key} from the room")
-                },
-                MembershipChange::Unbanned => {
-                    format!("* unbanned {state_key} from the room")
-                },
-                MembershipChange::Kicked => {
-                    format!("* kicked {state_key} from the room")
-                },
-                MembershipChange::Invited => {
-                    format!("* invited {state_key} to the room")
-                },
-                MembershipChange::KickedAndBanned => {
-                    format!("* kicked and banned {state_key} from the room")
-                },
-                MembershipChange::InvitationAccepted => {
-                    return Cow::Borrowed("* accepted an invitation to join the room");
-                },
-                MembershipChange::InvitationRejected => {
-                    return Cow::Borrowed("* rejected an invitation to join the room");
-                },
-                MembershipChange::InvitationRevoked => {
-                    format!("* revoked an invitation for {state_key} to join the room")
-                },
-                MembershipChange::Knocked => {
-                    return Cow::Borrowed("* would like to join the room");
-                },
-                MembershipChange::KnockAccepted => {
-                    format!("* accepted the room knock from {state_key}")
-                },
-                MembershipChange::KnockRetracted => {
-                    return Cow::Borrowed("* retracted their room knock");
-                },
-                MembershipChange::KnockDenied => {
-                    format!("* rejected the room knock from {state_key}")
-                },
-                MembershipChange::ProfileChanged { displayname_change, avatar_url_change } => {
-                    match (displayname_change, avatar_url_change) {
-                        (Some(change), avatar_change) => {
-                            let mut m = match (change.old, change.new) {
-                                (None, Some(new)) => {
-                                    format!("* set their display name to {new:?}")
-                                },
-                                (Some(old), Some(new)) => {
-                                    format!("* changed their display name from {old} to {new}")
-                                },
-                                (Some(_), None) => "* unset their display name".to_string(),
-                                (None, None) => {
-                                    "* made an unknown change to their display name".to_string()
-                                },
-                            };
-
-                            if avatar_change.is_some() {
-                                m.push_str(" and changed their user avatar");
-                            }
-
-                            m
-                        },
-                        (None, Some(change)) => {
-                            match (change.old, change.new) {
-                                (None, Some(_)) => {
-                                    return Cow::Borrowed("* added a user avatar");
-                                },
-                                (Some(_), Some(_)) => {
-                                    return Cow::Borrowed("* changed their user avatar");
-                                },
-                                (Some(_), None) => {
-                                    return Cow::Borrowed("* removed their user avatar");
-                                },
-                                (None, None) => {
-                                    return Cow::Borrowed(
-                                        "* made an unknown change to their user avatar",
-                                    );
-                                },
-                            }
-                        },
-                        (None, None) => {
-                            return Cow::Borrowed("* changed their user profile");
-                        },
-                    }
-                },
-                ev => {
-                    format!("* made an unknown membership change to {state_key}: {ev:?}")
-                },
-            }
-        },
-        AnyFullStateEventContent::RoomName(FullStateEventContent::Original { content, .. }) => {
             format!("* updated the room name to {:?}", content.name)
         },
-        AnyFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Original {
+            ..
+        }) => {
             return Cow::Borrowed("* updated the pinned events for the room");
         },
-        AnyFullStateEventContent::RoomPowerLevels(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomPowerLevels(FullStateEventContent::Original {
+            ..
+        }) => {
             return Cow::Borrowed("* updated the power levels for the room");
         },
-        AnyFullStateEventContent::RoomServerAcl(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomServerAcl(FullStateEventContent::Original {
+            ..
+        }) => {
             return Cow::Borrowed("* updated the room's server ACLs");
         },
-        AnyFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Original {
             content,
             ..
         }) => {
             format!("* sent a third-party invite to {:?}", content.display_name)
         },
-        AnyFullStateEventContent::RoomTombstone(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomTombstone(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -311,119 +307,90 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
                 content.replacement_room.as_str()
             )
         },
-        AnyFullStateEventContent::RoomTopic(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomTopic(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             format!("* set the room topic to {:?}", content.topic)
         },
-        AnyFullStateEventContent::SpaceChild(FullStateEventContent::Original { .. }) => {
-            format!("* added a space child: {}", ev.state_key())
+        AnyOtherFullStateEventContent::SpaceChild(FullStateEventContent::Original { .. }) => {
+            format!("* added a space child: {}", change.state_key())
         },
-        AnyFullStateEventContent::SpaceParent(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::SpaceParent(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             if content.canonical {
-                format!("* added a canonical parent space: {}", ev.state_key())
+                format!("* added a canonical parent space: {}", change.state_key())
             } else {
-                format!("* added a parent space: {}", ev.state_key())
+                format!("* added a parent space: {}", change.state_key())
             }
-        },
-        AnyFullStateEventContent::BeaconInfo(FullStateEventContent::Original { .. }) => {
-            return Cow::Borrowed("* shared beacon information");
-        },
-        AnyFullStateEventContent::CallMember(FullStateEventContent::Original { .. }) => {
-            return Cow::Borrowed("* updated membership for room call");
-        },
-        AnyFullStateEventContent::MemberHints(FullStateEventContent::Original {
-            content, ..
-        }) => {
-            let mut m = String::from("* updated the list of service members in the room hints: ");
-
-            for (i, member) in content.service_members.iter().enumerate() {
-                if i != 0 {
-                    m.push_str(", ");
-                }
-
-                m.push_str(member.as_str());
-            }
-
-            m
         },
 
         // Redacted variants of state events:
-        AnyFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated a room policy rule (redacted)");
         },
-        AnyFullStateEventContent::PolicyRuleServer(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleServer(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated a server policy rule (redacted)");
         },
-        AnyFullStateEventContent::PolicyRuleUser(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleUser(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated a user policy rule (redacted)");
         },
-        AnyFullStateEventContent::RoomAliases(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomAliases(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the room aliases for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomAvatar(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomAvatar(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the room avatar (redacted)");
         },
-        AnyFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the canonical alias for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomCreate(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomCreate(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* created the room (redacted)");
         },
-        AnyFullStateEventContent::RoomEncryption(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomEncryption(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the encryption settings for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomGuestAccess(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomGuestAccess(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed(
                 "* updated the guest access configuration for the room (redacted)",
             );
         },
-        AnyFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Redacted(
+            _,
+        )) => {
             return Cow::Borrowed("* updated history visilibity for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomJoinRules(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the join rules for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomMember(FullStateEventContent::Redacted(_)) => {
-            return Cow::Borrowed("* updated the room membership (redacted)");
-        },
-        AnyFullStateEventContent::RoomName(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomName(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the room name (redacted)");
         },
-        AnyFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the pinned events for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomPowerLevels(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomPowerLevels(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the power levels for the room (redacted)");
         },
-        AnyFullStateEventContent::RoomServerAcl(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomServerAcl(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the room's server ACLs (redacted)");
         },
-        AnyFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* sent a third-party invite (redacted)");
         },
-        AnyFullStateEventContent::RoomTombstone(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomTombstone(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* upgraded the room (redacted)");
         },
-        AnyFullStateEventContent::RoomTopic(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomTopic(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* updated the room topic (redacted)");
         },
-        AnyFullStateEventContent::SpaceChild(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::SpaceChild(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* added a space child (redacted)");
         },
-        AnyFullStateEventContent::SpaceParent(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::SpaceParent(FullStateEventContent::Redacted(_)) => {
             return Cow::Borrowed("* added a parent space (redacted)");
-        },
-        AnyFullStateEventContent::BeaconInfo(FullStateEventContent::Redacted(_)) => {
-            return Cow::Borrowed("* shared beacon information (redacted)");
-        },
-        AnyFullStateEventContent::CallMember(FullStateEventContent::Redacted(_)) => {
-            return Cow::Borrowed("Call membership changed");
-        },
-        AnyFullStateEventContent::MemberHints(FullStateEventContent::Redacted(_)) => {
-            return Cow::Borrowed("Member hints changed");
         },
 
         // Handle unknown events:
@@ -432,7 +399,7 @@ pub fn body_cow_state(ev: &AnySyncStateEvent) -> Cow<'static, str> {
         },
     };
 
-    return Cow::Owned(event);
+    Cow::Owned(event)
 }
 
 pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
@@ -586,6 +553,8 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             content,
             prev_content,
         }) => {
+            use matrix_sdk::ruma::events::room::member::MembershipChange;
+
             let Ok(state_key) = UserId::parse(ev.state_key()) else {
                 let prefix =
                     StyleTreeNode::Text("* failed to calculate membership change for ".into());

--- a/src/message/state.rs
+++ b/src/message/state.rs
@@ -2,12 +2,8 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use matrix_sdk::ruma::events::{
-    AnyFullStateEventContent,
-    AnySyncStateEvent,
-    FullStateEventContent,
-};
-use matrix_sdk::ruma::{OwnedRoomId, UserId};
+use matrix_sdk::ruma::events::FullStateEventContent;
+use matrix_sdk::ruma::OwnedRoomId;
 use matrix_sdk_ui::timeline::{
     AnyOtherFullStateEventContent,
     MemberProfileChange,
@@ -26,19 +22,19 @@ fn bold(s: impl Into<Cow<'static, str>>) -> StyleTreeNode {
 }
 
 pub fn body_cow_membership(change: &RoomMembershipChange) -> Cow<'static, str> {
-    let user = change.user_id();
+    let user_id = change.user_id();
     let change = match change.change() {
         None => {
-            format!("* changed {user} in unknown ways")
+            format!("* changed {user_id} in unknown ways")
         },
         Some(MembershipChange::None) => {
-            format!("* did nothing to {user}")
+            format!("* did nothing to {user_id}")
         },
         Some(MembershipChange::Error) => {
-            format!("* failed to calculate membership change to {user}")
+            format!("* failed to calculate membership change to {user_id}")
         },
         Some(MembershipChange::NotImplemented) => {
-            format!("* changed {user} in unknown ways")
+            format!("* changed {user_id} in unknown ways")
         },
 
         Some(MembershipChange::Joined) => {
@@ -48,19 +44,19 @@ pub fn body_cow_membership(change: &RoomMembershipChange) -> Cow<'static, str> {
             return Cow::Borrowed("* left the room");
         },
         Some(MembershipChange::Banned) => {
-            format!("* banned {user} from the room")
+            format!("* banned {user_id} from the room")
         },
         Some(MembershipChange::Unbanned) => {
-            format!("* unbanned {user} from the room")
+            format!("* unbanned {user_id} from the room")
         },
         Some(MembershipChange::Kicked) => {
-            format!("* kicked {user} from the room")
+            format!("* kicked {user_id} from the room")
         },
         Some(MembershipChange::Invited) => {
-            format!("* invited {user} to the room")
+            format!("* invited {user_id} to the room")
         },
         Some(MembershipChange::KickedAndBanned) => {
-            format!("* kicked and banned {user} from the room")
+            format!("* kicked and banned {user_id} from the room")
         },
         Some(MembershipChange::InvitationAccepted) => {
             return Cow::Borrowed("* accepted an invitation to join the room");
@@ -69,19 +65,19 @@ pub fn body_cow_membership(change: &RoomMembershipChange) -> Cow<'static, str> {
             return Cow::Borrowed("* rejected an invitation to join the room");
         },
         Some(MembershipChange::InvitationRevoked) => {
-            format!("* revoked an invitation for {user} to join the room")
+            format!("* revoked an invitation for {user_id} to join the room")
         },
         Some(MembershipChange::Knocked) => {
             return Cow::Borrowed("* would like to join the room");
         },
         Some(MembershipChange::KnockAccepted) => {
-            format!("* accepted the room knock from {user}")
+            format!("* accepted the room knock from {user_id}")
         },
         Some(MembershipChange::KnockRetracted) => {
             return Cow::Borrowed("* retracted their room knock");
         },
         Some(MembershipChange::KnockDenied) => {
-            format!("* rejected the room knock from {user}")
+            format!("* rejected the room knock from {user_id}")
         },
     };
 
@@ -402,9 +398,150 @@ pub fn body_cow_state(change: &OtherState) -> Cow<'static, str> {
     Cow::Owned(event)
 }
 
-pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
-    let children = match ev.content() {
-        AnyFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Original {
+pub fn html_membership(change: &RoomMembershipChange) -> StyleTree {
+    let user_id = StyleTreeNode::UserId(change.user_id().to_owned());
+
+    let children = match change.change() {
+        None => {
+            let prefix = StyleTreeNode::Text("* changed ".into());
+            let suffix = StyleTreeNode::Text(" in unknown ways".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::None) => {
+            let prefix = StyleTreeNode::Text("* did nothing to ".into());
+            vec![prefix, user_id]
+        },
+        Some(MembershipChange::Error) => {
+            let prefix = StyleTreeNode::Text("* failed to calculate membership change to ".into());
+            vec![prefix, user_id]
+        },
+        Some(MembershipChange::NotImplemented) => {
+            let prefix = StyleTreeNode::Text("* changed ".into());
+            let suffix = StyleTreeNode::Text(" in unknown ways".into());
+            vec![prefix, user_id, suffix]
+        },
+
+        Some(MembershipChange::Joined) => {
+            vec![StyleTreeNode::Text("* joined the room".into())]
+        },
+        Some(MembershipChange::Left) => {
+            vec![StyleTreeNode::Text("* left the room".into())]
+        },
+        Some(MembershipChange::Banned) => {
+            let prefix = StyleTreeNode::Text("* banned ".into());
+            let suffix = StyleTreeNode::Text(" from the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::Unbanned) => {
+            let prefix = StyleTreeNode::Text("* unbanned ".into());
+            let suffix = StyleTreeNode::Text(" from the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::Kicked) => {
+            let prefix = StyleTreeNode::Text("* kicked ".into());
+            let suffix = StyleTreeNode::Text(" from the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::Invited) => {
+            let prefix = StyleTreeNode::Text("* invited ".into());
+            let suffix = StyleTreeNode::Text(" to the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::KickedAndBanned) => {
+            let prefix = StyleTreeNode::Text("* kicked and banned ".into());
+            let suffix = StyleTreeNode::Text(" from the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::InvitationAccepted) => {
+            vec![StyleTreeNode::Text(
+                "* accepted an invitation to join the room".into(),
+            )]
+        },
+        Some(MembershipChange::InvitationRejected) => {
+            vec![StyleTreeNode::Text(
+                "* rejected an invitation to join the room".into(),
+            )]
+        },
+        Some(MembershipChange::InvitationRevoked) => {
+            let prefix = StyleTreeNode::Text("* revoked an invitation for ".into());
+            let suffix = StyleTreeNode::Text(" to join the room".into());
+            vec![prefix, user_id, suffix]
+        },
+        Some(MembershipChange::Knocked) => {
+            vec![StyleTreeNode::Text("* would like to join the room".into())]
+        },
+        Some(MembershipChange::KnockAccepted) => {
+            let prefix = StyleTreeNode::Text("* accepted the room knock from ".into());
+            vec![prefix, user_id]
+        },
+        Some(MembershipChange::KnockRetracted) => {
+            vec![StyleTreeNode::Text("* retracted their room knock".into())]
+        },
+        Some(MembershipChange::KnockDenied) => {
+            let prefix = StyleTreeNode::Text("* rejected the room knock from ".into());
+            vec![prefix, user_id]
+        },
+    };
+
+    StyleTree { children }
+}
+
+pub fn html_profile(change: &MemberProfileChange) -> StyleTree {
+    let user_id = change.user_id().to_owned();
+
+    let children = match (change.displayname_change(), change.avatar_url_change()) {
+        (Some(change), avatar_change) => {
+            let mut m = match (&change.old, &change.new) {
+                (None, Some(new)) => {
+                    vec![
+                        StyleTreeNode::Text("* set their display name to ".into()),
+                        StyleTreeNode::DisplayName(new.into(), user_id),
+                    ]
+                },
+                (Some(old), Some(new)) => {
+                    vec![
+                        StyleTreeNode::Text("* changed their display name from ".into()),
+                        StyleTreeNode::DisplayName(old.into(), user_id.clone()),
+                        StyleTreeNode::Text(" to ".into()),
+                        StyleTreeNode::DisplayName(new.into(), user_id),
+                    ]
+                },
+                (Some(_), None) => {
+                    vec![StyleTreeNode::Text("* unset their display name".into())]
+                },
+                (None, None) => {
+                    vec![StyleTreeNode::Text(
+                        "* made an unknown change to their display name".into(),
+                    )]
+                },
+            };
+
+            if avatar_change.is_some() {
+                m.push(StyleTreeNode::Text(" and changed their user avatar".into()));
+            }
+
+            m
+        },
+        (None, Some(change)) => {
+            let m = match (&change.old, &change.new) {
+                (None, Some(_)) => Cow::Borrowed("* added a user avatar"),
+                (Some(_), Some(_)) => Cow::Borrowed("* changed their user avatar"),
+                (Some(_), None) => Cow::Borrowed("* removed their user avatar"),
+                (None, None) => Cow::Borrowed("* made an unknown change to their user avatar"),
+            };
+
+            vec![StyleTreeNode::Text(m)]
+        },
+        (None, None) => {
+            vec![StyleTreeNode::Text("* changed their user profile".into())]
+        },
+    };
+    StyleTree { children }
+}
+
+pub fn html_state(change: &OtherState) -> StyleTree {
+    let children = match change.content() {
+        AnyOtherFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -422,7 +559,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             cs
         },
-        AnyFullStateEventContent::PolicyRuleServer(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::PolicyRuleServer(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -440,7 +577,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             cs
         },
-        AnyFullStateEventContent::PolicyRuleUser(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::PolicyRuleUser(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -458,8 +595,9 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             cs
         },
-        AnyFullStateEventContent::RoomAliases(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomAliases(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             let prefix = StyleTreeNode::Text("* set the room aliases to: ".into());
             let mut cs = vec![prefix];
@@ -474,16 +612,16 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             cs
         },
-        AnyFullStateEventContent::RoomAvatar(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomAvatar(FullStateEventContent::Original {
             content,
             prev_content,
         }) => {
             let prev_url = prev_content.as_ref().and_then(|p| p.url.as_ref());
 
-            let node = match (prev_url, content.url) {
+            let node = match (prev_url, &content.url) {
                 (None, Some(_)) => StyleTreeNode::Text("* added a room avatar".into()),
                 (Some(old), Some(new)) => {
-                    if old != &new {
+                    if old != new {
                         StyleTreeNode::Text("* replaced the room avatar".into())
                     } else {
                         StyleTreeNode::Text("* updated the room avatar state".into())
@@ -495,7 +633,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
 
             vec![node]
         },
-        AnyFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -510,8 +648,9 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
                 )]
             }
         },
-        AnyFullStateEventContent::RoomCreate(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomCreate(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             if content.federate {
                 vec![StyleTreeNode::Text("* created a federated room".into())]
@@ -519,12 +658,14 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
                 vec![StyleTreeNode::Text("* created a non-federated room".into())]
             }
         },
-        AnyFullStateEventContent::RoomEncryption(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomEncryption(FullStateEventContent::Original {
+            ..
+        }) => {
             vec![StyleTreeNode::Text(
                 "* updated the encryption settings for the room".into(),
             )]
         },
-        AnyFullStateEventContent::RoomGuestAccess(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomGuestAccess(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -532,7 +673,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let prefix = StyleTreeNode::Text("* set guest access for the room to ".into());
             vec![prefix, access]
         },
-        AnyFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -541,7 +682,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let vis = bold(format!("{:?}", content.history_visibility.as_str()));
             vec![prefix, vis]
         },
-        AnyFullStateEventContent::RoomJoinRules(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -549,179 +690,36 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let rule = bold(format!("{:?}", content.join_rule.as_str()));
             vec![prefix, rule]
         },
-        AnyFullStateEventContent::RoomMember(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomName(FullStateEventContent::Original {
             content,
-            prev_content,
+            ..
         }) => {
-            use matrix_sdk::ruma::events::room::member::MembershipChange;
-
-            let Ok(state_key) = UserId::parse(ev.state_key()) else {
-                let prefix =
-                    StyleTreeNode::Text("* failed to calculate membership change for ".into());
-                let user_id = bold(format!("{:?}", ev.state_key()));
-                let children = vec![prefix, user_id];
-
-                return StyleTree { children };
-            };
-
-            let prev_details = prev_content.as_ref().map(|p| p.details());
-            let change = content.membership_change(prev_details, ev.sender(), &state_key);
-            let user_id = StyleTreeNode::UserId(state_key.clone());
-
-            match change {
-                MembershipChange::None => {
-                    let prefix = StyleTreeNode::Text("* did nothing to ".into());
-                    vec![prefix, user_id]
-                },
-                MembershipChange::Error => {
-                    let prefix =
-                        StyleTreeNode::Text("* failed to calculate membership change to ".into());
-                    vec![prefix, user_id]
-                },
-                MembershipChange::Joined => {
-                    vec![StyleTreeNode::Text("* joined the room".into())]
-                },
-                MembershipChange::Left => {
-                    vec![StyleTreeNode::Text("* left the room".into())]
-                },
-                MembershipChange::Banned => {
-                    let prefix = StyleTreeNode::Text("* banned ".into());
-                    let suffix = StyleTreeNode::Text(" from the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::Unbanned => {
-                    let prefix = StyleTreeNode::Text("* unbanned ".into());
-                    let suffix = StyleTreeNode::Text(" from the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::Kicked => {
-                    let prefix = StyleTreeNode::Text("* kicked ".into());
-                    let suffix = StyleTreeNode::Text(" from the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::Invited => {
-                    let prefix = StyleTreeNode::Text("* invited ".into());
-                    let suffix = StyleTreeNode::Text(" to the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::KickedAndBanned => {
-                    let prefix = StyleTreeNode::Text("* kicked and banned ".into());
-                    let suffix = StyleTreeNode::Text(" from the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::InvitationAccepted => {
-                    vec![StyleTreeNode::Text(
-                        "* accepted an invitation to join the room".into(),
-                    )]
-                },
-                MembershipChange::InvitationRejected => {
-                    vec![StyleTreeNode::Text(
-                        "* rejected an invitation to join the room".into(),
-                    )]
-                },
-                MembershipChange::InvitationRevoked => {
-                    let prefix = StyleTreeNode::Text("* revoked an invitation for ".into());
-                    let suffix = StyleTreeNode::Text(" to join the room".into());
-                    vec![prefix, user_id, suffix]
-                },
-                MembershipChange::Knocked => {
-                    vec![StyleTreeNode::Text("* would like to join the room".into())]
-                },
-                MembershipChange::KnockAccepted => {
-                    let prefix = StyleTreeNode::Text("* accepted the room knock from ".into());
-                    vec![prefix, user_id]
-                },
-                MembershipChange::KnockRetracted => {
-                    vec![StyleTreeNode::Text("* retracted their room knock".into())]
-                },
-                MembershipChange::KnockDenied => {
-                    let prefix = StyleTreeNode::Text("* rejected the room knock from ".into());
-                    vec![prefix, user_id]
-                },
-                MembershipChange::ProfileChanged { displayname_change, avatar_url_change } => {
-                    match (displayname_change, avatar_url_change) {
-                        (Some(change), avatar_change) => {
-                            let mut m = match (change.old, change.new) {
-                                (None, Some(new)) => {
-                                    vec![
-                                        StyleTreeNode::Text("* set their display name to ".into()),
-                                        StyleTreeNode::DisplayName(new.into(), state_key),
-                                    ]
-                                },
-                                (Some(old), Some(new)) => {
-                                    vec![
-                                        StyleTreeNode::Text(
-                                            "* changed their display name from ".into(),
-                                        ),
-                                        StyleTreeNode::DisplayName(old.into(), state_key.clone()),
-                                        StyleTreeNode::Text(" to ".into()),
-                                        StyleTreeNode::DisplayName(new.into(), state_key),
-                                    ]
-                                },
-                                (Some(_), None) => {
-                                    vec![StyleTreeNode::Text("* unset their display name".into())]
-                                },
-                                (None, None) => {
-                                    vec![StyleTreeNode::Text(
-                                        "* made an unknown change to their display name".into(),
-                                    )]
-                                },
-                            };
-
-                            if avatar_change.is_some() {
-                                m.push(StyleTreeNode::Text(
-                                    " and changed their user avatar".into(),
-                                ));
-                            }
-
-                            m
-                        },
-                        (None, Some(change)) => {
-                            let m = match (change.old, change.new) {
-                                (None, Some(_)) => Cow::Borrowed("* added a user avatar"),
-                                (Some(_), Some(_)) => Cow::Borrowed("* changed their user avatar"),
-                                (Some(_), None) => Cow::Borrowed("* removed their user avatar"),
-                                (None, None) => {
-                                    Cow::Borrowed("* made an unknown change to their user avatar")
-                                },
-                            };
-
-                            vec![StyleTreeNode::Text(m)]
-                        },
-                        (None, None) => {
-                            vec![StyleTreeNode::Text("* changed their user profile".into())]
-                        },
-                    }
-                },
-                ev => {
-                    let prefix =
-                        StyleTreeNode::Text("* made an unknown membership change to ".into());
-                    let suffix = StyleTreeNode::Text(format!(": {ev:?}").into());
-                    vec![prefix, user_id, suffix]
-                },
-            }
-        },
-        AnyFullStateEventContent::RoomName(FullStateEventContent::Original { content, .. }) => {
             let prefix = StyleTreeNode::Text("* updated the room name to ".into());
             let name = bold(format!("{:?}", content.name));
             vec![prefix, name]
         },
-        AnyFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Original {
+            ..
+        }) => {
             vec![StyleTreeNode::Text(
                 "* updated the pinned events for the room".into(),
             )]
         },
-        AnyFullStateEventContent::RoomPowerLevels(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomPowerLevels(FullStateEventContent::Original {
+            ..
+        }) => {
             vec![StyleTreeNode::Text(
                 "* updated the power levels for the room".into(),
             )]
         },
-        AnyFullStateEventContent::RoomServerAcl(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::RoomServerAcl(FullStateEventContent::Original {
+            ..
+        }) => {
             vec![StyleTreeNode::Text(
                 "* updated the room's server ACLs".into(),
             )]
         },
-        AnyFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -729,7 +727,7 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let name = bold(format!("{:?}", content.display_name));
             vec![prefix, name]
         },
-        AnyFullStateEventContent::RoomTombstone(FullStateEventContent::Original {
+        AnyOtherFullStateEventContent::RoomTombstone(FullStateEventContent::Original {
             content,
             ..
         }) => {
@@ -737,26 +735,28 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
             let room = StyleTreeNode::RoomId(content.replacement_room.clone());
             vec![prefix, room]
         },
-        AnyFullStateEventContent::RoomTopic(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::RoomTopic(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             let prefix = StyleTreeNode::Text("* set the room topic to ".into());
             let topic = bold(format!("{:?}", content.topic));
             vec![prefix, topic]
         },
-        AnyFullStateEventContent::SpaceChild(FullStateEventContent::Original { .. }) => {
+        AnyOtherFullStateEventContent::SpaceChild(FullStateEventContent::Original { .. }) => {
             let prefix = StyleTreeNode::Text("* added a space child: ".into());
 
-            let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
+            let room_id = if let Ok(room_id) = OwnedRoomId::from_str(change.state_key()) {
                 StyleTreeNode::RoomId(room_id)
             } else {
-                bold(ev.state_key().to_string())
+                bold(change.state_key().to_string())
             };
 
             vec![prefix, room_id]
         },
-        AnyFullStateEventContent::SpaceParent(FullStateEventContent::Original {
-            content, ..
+        AnyOtherFullStateEventContent::SpaceParent(FullStateEventContent::Original {
+            content,
+            ..
         }) => {
             let prefix = if content.canonical {
                 StyleTreeNode::Text("* added a canonical parent space: ".into())
@@ -764,153 +764,113 @@ pub fn html_state(ev: &AnySyncStateEvent) -> StyleTree {
                 StyleTreeNode::Text("* added a parent space: ".into())
             };
 
-            let room_id = if let Ok(room_id) = OwnedRoomId::from_str(ev.state_key()) {
+            let room_id = if let Ok(room_id) = OwnedRoomId::from_str(change.state_key()) {
                 StyleTreeNode::RoomId(room_id)
             } else {
-                bold(ev.state_key().to_string())
+                bold(change.state_key().to_string())
             };
 
             vec![prefix, room_id]
         },
-        AnyFullStateEventContent::BeaconInfo(FullStateEventContent::Original { .. }) => {
-            vec![StyleTreeNode::Text("* shared beacon information".into())]
-        },
-        AnyFullStateEventContent::CallMember(FullStateEventContent::Original { .. }) => {
-            vec![StyleTreeNode::Text(
-                "* updated membership for room call".into(),
-            )]
-        },
-        AnyFullStateEventContent::MemberHints(FullStateEventContent::Original {
-            content, ..
-        }) => {
-            let prefix = StyleTreeNode::Text(
-                "* updated the list of service members in the room hints: ".into(),
-            );
-            let mut cs = vec![prefix];
-
-            for (i, member) in content.service_members.iter().enumerate() {
-                if i != 0 {
-                    cs.push(StyleTreeNode::Text(", ".into()));
-                }
-
-                cs.push(StyleTreeNode::UserId(member.clone()));
-            }
-
-            cs
-        },
 
         // Redacted variants of state events:
-        AnyFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated a room policy rule (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::PolicyRuleServer(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleServer(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated a server policy rule (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::PolicyRuleUser(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::PolicyRuleUser(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated a user policy rule (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomAliases(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomAliases(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the room aliases for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomAvatar(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomAvatar(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the room avatar (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomCanonicalAlias(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the canonical alias for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomCreate(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomCreate(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text("* created the room (redacted)".into())]
         },
-        AnyFullStateEventContent::RoomEncryption(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomEncryption(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the encryption settings for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomGuestAccess(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomGuestAccess(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the guest access configuration for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomHistoryVisibility(FullStateEventContent::Redacted(
+            _,
+        )) => {
             vec![StyleTreeNode::Text(
                 "* updated history visilibity for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomJoinRules(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the join rules for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomMember(FullStateEventContent::Redacted(_)) => {
-            vec![StyleTreeNode::Text(
-                "* updated the room membership (redacted)".into(),
-            )]
-        },
-        AnyFullStateEventContent::RoomName(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomName(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the room name (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomPinnedEvents(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the pinned events for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomPowerLevels(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomPowerLevels(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the power levels for the room (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomServerAcl(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomServerAcl(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the room's server ACLs (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomThirdPartyInvite(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* sent a third-party invite (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::RoomTombstone(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomTombstone(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text("* upgraded the room (redacted)".into())]
         },
-        AnyFullStateEventContent::RoomTopic(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::RoomTopic(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* updated the room topic (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::SpaceChild(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::SpaceChild(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* added a space child (redacted)".into(),
             )]
         },
-        AnyFullStateEventContent::SpaceParent(FullStateEventContent::Redacted(_)) => {
+        AnyOtherFullStateEventContent::SpaceParent(FullStateEventContent::Redacted(_)) => {
             vec![StyleTreeNode::Text(
                 "* added a parent space (redacted)".into(),
             )]
-        },
-        AnyFullStateEventContent::BeaconInfo(FullStateEventContent::Redacted(_)) => {
-            vec![StyleTreeNode::Text(
-                "* shared beacon information (redacted)".into(),
-            )]
-        },
-        AnyFullStateEventContent::CallMember(FullStateEventContent::Redacted(_)) => {
-            vec![StyleTreeNode::Text("Call membership changed".into())]
-        },
-        AnyFullStateEventContent::MemberHints(FullStateEventContent::Redacted(_)) => {
-            vec![StyleTreeNode::Text("Member hints changed".into())]
         },
 
         // Handle unknown events:

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -234,9 +234,9 @@ fn is_focused(locked: &ProgramStore) -> bool {
 }
 
 async fn is_visible_room(store: &AsyncProgramStore, room_id: &RoomId) -> bool {
-    let mut locked = store.lock().await;
+    let locked = store.lock().await;
 
-    is_focused(&locked) && is_open(&mut locked, room_id)
+    is_focused(&locked) && is_open(&locked, room_id)
 }
 
 pub async fn parse_full_notification(

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -215,14 +215,18 @@ fn is_missing_mention(body: &Option<String>, mode: RoomNotificationMode, client:
     false
 }
 
-fn is_open(locked: &mut ProgramStore, room_id: &RoomId) -> bool {
+fn is_open(locked: &ProgramStore, room_id: &RoomId) -> bool {
     if let Some(draw_curr) = locked.application.draw_curr {
-        let info = locked.application.get_room_info(room_id.to_owned());
-        if let Some(draw_last) = info.draw_last {
-            return draw_last == draw_curr;
-        }
+        let draw_last = locked
+            .application
+            .rooms
+            .get(room_id)
+            .and_then(|info| info.draw_last.as_ref());
+
+        draw_last == Some(&draw_curr)
+    } else {
+        false
     }
-    false
 }
 
 fn is_focused(locked: &ProgramStore) -> bool {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,11 +1,7 @@
-use std::{
-    fs::File,
-    io::{Read, Write},
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{
-    media::{MediaFormat, MediaRequestParameters},
+    media::{MediaFormat, MediaRequestParameters, UniqueKey},
     ruma::{
         events::{
             room::{
@@ -15,18 +11,101 @@ use matrix_sdk::{
             MessageLikeEvent,
         },
         OwnedEventId,
-        OwnedRoomId,
     },
     Media,
 };
 use ratatui::layout::Rect;
-use ratatui_image::Resize;
+use ratatui_image::{picker::Picker, protocol::Protocol, Resize};
+use tokio::sync::Semaphore;
 
 use crate::{
-    base::{AsyncProgramStore, ChatStore, IambError},
-    config::ImagePreviewSize,
-    message::ImageStatus,
+    base::{AsyncProgramStore, IambError},
+    config::{ApplicationSettings, ImagePreviewSize},
+    worker::Requester,
 };
+
+pub enum ImageStatus {
+    Queued(ImagePreviewSize),
+    Downloading(ImagePreviewSize),
+    Loaded(Protocol),
+    Error(String),
+}
+
+pub struct PreviewManager {
+    /// Image preview "protocol" picker.
+    picker: Option<Arc<Picker>>,
+
+    /// Permits for rendering images in background thread.
+    permits: Arc<Semaphore>,
+
+    /// Indexed by [`MediaSource::unique_key`]
+    previews: HashMap<String, ImageStatus>,
+}
+
+impl PreviewManager {
+    pub fn new(picker: Option<Picker>) -> Self {
+        Self {
+            picker: picker.map(Into::into),
+            permits: Arc::new(Semaphore::new(2)),
+            previews: Default::default(),
+        }
+    }
+
+    pub fn get(&self, source: &MediaSource) -> Option<&ImageStatus> {
+        self.previews.get(&source.unique_key())
+    }
+
+    fn insert(&mut self, key: String, status: ImageStatus) {
+        self.previews.insert(key, status);
+    }
+
+    /// Queue download and preparation of preview
+    pub fn load(&mut self, source: &MediaSource, worker: &Requester) {
+        let Some(status) = self.previews.get_mut(&source.unique_key()) else {
+            return;
+        };
+        let Some(picker) = &self.picker else { return };
+
+        if let ImageStatus::Queued(size) = status {
+            let size = *size;
+            *status = ImageStatus::Downloading(size);
+
+            worker.load_image(
+                source.to_owned(),
+                size.to_owned(),
+                Arc::clone(picker),
+                Arc::clone(&self.permits),
+            );
+        }
+    }
+
+    pub fn register_preview(
+        &mut self,
+        settings: &ApplicationSettings,
+        source: MediaSource,
+        size: ImagePreviewSize,
+        worker: &Requester,
+    ) {
+        if self.picker.is_none() {
+            return;
+        }
+
+        let key = source.unique_key();
+        if self.previews.contains_key(&key) {
+            return;
+        }
+        self.previews.insert(key, ImageStatus::Queued(size));
+
+        if settings
+            .tunables
+            .image_preview
+            .as_ref()
+            .is_some_and(|setting| !setting.lazy_load)
+        {
+            self.load(&source, worker);
+        }
+    }
+}
 
 pub fn source_from_event(
     ev: &MessageLikeEvent<RoomMessageEventContent>,
@@ -50,171 +129,54 @@ impl From<Rect> for ImagePreviewSize {
     }
 }
 
-/// Download and prepare the preview, and then lock the store to insert it.
-pub fn spawn_insert_preview(
+pub async fn load_image(
     store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    source: MediaSource,
     media: Media,
-    cache_dir: PathBuf,
-    preview: ImagePreviewSize,
+    source: MediaSource,
+    picker: Arc<Picker>,
+    permits: Arc<Semaphore>,
+    size: ImagePreviewSize,
 ) {
-    tokio::spawn(async move {
-        let img = download_or_load(event_id.to_owned(), source, media, cache_dir)
+    async fn load_image_inner(
+        media: Media,
+        source: MediaSource,
+        picker: Arc<Picker>,
+        permits: Arc<Semaphore>,
+        size: ImagePreviewSize,
+    ) -> Result<ImageStatus, IambError> {
+        let reader = media
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
             .await
             .map(std::io::Cursor::new)
             .map(image::ImageReader::new)
             .map_err(IambError::Matrix)
-            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError));
+            .and_then(|reader| reader.with_guessed_format().map_err(IambError::IOError))?;
 
-        match img {
-            Err(err) => {
-                try_set_msg_preview_error(
-                    &mut store.lock().await.application,
-                    room_id,
-                    event_id,
-                    err,
-                );
-            },
-            Ok(img) => {
-                let mut locked = store.lock().await;
+        let image = reader.decode().map_err(IambError::Image)?;
 
-                match locked
-                    .application
-                    .rooms
-                    .get_or_default(room_id.clone())
-                    .get_event_mut(&event_id)
-                    .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-                {
-                    Err(err) => {
-                        try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-                    },
-                    Ok(msg) => msg.image_preview = ImageStatus::Loading(Some(img), preview),
-                }
-            },
-        }
-    });
-}
+        let permit = permits
+            .acquire()
+            .await
+            .map_err(|err| IambError::Preview(err.to_string()))?;
 
-pub async fn render_preview(
-    store: AsyncProgramStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-) {
-    let mut locked = store.lock().await;
-
-    let picker = locked.application.picker.clone();
-    let Some(img) = locked
-        .application
-        .rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .map(|msg| {
-            if let ImageStatus::Loading(reader, size) = &mut msg.image_preview {
-                reader.take().map(|reader| (reader, size.clone()))
-            } else {
-                None
-            }
-        })
-        .transpose()
-    else {
-        // ignore if image is already being loaded
-        return;
-    };
-
-    // make shure to unlock store while computing `new_protocol`
-    drop(locked);
-
-    let image = picker
-        .ok_or_else(|| IambError::Preview("Picker is empty".to_string()))
-        .and_then(|picker| {
-            let (reader, size) = img?;
-            Ok((picker, reader, size))
-        })
-        .and_then(|(picker, reader, size)| {
-            let image = reader.decode().map_err(IambError::Image)?;
-            Ok((picker, image, size))
-        })
-        .and_then(|(picker, image, size)| {
+        let handle = tokio::task::spawn_blocking(move || {
             picker
                 .new_protocol(image, size.into(), Resize::Fit(None))
-                .map_err(|err| IambError::Preview(format!("{err}")))
+                .map_err(|err| IambError::Preview(err.to_string()))
         });
 
+        let image = handle.await.map_err(|err| IambError::Preview(err.to_string()))??;
+        std::mem::drop(permit);
+
+        Ok(ImageStatus::Loaded(image))
+    }
+    let key = source.unique_key();
+
+    let status = match load_image_inner(media, source, picker, permits, size).await {
+        Ok(status) => status,
+        Err(err) => ImageStatus::Error(format!("{err:?}")),
+    };
+
     let mut locked = store.lock().await;
-
-    match image {
-        Err(err) => {
-            try_set_msg_preview_error(&mut locked.application, room_id, event_id, err);
-        },
-        Ok(backend) => {
-            locked
-                .application
-                .rooms
-                .get_or_default(room_id)
-                .get_event_mut(&event_id)
-                .unwrap()
-                .image_preview = ImageStatus::Loaded(backend);
-        },
-    }
-}
-
-fn try_set_msg_preview_error(
-    application: &mut ChatStore,
-    room_id: OwnedRoomId,
-    event_id: OwnedEventId,
-    err: IambError,
-) {
-    let rooms = &mut application.rooms;
-
-    match rooms
-        .get_or_default(room_id.clone())
-        .get_event_mut(&event_id)
-        .ok_or_else(|| IambError::Preview("Message not found".to_string()))
-    {
-        Ok(msg) => msg.image_preview = ImageStatus::Error(format!("{err:?}")),
-        Err(err) => {
-            tracing::error!(
-                "Failed to set error on msg.image_backend for event {}, room {}: {}",
-                event_id,
-                room_id,
-                err
-            )
-        },
-    }
-}
-
-async fn download_or_load(
-    event_id: OwnedEventId,
-    source: MediaSource,
-    media: Media,
-    mut cache_path: PathBuf,
-) -> Result<Vec<u8>, matrix_sdk::Error> {
-    cache_path.push(Path::new(event_id.localpart()));
-
-    match File::open(&cache_path) {
-        Ok(mut f) => {
-            let mut buffer = Vec::new();
-            f.read_to_end(&mut buffer)?;
-            Ok(buffer)
-        },
-        Err(_) => {
-            media
-                .get_media_content(
-                    &MediaRequestParameters { source, format: MediaFormat::File },
-                    true,
-                )
-                .await
-                .and_then(|buffer| {
-                    if let Err(err) =
-                        File::create(&cache_path).and_then(|mut f| f.write_all(&buffer))
-                    {
-                        return Err(err.into());
-                    }
-                    Ok(buffer)
-                })
-        },
-    }
+    locked.application.previews.insert(key, status);
 }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -73,27 +73,25 @@ impl PreviewManager {
     pub fn register_preview(
         &mut self,
         settings: &ApplicationSettings,
-        source: MediaSource,
-        size: ImagePreviewSize,
+        source: &MediaSource,
         worker: &Requester,
     ) {
         if self.picker.is_none() {
             return;
         }
 
+        let Some(image_preview) = &settings.tunables.image_preview else {
+            return;
+        };
+
         let key = source.unique_key();
         if self.previews.contains_key(&key) {
             return;
         }
-        self.previews.insert(key, ImageStatus::Queued(size));
+        self.previews.insert(key, ImageStatus::Queued(image_preview.size));
 
-        if settings
-            .tunables
-            .image_preview
-            .as_ref()
-            .is_some_and(|setting| !setting.lazy_load)
-        {
-            self.load(&source, worker);
+        if !image_preview.lazy_load {
+            self.load(source, worker);
         }
     }
 }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -2,16 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{
     media::{MediaFormat, MediaRequestParameters, UniqueKey},
-    ruma::{
-        events::{
-            room::{
-                message::{MessageType, RoomMessageEventContent},
-                MediaSource,
-            },
-            MessageLikeEvent,
-        },
-        OwnedEventId,
-    },
+    ruma::events::room::MediaSource,
     Media,
 };
 use ratatui::layout::Rect;
@@ -105,17 +96,6 @@ impl PreviewManager {
             self.load(&source, worker);
         }
     }
-}
-
-pub fn source_from_event(
-    ev: &MessageLikeEvent<RoomMessageEventContent>,
-) -> Option<(OwnedEventId, MediaSource)> {
-    if let MessageLikeEvent::Original(ev) = &ev {
-        if let MessageType::Image(c) = &ev.content.msgtype {
-            return Some((ev.event_id.clone(), c.source.clone()));
-        }
-    }
-    None
 }
 
 impl From<ImagePreviewSize> for Rect {

--- a/src/sled_export.rs
+++ b/src/sled_export.rs
@@ -14,7 +14,7 @@ use sled::{Config, IVec};
 use std::path::Path;
 
 use crate::base::IambError;
-use matrix_sdk::crypto::olm::{ExportedRoomKey, InboundGroupSession, PickledInboundGroupSession};
+use matrix_sdk_crypto::olm::{ExportedRoomKey, InboundGroupSession, PickledInboundGroupSession};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SledMigrationError {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -163,7 +163,6 @@ pub fn mock_dirs() -> DirectoryValues {
         data: PathBuf::new(),
         logs: PathBuf::new(),
         downloads: None,
-        image_previews: PathBuf::new(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,15 @@
 #![allow(unused)]
 
+use std::borrow::Cow;
+use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{collections::HashMap, sync::Weak};
 
+use chrono::DateTime;
+use matrix_sdk::ruma::events::receipt::Receipt;
+use matrix_sdk::ruma::events::room::MediaSource;
+use matrix_sdk::ruma::UserId;
 use matrix_sdk::ruma::{
     event_id,
     events::room::message::RoomMessageEventContent,
@@ -16,11 +23,33 @@ use matrix_sdk::ruma::{
 };
 
 use lazy_static::lazy_static;
-use ratatui::style::{Color, Style};
+use matrix_sdk_ui::eyeball_im::Vector;
+use matrix_sdk_ui::timeline::{
+    EventTimelineItem,
+    MsgLikeContent,
+    Profile,
+    TimelineDetails,
+    TimelineEventItemId,
+    TimelineItem,
+    TimelineItemContent,
+    TimelineUniqueId,
+};
+use modalkit::prelude::ViewportContext;
+use ratatui::style::{Color, Modifier as StyleModifier, Style};
+use ratatui::text::{Line, Span, Text};
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::Level;
 use url::Url;
 
+use crate::message::{
+    MessageCursor,
+    MessageExt,
+    MessageTimeStamp,
+    ProtocolPreview,
+    TimelineItemExt,
+};
+use crate::preview::PreviewManager;
+use crate::util::space_span;
 use crate::{
     base::{ChatStore, ProgramStore, RoomInfo},
     config::{
@@ -51,85 +80,217 @@ lazy_static! {
     pub static ref TEST_USER3: OwnedUserId = user_id!("@user3:example.com").to_owned();
     pub static ref TEST_USER4: OwnedUserId = user_id!("@user4:example.com").to_owned();
     pub static ref TEST_USER5: OwnedUserId = user_id!("@user5:example.com").to_owned();
-    pub static ref MSG1_EVID: OwnedEventId = EventId::new(server_name!("example.com"));
-    pub static ref MSG2_EVID: OwnedEventId = EventId::new(server_name!("example.com"));
-    pub static ref MSG3_EVID: OwnedEventId =
-        event_id!("$5jRz3KfVhaUzXtVj7k:example.com").to_owned();
-    pub static ref MSG4_EVID: OwnedEventId =
-        event_id!("$JP6qFV7WyXk5ZnexM3:example.com").to_owned();
-    pub static ref MSG5_EVID: OwnedEventId = EventId::new(server_name!("example.com"));
-    pub static ref MSG1_KEY: MessageKey = todo!();
-    pub static ref MSG2_KEY: MessageKey = todo!();
-    pub static ref MSG3_KEY: MessageKey = todo!();
-    pub static ref MSG4_KEY: MessageKey = todo!();
-    pub static ref MSG5_KEY: MessageKey = todo!();
+    pub static ref MSG1_EVID: TimelineEventItemId =
+        TimelineEventItemId::EventId(EventId::new(server_name!("example.com")));
+    pub static ref MSG2_EVID: TimelineEventItemId =
+        TimelineEventItemId::EventId(EventId::new(server_name!("example.com")));
+    pub static ref MSG3_EVID: TimelineEventItemId =
+        TimelineEventItemId::EventId(event_id!("$5jRz3KfVhaUzXtVj7k:example.com").to_owned());
+    pub static ref MSG4_EVID: TimelineEventItemId =
+        TimelineEventItemId::EventId(event_id!("$JP6qFV7WyXk5ZnexM3:example.com").to_owned());
+    pub static ref MSG5_EVID: TimelineEventItemId =
+        TimelineEventItemId::EventId(EventId::new(server_name!("example.com")));
+    pub static ref MSG1_KEY: MessageKey =
+        MessageKey::new(6, TimelineUniqueId("MSG1_KEY".to_string()));
+    pub static ref MSG2_KEY: MessageKey =
+        MessageKey::new(1, TimelineUniqueId("MSG2_KEY".to_string()));
+    pub static ref MSG3_KEY: MessageKey =
+        MessageKey::new(2, TimelineUniqueId("MSG3_KEY".to_string()));
+    pub static ref MSG4_KEY: MessageKey =
+        MessageKey::new(3, TimelineUniqueId("MSG4_KEY".to_string()));
+    pub static ref MSG5_KEY: MessageKey =
+        MessageKey::new(4, TimelineUniqueId("MSG5_KEY".to_string()));
+    pub static ref DIVIDER1_KEY: MessageKey =
+        MessageKey::new(0, TimelineUniqueId("_divider1".to_string()));
+    pub static ref DIVIDER2_KEY: MessageKey =
+        MessageKey::new(5, TimelineUniqueId("_divider2".to_string()));
+}
+
+#[derive(Debug)]
+pub struct MockMessage {
+    text: &'static str,
+    content: TimelineItemContent,
+    sender: OwnedUserId,
+    id: TimelineEventItemId,
+}
+
+impl Deref for MockMessage {
+    type Target = EventTimelineItem;
+
+    fn deref(&self) -> &Self::Target {
+        unimplemented!()
+    }
+}
+
+impl MessageExt for MockMessage {
+    fn content(&self) -> &TimelineItemContent {
+        &self.content
+    }
+
+    fn sender(&self) -> &UserId {
+        &self.sender
+    }
+
+    fn sender_profile(&self) -> &TimelineDetails<Profile> {
+        &TimelineDetails::Pending
+    }
+
+    fn message_timestamp(&self) -> MessageTimeStamp {
+        unimplemented!()
+    }
+
+    fn identifier(&self) -> TimelineEventItemId {
+        self.id.clone()
+    }
+
+    fn is_local_echo(&self) -> bool {
+        matches!(self.identifier(), TimelineEventItemId::TransactionId(_))
+    }
+
+    fn read_receipts(&self) -> impl Iterator<Item = (&OwnedUserId, &Receipt)> {
+        vec![].into_iter()
+    }
+
+    fn is_edited(&self) -> bool {
+        false
+    }
+
+    // --- overrides ---
+
+    fn body(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.text)
+    }
+    fn image_preview(&self) -> Option<&MediaSource> {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct MockMessageItem {
+    id: TimelineUniqueId,
+    /// Either a message or a date divider
+    inner: Option<MockMessage>,
+}
+
+impl Deref for MockMessageItem {
+    type Target = TimelineItem;
+
+    fn deref(&self) -> &Self::Target {
+        unimplemented!()
+    }
+}
+
+impl TimelineItemExt for MockMessageItem {
+    fn item(&self) -> &TimelineItem {
+        unimplemented!()
+    }
+
+    fn sender(&self) -> Option<&UserId> {
+        self.inner.as_ref().map(|inner| inner.sender())
+    }
+
+    fn show_with_preview<'a>(
+        &'a self,
+        prev_sender: Option<&UserId>,
+        selected: bool,
+        vwctx: &ViewportContext<MessageCursor>,
+        info: &'a RoomInfo,
+        settings: &'a ApplicationSettings,
+        previews: &'a PreviewManager,
+    ) -> (Text<'a>, [Option<ProtocolPreview<'a>>; 2]) {
+        match &self.inner {
+            Some(inner) => {
+                inner.show_with_preview(prev_sender, selected, vwctx, info, settings, previews)
+            },
+            None => {
+                let time = DateTime::from_timestamp_nanos(0).format("%A, %B %d %Y").to_string();
+                let padding = vwctx.get_width().saturating_sub(time.len());
+                let leading = space_span(padding / 2, Style::default());
+                let trailing = space_span(padding.saturating_sub(padding / 2), Style::default());
+                let time = Span::styled(time, Style::new().add_modifier(StyleModifier::BOLD));
+
+                (Line::from(vec![leading, time, trailing]).into(), [None, None])
+            },
+        }
+    }
+}
+
+impl MockMessageItem {
+    fn new_message(
+        content: &'static str,
+        sender: OwnedUserId,
+        key: &MessageKey,
+        id: TimelineEventItemId,
+    ) -> Self {
+        Self {
+            id: key.id().to_owned(),
+            inner: Some(MockMessage {
+                id,
+                sender,
+                text: content,
+                content: TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
+            }),
+        }
+    }
+
+    pub fn unique_id(&self) -> &TimelineUniqueId {
+        &self.id
+    }
+
+    pub fn as_event(&self) -> Option<&Message> {
+        self.inner.as_ref()
+    }
+
+    pub fn is_timeline_start(&self) -> bool {
+        false
+    }
 }
 
 pub fn user_style(user: &str) -> Style {
     user_style_from_color(user_color(user))
 }
 
-pub fn mock_room1_message(
-    _content: RoomMessageEventContent,
-    _sender: OwnedUserId,
-    _key: MessageKey,
-) -> Message {
-    todo!()
+pub fn mock_message1() -> MockMessageItem {
+    let content = "writhe";
+
+    MockMessageItem::new_message(content, TEST_USER1.clone(), &MSG1_KEY, MSG1_EVID.clone())
 }
 
-pub fn mock_message1() -> Message {
-    // let content = RoomMessageEventContent::text_plain("writhe");
-    // let content = MessageEvent::Local(MSG1_EVID.clone(), content.into());
+pub fn mock_message2() -> MockMessageItem {
+    let content = "helium";
 
-    todo!()
+    MockMessageItem::new_message(content, TEST_USER2.clone(), &MSG2_KEY, MSG2_EVID.clone())
 }
 
-pub fn mock_message2() -> Message {
-    let content = RoomMessageEventContent::text_plain("helium");
+pub fn mock_message3() -> MockMessageItem {
+    let content = "this\nis\na\nmultiline\nmessage";
 
-    mock_room1_message(content, TEST_USER2.clone(), MSG2_KEY.clone())
+    MockMessageItem::new_message(content, TEST_USER2.clone(), &MSG3_KEY, MSG3_EVID.clone())
 }
 
-pub fn mock_message3() -> Message {
-    let content = RoomMessageEventContent::text_plain("this\nis\na\nmultiline\nmessage");
+pub fn mock_message4() -> MockMessageItem {
+    let content = "help";
 
-    mock_room1_message(content, TEST_USER2.clone(), MSG3_KEY.clone())
+    MockMessageItem::new_message(content, TEST_USER1.clone(), &MSG4_KEY, MSG4_EVID.clone())
 }
 
-pub fn mock_message4() -> Message {
-    let content = RoomMessageEventContent::text_plain("help");
+pub fn mock_message5() -> MockMessageItem {
+    let content = "character";
 
-    mock_room1_message(content, TEST_USER1.clone(), MSG4_KEY.clone())
+    MockMessageItem::new_message(content, TEST_USER2.clone(), &MSG5_KEY, MSG5_EVID.clone())
 }
 
-pub fn mock_message5() -> Message {
-    let content = RoomMessageEventContent::text_plain("character");
-
-    mock_room1_message(content, TEST_USER2.clone(), MSG4_KEY.clone())
-}
-
-// pub fn mock_keys() -> HashMap<OwnedEventId, EventLocation> {
-//     let mut keys = HashMap::new();
-//
-//     keys.insert(MSG1_EVID.clone(), EventLocation::Message(None, MSG1_KEY.clone()));
-//     keys.insert(MSG2_EVID.clone(), EventLocation::Message(None, MSG2_KEY.clone()));
-//     keys.insert(MSG3_EVID.clone(), EventLocation::Message(None, MSG3_KEY.clone()));
-//     keys.insert(MSG4_EVID.clone(), EventLocation::Message(None, MSG4_KEY.clone()));
-//     keys.insert(MSG5_EVID.clone(), EventLocation::Message(None, MSG5_KEY.clone()));
-//
-//     keys
-// }
-
-pub fn mock_messages() -> Messages {
-    todo!()
-}
-
-pub fn mock_room() -> RoomInfo {
-    // let mut room = RoomInfo::default();
-    // room.name = Some("Watercooler Discussion".into());
-    // room.keys = mock_keys();
-    // *room.get_thread_mut(None) = mock_messages();
-    todo!()
+pub fn mock_messages() -> Vector<Arc<MockMessageItem>> {
+    [
+        MockMessageItem { id: DIVIDER1_KEY.id().to_owned(), inner: None }.into(),
+        mock_message2().into(),
+        mock_message3().into(),
+        mock_message4().into(),
+        mock_message5().into(),
+        MockMessageItem { id: DIVIDER2_KEY.id().to_owned(), inner: None }.into(),
+        mock_message1().into(),
+    ]
+    .into()
 }
 
 pub fn mock_dirs() -> DirectoryValues {
@@ -218,11 +379,12 @@ pub async fn mock_store() -> ProgramStore {
     store.presences.get_or_default(TEST_USER4.clone());
     store.presences.get_or_default(TEST_USER5.clone());
 
-    // let room_id = TEST_ROOM1_ID.clone();
-    // let info = mock_room();
-    //
-    // store.rooms.insert(room_id.clone(), info);
-    // store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
-    todo!()
-    // ProgramStore::new(store)
+    let room_id = TEST_ROOM1_ID.clone();
+    let mut info = RoomInfo::mock_new();
+
+    info.get_thread_mut(None).unwrap().set_messages(mock_messages());
+
+    store.rooms.insert(room_id.clone(), info);
+    store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
+    ProgramStore::new(store)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -119,23 +119,15 @@ pub fn mock_keys() -> HashMap<OwnedEventId, EventLocation> {
 }
 
 pub fn mock_messages() -> Messages {
-    let mut messages = Messages::main();
-
-    messages.insert(MSG1_KEY.clone(), mock_message1());
-    messages.insert(MSG2_KEY.clone(), mock_message2());
-    messages.insert(MSG3_KEY.clone(), mock_message3());
-    messages.insert(MSG4_KEY.clone(), mock_message4());
-    messages.insert(MSG5_KEY.clone(), mock_message5());
-
-    messages
+    todo!()
 }
 
 pub fn mock_room() -> RoomInfo {
     let mut room = RoomInfo::default();
     room.name = Some("Watercooler Discussion".into());
     room.keys = mock_keys();
-    *room.get_thread_mut(None) = mock_messages();
-    room
+    // *room.get_thread_mut(None) = mock_messages();
+    todo!()
 }
 
 pub fn mock_dirs() -> DirectoryValues {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -123,9 +125,9 @@ pub fn mock_messages() -> Messages {
 }
 
 pub fn mock_room() -> RoomInfo {
-    let mut room = RoomInfo::default();
-    room.name = Some("Watercooler Discussion".into());
-    room.keys = mock_keys();
+    // let mut room = RoomInfo::default();
+    // room.name = Some("Watercooler Discussion".into());
+    // room.keys = mock_keys();
     // *room.get_thread_mut(None) = mock_messages();
     todo!()
 }
@@ -216,11 +218,11 @@ pub async fn mock_store() -> ProgramStore {
     store.presences.get_or_default(TEST_USER4.clone());
     store.presences.get_or_default(TEST_USER5.clone());
 
-    let room_id = TEST_ROOM1_ID.clone();
-    let info = mock_room();
-
-    store.rooms.insert(room_id.clone(), info);
-    store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
-
-    ProgramStore::new(store)
+    // let room_id = TEST_ROOM1_ID.clone();
+    // let info = mock_room();
+    //
+    // store.rooms.insert(room_id.clone(), info);
+    // store.names.insert(TEST_ROOM1_ALIAS.to_string(), room_id);
+    todo!()
+    // ProgramStore::new(store)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,6 @@ use std::{collections::HashMap, sync::Weak};
 use chrono::DateTime;
 use matrix_sdk::ruma::events::receipt::Receipt;
 use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::UserId;
 use matrix_sdk::ruma::{
     event_id,
     events::room::message::RoomMessageEventContent,
@@ -21,6 +20,7 @@ use matrix_sdk::ruma::{
     OwnedUserId,
     RoomId,
 };
+use matrix_sdk::ruma::{MilliSecondsSinceUnixEpoch, UserId};
 
 use lazy_static::lazy_static;
 use matrix_sdk_ui::eyeball_im::Vector;
@@ -33,6 +33,7 @@ use matrix_sdk_ui::timeline::{
     TimelineItem,
     TimelineItemContent,
     TimelineUniqueId,
+    VirtualTimelineItem,
 };
 use modalkit::prelude::ViewportContext;
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
@@ -165,6 +166,12 @@ impl MessageExt for MockMessage {
     }
 }
 
+impl MockMessage {
+    pub fn event_id(&self) -> Option<&EventId> {
+        None
+    }
+}
+
 #[derive(Debug)]
 pub struct MockMessageItem {
     id: TimelineUniqueId,
@@ -239,6 +246,14 @@ impl MockMessageItem {
 
     pub fn as_event(&self) -> Option<&Message> {
         self.inner.as_ref()
+    }
+
+    pub fn as_virtual(&self) -> Option<VirtualTimelineItem> {
+        if self.inner.is_none() {
+            Some(VirtualTimelineItem::DateDivider(MilliSecondsSinceUnixEpoch(0u16.into())))
+        } else {
+            None
+        }
     }
 
     pub fn is_timeline_start(&self) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
+use std::{collections::HashMap, sync::Weak};
 
 use matrix_sdk::ruma::{
     event_id,
@@ -207,7 +207,7 @@ pub async fn mock_store() -> ProgramStore {
     let (tx, _) = unbounded_channel();
     let homeserver = Url::parse("https://localhost").unwrap();
     let client = matrix_sdk::Client::new(homeserver).await.unwrap();
-    let worker = Requester { tx, client };
+    let worker = Requester { tx, client, store: Weak::new() };
 
     let mut store = ChatStore::new(worker, mock_settings());
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use matrix_sdk::ruma::{
     event_id,
-    events::room::message::{OriginalRoomMessageEvent, RoomMessageEventContent},
+    events::room::message::RoomMessageEventContent,
     server_name,
     user_id,
     EventId,
@@ -11,7 +11,6 @@ use matrix_sdk::ruma::{
     OwnedRoomId,
     OwnedUserId,
     RoomId,
-    UInt,
 };
 
 use lazy_static::lazy_static;
@@ -36,12 +35,7 @@ use crate::{
         UserDisplayStyle,
         UserDisplayTunables,
     },
-    message::{
-        Message,
-        MessageKey,
-        MessageTimeStamp::{LocalEcho, OriginServer},
-        Messages,
-    },
+    message::{Message, MessageKey, Messages},
     worker::Requester,
 };
 
@@ -62,15 +56,11 @@ lazy_static! {
     pub static ref MSG4_EVID: OwnedEventId =
         event_id!("$JP6qFV7WyXk5ZnexM3:example.com").to_owned();
     pub static ref MSG5_EVID: OwnedEventId = EventId::new(server_name!("example.com"));
-    pub static ref MSG1_KEY: MessageKey = MessageKey::new(LocalEcho, MSG1_EVID.clone());
-    pub static ref MSG2_KEY: MessageKey =
-        MessageKey::new(OriginServer(UInt::new(1).unwrap()), MSG2_EVID.clone());
-    pub static ref MSG3_KEY: MessageKey =
-        MessageKey::new(OriginServer(UInt::new(2).unwrap()), MSG3_EVID.clone());
-    pub static ref MSG4_KEY: MessageKey =
-        MessageKey::new(OriginServer(UInt::new(2).unwrap()), MSG4_EVID.clone());
-    pub static ref MSG5_KEY: MessageKey =
-        MessageKey::new(OriginServer(UInt::new(8).unwrap()), MSG5_EVID.clone());
+    pub static ref MSG1_KEY: MessageKey = todo!();
+    pub static ref MSG2_KEY: MessageKey = todo!();
+    pub static ref MSG3_KEY: MessageKey = todo!();
+    pub static ref MSG4_KEY: MessageKey = todo!();
+    pub static ref MSG5_KEY: MessageKey = todo!();
 }
 
 pub fn user_style(user: &str) -> Style {
@@ -78,22 +68,10 @@ pub fn user_style(user: &str) -> Style {
 }
 
 pub fn mock_room1_message(
-    content: RoomMessageEventContent,
-    sender: OwnedUserId,
-    key: MessageKey,
+    _content: RoomMessageEventContent,
+    _sender: OwnedUserId,
+    _key: MessageKey,
 ) -> Message {
-    let origin_server_ts = key.ts().as_millis().unwrap();
-    let event_id = key.event_id().to_owned();
-
-    let _event = OriginalRoomMessageEvent {
-        content,
-        event_id,
-        sender,
-        origin_server_ts,
-        room_id: TEST_ROOM1_ID.clone(),
-        unsigned: Default::default(),
-    };
-
     todo!()
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,11 +63,15 @@ lazy_static! {
     pub static ref MSG4_EVID: OwnedEventId =
         event_id!("$JP6qFV7WyXk5ZnexM3:example.com").to_owned();
     pub static ref MSG5_EVID: OwnedEventId = EventId::new(server_name!("example.com"));
-    pub static ref MSG1_KEY: MessageKey = (LocalEcho, MSG1_EVID.clone());
-    pub static ref MSG2_KEY: MessageKey = (OriginServer(UInt::new(1).unwrap()), MSG2_EVID.clone());
-    pub static ref MSG3_KEY: MessageKey = (OriginServer(UInt::new(2).unwrap()), MSG3_EVID.clone());
-    pub static ref MSG4_KEY: MessageKey = (OriginServer(UInt::new(2).unwrap()), MSG4_EVID.clone());
-    pub static ref MSG5_KEY: MessageKey = (OriginServer(UInt::new(8).unwrap()), MSG5_EVID.clone());
+    pub static ref MSG1_KEY: MessageKey = MessageKey::new(LocalEcho, MSG1_EVID.clone());
+    pub static ref MSG2_KEY: MessageKey =
+        MessageKey::new(OriginServer(UInt::new(1).unwrap()), MSG2_EVID.clone());
+    pub static ref MSG3_KEY: MessageKey =
+        MessageKey::new(OriginServer(UInt::new(2).unwrap()), MSG3_EVID.clone());
+    pub static ref MSG4_KEY: MessageKey =
+        MessageKey::new(OriginServer(UInt::new(2).unwrap()), MSG4_EVID.clone());
+    pub static ref MSG5_KEY: MessageKey =
+        MessageKey::new(OriginServer(UInt::new(8).unwrap()), MSG5_EVID.clone());
 }
 
 pub fn user_style(user: &str) -> Style {
@@ -79,8 +83,8 @@ pub fn mock_room1_message(
     sender: OwnedUserId,
     key: MessageKey,
 ) -> Message {
-    let origin_server_ts = key.0.as_millis().unwrap();
-    let event_id = key.1;
+    let origin_server_ts = key.ts().as_millis().unwrap();
+    let event_id = key.event_id().to_owned();
 
     let event = OriginalRoomMessageEvent {
         content,
@@ -98,7 +102,7 @@ pub fn mock_message1() -> Message {
     let content = RoomMessageEventContent::text_plain("writhe");
     let content = MessageEvent::Local(MSG1_EVID.clone(), content.into());
 
-    Message::new(content, TEST_USER1.clone(), MSG1_KEY.0)
+    Message::new(content, TEST_USER1.clone(), *MSG1_KEY.ts())
 }
 
 pub fn mock_message2() -> Message {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,7 +38,6 @@ use crate::{
     },
     message::{
         Message,
-        MessageEvent,
         MessageKey,
         MessageTimeStamp::{LocalEcho, OriginServer},
         Messages,
@@ -86,7 +85,7 @@ pub fn mock_room1_message(
     let origin_server_ts = key.ts().as_millis().unwrap();
     let event_id = key.event_id().to_owned();
 
-    let event = OriginalRoomMessageEvent {
+    let _event = OriginalRoomMessageEvent {
         content,
         event_id,
         sender,
@@ -95,14 +94,14 @@ pub fn mock_room1_message(
         unsigned: Default::default(),
     };
 
-    event.into()
+    todo!()
 }
 
 pub fn mock_message1() -> Message {
-    let content = RoomMessageEventContent::text_plain("writhe");
-    let content = MessageEvent::Local(MSG1_EVID.clone(), content.into());
+    // let content = RoomMessageEventContent::text_plain("writhe");
+    // let content = MessageEvent::Local(MSG1_EVID.clone(), content.into());
 
-    Message::new(content, TEST_USER1.clone(), *MSG1_KEY.ts())
+    todo!()
 }
 
 pub fn mock_message2() -> Message {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,7 +22,7 @@ use tracing::Level;
 use url::Url;
 
 use crate::{
-    base::{ChatStore, EventLocation, ProgramStore, RoomInfo},
+    base::{ChatStore, ProgramStore, RoomInfo},
     config::{
         user_color,
         user_style_from_color,
@@ -108,17 +108,17 @@ pub fn mock_message5() -> Message {
     mock_room1_message(content, TEST_USER2.clone(), MSG4_KEY.clone())
 }
 
-pub fn mock_keys() -> HashMap<OwnedEventId, EventLocation> {
-    let mut keys = HashMap::new();
-
-    keys.insert(MSG1_EVID.clone(), EventLocation::Message(None, MSG1_KEY.clone()));
-    keys.insert(MSG2_EVID.clone(), EventLocation::Message(None, MSG2_KEY.clone()));
-    keys.insert(MSG3_EVID.clone(), EventLocation::Message(None, MSG3_KEY.clone()));
-    keys.insert(MSG4_EVID.clone(), EventLocation::Message(None, MSG4_KEY.clone()));
-    keys.insert(MSG5_EVID.clone(), EventLocation::Message(None, MSG5_KEY.clone()));
-
-    keys
-}
+// pub fn mock_keys() -> HashMap<OwnedEventId, EventLocation> {
+//     let mut keys = HashMap::new();
+//
+//     keys.insert(MSG1_EVID.clone(), EventLocation::Message(None, MSG1_KEY.clone()));
+//     keys.insert(MSG2_EVID.clone(), EventLocation::Message(None, MSG2_KEY.clone()));
+//     keys.insert(MSG3_EVID.clone(), EventLocation::Message(None, MSG3_KEY.clone()));
+//     keys.insert(MSG4_EVID.clone(), EventLocation::Message(None, MSG4_KEY.clone()));
+//     keys.insert(MSG5_EVID.clone(), EventLocation::Message(None, MSG5_KEY.clone()));
+//
+//     keys
+// }
 
 pub fn mock_messages() -> Messages {
     todo!()

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,25 @@
 //! # Utility functions
 use std::borrow::Cow;
 
+use matrix_sdk_ui::timeline::TimelineDetails;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span, Text};
+
+pub trait TimelineDetailsExt<T> {
+    fn ready(&self) -> Option<&T>;
+}
+
+impl<T> TimelineDetailsExt<T> for TimelineDetails<T> {
+    fn ready(&self) -> Option<&T> {
+        match self {
+            TimelineDetails::Ready(v) => Some(v),
+            _ => None,
+        }
+    }
+}
 
 pub fn split_cow(cow: Cow<'_, str>, idx: usize) -> (Cow<'_, str>, Cow<'_, str>) {
     match cow {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -10,6 +10,7 @@ use std::cmp::{Ord, Ordering, PartialOrd};
 use std::fmt::{self, Display};
 use std::time::{Duration, Instant};
 
+use matrix_sdk::RoomDisplayName;
 use matrix_sdk::{
     encryption::verification::{format_emojis, SasVerification},
     room::{Room as MatrixRoom, RoomMember},
@@ -520,10 +521,7 @@ impl WindowOps<IambInfo> for IambWindow {
 
                 if need_fetch {
                     if let Ok(mems) = store.application.worker.members(room_id.clone()) {
-                        let mut items = mems
-                            .into_iter()
-                            .map(|m| MemberItem::new(m, room_id.clone()))
-                            .collect::<Vec<_>>();
+                        let mut items = mems.into_iter().map(MemberItem::new).collect::<Vec<_>>();
                         let fields = &store.application.settings.tunables.sort.members;
                         items.sort_by(|a, b| user_fields_cmp(a, b, fields));
                         state.set(items);
@@ -776,18 +774,13 @@ impl Window<IambInfo> for IambWindow {
     fn open(id: IambId, store: &mut ProgramStore) -> IambResult<Self> {
         match id {
             IambId::Room(room_id, thread) => {
-                let Some(info) = store.application.rooms.get_mut(&room_id) else {
+                let Some(room) = store.application.worker.client.get_room(&room_id) else {
                     return Err(UIError::Application(IambError::UnknownRoom(room_id)));
                 };
 
-                if let Some(root) = thread.as_deref() {
-                    info.ensure_thread(root, &store.application.worker)
-                        .map_err(IambError::from)?;
-                }
+                let room = RoomState::new(room, thread, store);
 
-                let room = RoomState::new(info.room().clone(), thread, store);
-
-                return Ok(room.into());
+                return Ok(room?.into());
             },
             IambId::DirectList => {
                 let list = DirectListState::new(IambBufferId::DirectList, vec![]);
@@ -852,7 +845,7 @@ impl Window<IambInfo> for IambWindow {
 
             let room = RoomState::new(info.room().clone(), None, store);
 
-            Ok(room.into())
+            Ok(room?.into())
         }
     }
 
@@ -920,9 +913,9 @@ impl<T: ItemType> GenericChatItem<T> {
     fn new(info: &RoomInfo, store: &ProgramStore, is_dm: T) -> Self {
         let unread = info.unreads(&store.application.settings);
         let tags = info.tags.clone();
-        let name = info.name.clone();
 
         let room = info.room().clone();
+        let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
         let alias = room.canonical_alias();
 
         Self { room, name, tags, alias, is_dm, unread }
@@ -1315,12 +1308,11 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for VerifyItem {
 #[derive(Clone)]
 pub struct MemberItem {
     member: RoomMember,
-    room_id: OwnedRoomId,
 }
 
 impl MemberItem {
-    fn new(member: RoomMember, room_id: OwnedRoomId) -> Self {
-        Self { member, room_id }
+    fn new(member: RoomMember) -> Self {
+        Self { member }
     }
 }
 
@@ -1337,7 +1329,6 @@ impl ListItem<IambInfo> for MemberItem {
         _: &ViewportContext<ListCursor>,
         store: &mut ProgramStore,
     ) -> Text<'_> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
         let user_id = self.member.user_id();
 
         let (color, name) = store.application.settings.get_user_overrides(self.member.user_id());
@@ -1354,8 +1345,8 @@ impl ListItem<IambInfo> for MemberItem {
         if let Some(name) = name {
             spans.push(Span::styled(name, style));
             parens = true;
-        } else if let Some(display) = info.display_names.get(user_id) {
-            spans.push(Span::styled(display.clone(), style));
+        } else if let Some(display) = self.member.display_name() {
+            spans.push(Span::styled(display, style));
             parens = true;
         }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -58,7 +58,6 @@ use modalkit_ratatui::{
 };
 
 use crate::base::{
-    ChatStore,
     IambBufferId,
     IambError,
     IambId,
@@ -828,20 +827,12 @@ impl Window<IambInfo> for IambWindow {
     }
 
     fn find(name: String, store: &mut ProgramStore) -> IambResult<Self> {
-        let ChatStore { names, worker, .. } = &mut store.application;
-
-        if let Some(room) = names.get_mut(&name) {
+        if let Some(room) = store.application.names.get_mut(&name) {
             let id = IambId::Room(room.clone(), None);
 
             IambWindow::open(id, store)
         } else {
-            let room_id = worker.join_room(name.clone())?;
-            // TODO: make sure `RoomInfo` exists
-            names.insert(name, room_id.clone());
-
-            let Some(info) = store.application.rooms.get_mut(&room_id) else {
-                return Err(UIError::Application(IambError::UnknownRoom(room_id)));
-            };
+            let info = store.application.join_room(name)?;
 
             let room = RoomState::new(info.room().clone(), None, store);
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -800,7 +800,8 @@ impl Window<IambInfo> for IambWindow {
                 let (room, name, tags) = store.application.worker.get_room(room_id)?;
                 let room = RoomState::new(room, thread, name, tags, store);
 
-                store.application.need_load.need_members(room.id().to_owned());
+                // TODO: fetch members
+                // store.application.need_load.need_members(room.id().to_owned());
                 return Ok(room.into());
             },
             IambId::DirectList => {
@@ -862,7 +863,8 @@ impl Window<IambInfo> for IambWindow {
             let (room, name, tags) = store.application.worker.get_room(room_id)?;
             let room = RoomState::new(room, None, name, tags, store);
 
-            store.application.need_load.need_members(room.id().to_owned());
+            // TODO: fetch members
+            // store.application.need_load.need_members(room.id().to_owned());
             Ok(room.into())
         }
     }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1234,7 +1234,8 @@ impl SpaceItem {
         let room_id = room_info.0.room_id();
         let name = store
             .application
-            .get_room_info(room_id.to_owned())
+            .rooms
+            .get_or_default(room_id.to_owned())
             .name
             .clone()
             .unwrap_or_default();

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -901,7 +901,7 @@ impl ItemType for UndifferentiatedItem {
 #[derive(Clone)]
 pub struct GenericChatItem<T: ItemType> {
     room: MatrixRoom,
-    name: Option<String>,
+    name: String,
     tags: Option<Tags>,
     alias: Option<OwnedRoomAliasId>,
     unread: UnreadInfo,
@@ -933,7 +933,7 @@ impl<T: ItemType> GenericChatItem<T> {
 
 impl<T: ItemType> RoomLikeItem for GenericChatItem<T> {
     fn name(&self) -> &str {
-        self.name.as_deref().unwrap_or_default()
+        &self.name
     }
 
     fn alias(&self) -> Option<&RoomAliasId> {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -8,8 +8,6 @@
 //! where we have the message bar and room ID easily accessible and resettable.
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::fmt::{self, Display};
-use std::ops::Deref;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use matrix_sdk::{
@@ -70,6 +68,7 @@ use crate::base::{
     ProgramContext,
     ProgramStore,
     RoomAction,
+    RoomInfo,
     SendAction,
     SortColumn,
     SortFieldRoom,
@@ -85,8 +84,6 @@ use feruca::Collator;
 
 pub mod room;
 pub mod welcome;
-
-type MatrixRoomInfo = Arc<(MatrixRoom, Option<Tags>)>;
 
 const MEMBER_FETCH_DEBOUNCE: Duration = Duration::from_secs(5);
 
@@ -407,19 +404,13 @@ impl IambWindow {
     }
 }
 
-pub type DirectListState = ListState<DirectItem, IambInfo>;
+pub type DirectListState = ListState<GenericChatItem<UndifferentiatedItem>, IambInfo>;
 pub type MemberListState = ListState<MemberItem, IambInfo>;
-pub type RoomListState = ListState<RoomItem, IambInfo>;
-pub type ChatListState = ListState<GenericChatItem, IambInfo>;
-pub type UnreadListState = ListState<GenericChatItem, IambInfo>;
+pub type RoomListState = ListState<GenericChatItem<UndifferentiatedItem>, IambInfo>;
+pub type ChatListState = ListState<GenericChatItem<ChatItem>, IambInfo>;
+pub type UnreadListState = ListState<GenericChatItem<ChatItem>, IambInfo>;
 pub type SpaceListState = ListState<SpaceItem, IambInfo>;
 pub type VerifyListState = ListState<VerifyItem, IambInfo>;
-
-impl From<ChatListState> for IambWindow {
-    fn from(list: ChatListState) -> Self {
-        IambWindow::ChatList(list)
-    }
-}
 
 impl From<RoomState> for IambWindow {
     fn from(room: RoomState) -> Self {
@@ -430,18 +421,6 @@ impl From<RoomState> for IambWindow {
 impl From<VerifyListState> for IambWindow {
     fn from(list: VerifyListState) -> Self {
         IambWindow::VerifyList(list)
-    }
-}
-
-impl From<DirectListState> for IambWindow {
-    fn from(list: DirectListState) -> Self {
-        IambWindow::DirectList(list)
-    }
-}
-
-impl From<RoomListState> for IambWindow {
-    fn from(list: RoomListState) -> Self {
-        IambWindow::RoomList(list)
     }
 }
 
@@ -517,13 +496,13 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .dms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| DirectItem::new(room_info, store))
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, UndifferentiatedItem))
                     .collect::<Vec<_>>();
                 let fields = &store.application.settings.tunables.sort.dms;
-                let collator = &mut store.application.collator;
-                items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
 
                 state.set(items);
 
@@ -563,13 +542,13 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .rooms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| RoomItem::new(room_info, store))
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, UndifferentiatedItem))
                     .collect::<Vec<_>>();
                 let fields = &store.application.settings.tunables.sort.rooms;
-                let collator = &mut store.application.collator;
-                items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
 
                 state.set(items);
 
@@ -584,24 +563,24 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .rooms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| GenericChatItem::new(room_info, store, false))
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, ChatItem::Room))
                     .collect::<Vec<_>>();
 
                 let dms = store
                     .application
                     .sync_info
                     .dms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| GenericChatItem::new(room_info, store, true));
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, ChatItem::Dm));
 
                 items.extend(dms);
 
                 let fields = &store.application.settings.tunables.sort.chats;
-                let collator = &mut store.application.collator;
-                items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
 
                 state.set(items);
 
@@ -616,9 +595,9 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .rooms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| GenericChatItem::new(room_info, store, false))
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, ChatItem::Room))
                     .filter(RoomLikeItem::is_unread)
                     .collect::<Vec<_>>();
 
@@ -626,16 +605,16 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .dms
-                    .clone()
-                    .into_iter()
-                    .map(|room_info| GenericChatItem::new(room_info, store, true))
+                    .iter()
+                    .filter_map(|room_id| store.application.rooms.get(room_id))
+                    .map(|info| GenericChatItem::new(info, store, ChatItem::Dm))
                     .filter(RoomLikeItem::is_unread);
 
                 items.extend(dms);
 
                 let fields = &store.application.settings.tunables.sort.chats;
-                let collator = &mut store.application.collator;
-                items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
 
                 state.set(items);
 
@@ -650,13 +629,13 @@ impl WindowOps<IambInfo> for IambWindow {
                     .application
                     .sync_info
                     .spaces
-                    .clone()
-                    .into_iter()
-                    .map(|room| SpaceItem::new(room, store))
+                    .iter()
+                    .filter_map(|room_id| store.application.worker.client.get_room(room_id))
+                    .map(SpaceItem::new)
                     .collect::<Vec<_>>();
                 let fields = &store.application.settings.tunables.sort.spaces;
-                let collator = &mut store.application.collator;
-                items.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
 
                 state.set(items);
 
@@ -688,16 +667,16 @@ impl WindowOps<IambInfo> for IambWindow {
     fn dup(&self, store: &mut ProgramStore) -> Self {
         match self {
             IambWindow::Room(w) => w.dup(store).into(),
-            IambWindow::DirectList(w) => w.dup(store).into(),
+            IambWindow::DirectList(w) => IambWindow::DirectList(w.dup(store)),
             IambWindow::MemberList(w, room_id, last_fetch) => {
                 IambWindow::MemberList(w.dup(store), room_id.clone(), *last_fetch)
             },
-            IambWindow::RoomList(w) => w.dup(store).into(),
+            IambWindow::RoomList(w) => IambWindow::RoomList(w.dup(store)),
             IambWindow::SpaceList(w) => w.dup(store).into(),
             IambWindow::VerifyList(w) => w.dup(store).into(),
             IambWindow::Welcome(w) => w.dup(store).into(),
-            IambWindow::ChatList(w) => w.dup(store).into(),
-            IambWindow::UnreadList(w) => w.dup(store).into(),
+            IambWindow::ChatList(w) => IambWindow::ChatList(w.dup(store)),
+            IambWindow::UnreadList(w) => IambWindow::UnreadList(w.dup(store)),
         }
     }
 
@@ -807,7 +786,7 @@ impl Window<IambInfo> for IambWindow {
             IambId::DirectList => {
                 let list = DirectListState::new(IambBufferId::DirectList, vec![]);
 
-                return Ok(list.into());
+                return Ok(IambWindow::DirectList(list));
             },
             IambId::MemberList(room_id) => {
                 let id = IambBufferId::MemberList(room_id.clone());
@@ -819,7 +798,7 @@ impl Window<IambInfo> for IambWindow {
             IambId::RoomList => {
                 let list = RoomListState::new(IambBufferId::RoomList, vec![]);
 
-                return Ok(list.into());
+                return Ok(IambWindow::RoomList(list));
             },
             IambId::SpaceList => {
                 let list = SpaceListState::new(IambBufferId::SpaceList, vec![]);
@@ -839,12 +818,12 @@ impl Window<IambInfo> for IambWindow {
             IambId::ChatList => {
                 let list = ChatListState::new(IambBufferId::ChatList, vec![]);
 
-                Ok(list.into())
+                return Ok(IambWindow::ChatList(list));
             },
             IambId::UnreadList => {
                 let list = UnreadListState::new(IambBufferId::UnreadList, vec![]);
 
-                Ok(IambWindow::UnreadList(list))
+                return Ok(IambWindow::UnreadList(list));
             },
         }
     }
@@ -881,47 +860,80 @@ impl Window<IambInfo> for IambWindow {
     }
 }
 
-#[derive(Clone)]
-pub struct GenericChatItem {
-    room_info: MatrixRoomInfo,
-    name: String,
-    alias: Option<OwnedRoomAliasId>,
-    unread: UnreadInfo,
-    is_dm: bool,
+pub trait ItemType: Clone {
+    fn is_dm(&self) -> bool;
+    fn show_marker(&self) -> bool;
 }
 
-impl GenericChatItem {
-    fn new(room_info: MatrixRoomInfo, store: &mut ProgramStore, is_dm: bool) -> Self {
-        let room = &room_info.deref().0;
-        let room_id = room.room_id();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatItem {
+    Room,
+    Dm,
+}
 
-        let info = store.application.rooms.get_or_default(room_id.to_owned());
-        let name = info.name.clone().unwrap_or_default();
+impl ItemType for ChatItem {
+    fn is_dm(&self) -> bool {
+        match self {
+            Self::Room => false,
+            Self::Dm => true,
+        }
+    }
+
+    fn show_marker(&self) -> bool {
+        true
+    }
+}
+
+/// Eiter a dm-only or a room-only item
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UndifferentiatedItem;
+
+impl ItemType for UndifferentiatedItem {
+    fn is_dm(&self) -> bool {
+        false
+    }
+
+    fn show_marker(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone)]
+pub struct GenericChatItem<T: ItemType> {
+    room: MatrixRoom,
+    name: Option<String>,
+    tags: Option<Tags>,
+    alias: Option<OwnedRoomAliasId>,
+    unread: UnreadInfo,
+    is_dm: T,
+}
+
+impl<T: ItemType> GenericChatItem<T> {
+    fn new(info: &RoomInfo, store: &ProgramStore, is_dm: T) -> Self {
+        let unread = info.unreads(&store.application.settings);
+        let tags = info.tags.clone();
+        let name = info.name.clone();
+
+        let room = info.room().clone();
         let alias = room.canonical_alias();
-        let unread = info.unreads(&store.application.settings);
-        info.tags.clone_from(&room_info.deref().1);
 
-        if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
-        }
-
-        GenericChatItem { room_info, name, alias, is_dm, unread }
+        Self { room, name, tags, alias, is_dm, unread }
     }
 
     #[inline]
     fn room(&self) -> &MatrixRoom {
-        &self.room_info.deref().0
+        &self.room
     }
 
     #[inline]
     fn tags(&self) -> &Option<Tags> {
-        &self.room_info.deref().1
+        &self.tags
     }
 }
 
-impl RoomLikeItem for GenericChatItem {
+impl<T: ItemType> RoomLikeItem for GenericChatItem<T> {
     fn name(&self) -> &str {
-        self.name.as_str()
+        self.name.as_deref().unwrap_or_default()
     }
 
     fn alias(&self) -> Option<&RoomAliasId> {
@@ -933,7 +945,7 @@ impl RoomLikeItem for GenericChatItem {
     }
 
     fn has_tag(&self, tag: TagName) -> bool {
-        if let Some(tags) = &self.room_info.deref().1 {
+        if let Some(tags) = self.tags() {
             tags.contains_key(&tag)
         } else {
             false
@@ -953,13 +965,13 @@ impl RoomLikeItem for GenericChatItem {
     }
 }
 
-impl Display for GenericChatItem {
+impl<T: ItemType> Display for GenericChatItem<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name)
+        write!(f, "{}", self.name())
     }
 }
 
-impl ListItem<IambInfo> for GenericChatItem {
+impl<T: ItemType> ListItem<IambInfo> for GenericChatItem<T> {
     fn show(
         &self,
         selected: bool,
@@ -968,14 +980,16 @@ impl ListItem<IambInfo> for GenericChatItem {
     ) -> Text<'_> {
         let unread = self.unread.is_unread();
         let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, unread, style);
+        let (name, mut labels) = name_and_labels(self.name(), unread, style);
         let mut spans = vec![name];
 
-        labels.push(if self.is_dm {
-            vec![Span::styled("DM", style)]
-        } else {
-            vec![Span::styled("Room", style)]
-        });
+        if self.is_dm.show_marker() {
+            labels.push(if self.is_dm.is_dm() {
+                vec![Span::styled("DM", style)]
+            } else {
+                vec![Span::styled("Room", style)]
+            });
+        }
 
         if let Some(tags) = &self.tags() {
             labels.extend(tags.keys().map(|t| tag_to_span(t, style)));
@@ -990,230 +1004,7 @@ impl ListItem<IambInfo> for GenericChatItem {
     }
 }
 
-impl Promptable<ProgramContext, ProgramStore, IambInfo> for GenericChatItem {
-    fn prompt(
-        &mut self,
-        act: &PromptAction,
-        ctx: &ProgramContext,
-        _: &mut ProgramStore,
-    ) -> EditResult<Vec<(ProgramAction, ProgramContext)>, IambInfo> {
-        room_prompt(self.room_id(), act, ctx)
-    }
-}
-
-#[derive(Clone)]
-pub struct RoomItem {
-    room_info: MatrixRoomInfo,
-    name: String,
-    alias: Option<OwnedRoomAliasId>,
-    unread: UnreadInfo,
-}
-
-impl RoomItem {
-    fn new(room_info: MatrixRoomInfo, store: &mut ProgramStore) -> Self {
-        let room = &room_info.deref().0;
-        let room_id = room.room_id();
-
-        let info = store.application.rooms.get_or_default(room_id.to_owned());
-        let name = info.name.clone().unwrap_or_default();
-        let alias = room.canonical_alias();
-        let unread = info.unreads(&store.application.settings);
-        info.tags.clone_from(&room_info.deref().1);
-
-        if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
-        }
-
-        RoomItem { room_info, name, alias, unread }
-    }
-
-    #[inline]
-    fn room(&self) -> &MatrixRoom {
-        &self.room_info.deref().0
-    }
-
-    #[inline]
-    fn tags(&self) -> &Option<Tags> {
-        &self.room_info.deref().1
-    }
-}
-
-impl RoomLikeItem for RoomItem {
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    fn alias(&self) -> Option<&RoomAliasId> {
-        self.alias.as_deref()
-    }
-
-    fn room_id(&self) -> &RoomId {
-        self.room().room_id()
-    }
-
-    fn has_tag(&self, tag: TagName) -> bool {
-        if let Some(tags) = &self.room_info.deref().1 {
-            tags.contains_key(&tag)
-        } else {
-            false
-        }
-    }
-
-    fn recent_ts(&self) -> Option<&MessageTimeStamp> {
-        self.unread.latest()
-    }
-
-    fn is_unread(&self) -> bool {
-        self.unread.is_unread()
-    }
-
-    fn is_invite(&self) -> bool {
-        self.room().state() == MatrixRoomState::Invited
-    }
-}
-
-impl Display for RoomItem {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-
-impl ListItem<IambInfo> for RoomItem {
-    fn show(
-        &self,
-        selected: bool,
-        _: &ViewportContext<ListCursor>,
-        _: &mut ProgramStore,
-    ) -> Text<'_> {
-        let unread = self.unread.is_unread();
-        let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, unread, style);
-        let mut spans = vec![name];
-
-        if let Some(tags) = &self.tags() {
-            labels.extend(tags.keys().map(|t| tag_to_span(t, style)));
-        }
-
-        append_tags(labels, &mut spans, style);
-
-        Text::from(Line::from(spans))
-    }
-
-    fn get_word(&self) -> Option<String> {
-        self.room_id().to_string().into()
-    }
-}
-
-impl Promptable<ProgramContext, ProgramStore, IambInfo> for RoomItem {
-    fn prompt(
-        &mut self,
-        act: &PromptAction,
-        ctx: &ProgramContext,
-        _: &mut ProgramStore,
-    ) -> EditResult<Vec<(ProgramAction, ProgramContext)>, IambInfo> {
-        room_prompt(self.room_id(), act, ctx)
-    }
-}
-
-#[derive(Clone)]
-pub struct DirectItem {
-    room_info: MatrixRoomInfo,
-    name: String,
-    alias: Option<OwnedRoomAliasId>,
-    unread: UnreadInfo,
-}
-
-impl DirectItem {
-    fn new(room_info: MatrixRoomInfo, store: &mut ProgramStore) -> Self {
-        let room_id = room_info.0.room_id().to_owned();
-        let alias = room_info.0.canonical_alias();
-
-        let info = store.application.rooms.get_or_default(room_id);
-        let name = info.name.clone().unwrap_or_default();
-        let unread = info.unreads(&store.application.settings);
-        info.tags.clone_from(&room_info.deref().1);
-
-        DirectItem { room_info, name, alias, unread }
-    }
-
-    #[inline]
-    fn room(&self) -> &MatrixRoom {
-        &self.room_info.deref().0
-    }
-
-    #[inline]
-    fn tags(&self) -> &Option<Tags> {
-        &self.room_info.deref().1
-    }
-}
-
-impl RoomLikeItem for DirectItem {
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    fn alias(&self) -> Option<&RoomAliasId> {
-        self.alias.as_deref()
-    }
-
-    fn has_tag(&self, tag: TagName) -> bool {
-        if let Some(tags) = &self.room_info.deref().1 {
-            tags.contains_key(&tag)
-        } else {
-            false
-        }
-    }
-
-    fn room_id(&self) -> &RoomId {
-        self.room().room_id()
-    }
-
-    fn recent_ts(&self) -> Option<&MessageTimeStamp> {
-        self.unread.latest()
-    }
-
-    fn is_unread(&self) -> bool {
-        self.unread.is_unread()
-    }
-
-    fn is_invite(&self) -> bool {
-        self.room().state() == MatrixRoomState::Invited
-    }
-}
-
-impl Display for DirectItem {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, ":verify request {}", self.name)
-    }
-}
-
-impl ListItem<IambInfo> for DirectItem {
-    fn show(
-        &self,
-        selected: bool,
-        _: &ViewportContext<ListCursor>,
-        _: &mut ProgramStore,
-    ) -> Text<'_> {
-        let unread = self.unread.is_unread();
-        let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, unread, style);
-        let mut spans = vec![name];
-
-        if let Some(tags) = &self.tags() {
-            labels.extend(tags.keys().map(|t| tag_to_span(t, style)));
-        }
-
-        append_tags(labels, &mut spans, style);
-
-        Text::from(Line::from(spans))
-    }
-
-    fn get_word(&self) -> Option<String> {
-        self.room_id().to_string().into()
-    }
-}
-
-impl Promptable<ProgramContext, ProgramStore, IambInfo> for DirectItem {
+impl<T: ItemType> Promptable<ProgramContext, ProgramStore, IambInfo> for GenericChatItem<T> {
     fn prompt(
         &mut self,
         act: &PromptAction,
@@ -1226,39 +1017,28 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for DirectItem {
 
 #[derive(Clone)]
 pub struct SpaceItem {
-    room_info: MatrixRoomInfo,
-    name: String,
+    room: MatrixRoom,
+    name: Option<String>,
     alias: Option<OwnedRoomAliasId>,
 }
 
 impl SpaceItem {
-    fn new(room_info: MatrixRoomInfo, store: &mut ProgramStore) -> Self {
-        let room_id = room_info.0.room_id();
-        let name = store
-            .application
-            .rooms
-            .get_or_default(room_id.to_owned())
-            .name
-            .clone()
-            .unwrap_or_default();
-        let alias = room_info.0.canonical_alias();
+    fn new(room: MatrixRoom) -> Self {
+        let name = room.cached_display_name().map(|name| name.to_string());
+        let alias = room.canonical_alias();
 
-        if let Some(alias) = &alias {
-            store.application.names.insert(alias.to_string(), room_id.to_owned());
-        }
-
-        SpaceItem { room_info, name, alias }
+        SpaceItem { room, name, alias }
     }
 
     #[inline]
     fn room(&self) -> &MatrixRoom {
-        &self.room_info.deref().0
+        &self.room
     }
 }
 
 impl RoomLikeItem for SpaceItem {
     fn name(&self) -> &str {
-        self.name.as_str()
+        self.name.as_deref().unwrap_or_default()
     }
 
     fn room_id(&self) -> &RoomId {
@@ -1292,7 +1072,7 @@ impl RoomLikeItem for SpaceItem {
 
 impl Display for SpaceItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name)
+        write!(f, "{}", self.name())
     }
 }
 
@@ -1303,7 +1083,7 @@ impl ListItem<IambInfo> for SpaceItem {
         _: &ViewportContext<ListCursor>,
         _: &mut ProgramStore,
     ) -> Text<'_> {
-        selected_text(self.name.as_str(), selected)
+        selected_text(self.name(), selected)
     }
 
     fn get_word(&self) -> Option<String> {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -776,11 +776,17 @@ impl Window<IambInfo> for IambWindow {
     fn open(id: IambId, store: &mut ProgramStore) -> IambResult<Self> {
         match id {
             IambId::Room(room_id, thread) => {
-                let (room, name, tags) = store.application.worker.get_room(room_id)?;
-                let room = RoomState::new(room, thread, name, tags, store);
+                let Some(info) = store.application.rooms.get_mut(&room_id) else {
+                    return Err(UIError::Application(IambError::UnknownRoom(room_id)));
+                };
 
-                // TODO: fetch members
-                // store.application.need_load.need_members(room.id().to_owned());
+                if let Some(root) = thread.as_deref() {
+                    info.ensure_thread(root, &store.application.worker)
+                        .map_err(IambError::from)?;
+                }
+
+                let room = RoomState::new(info.room().clone(), thread, store);
+
                 return Ok(room.into());
             },
             IambId::DirectList => {
@@ -837,13 +843,15 @@ impl Window<IambInfo> for IambWindow {
             IambWindow::open(id, store)
         } else {
             let room_id = worker.join_room(name.clone())?;
+            // TODO: make sure `RoomInfo` exists
             names.insert(name, room_id.clone());
 
-            let (room, name, tags) = store.application.worker.get_room(room_id)?;
-            let room = RoomState::new(room, None, name, tags, store);
+            let Some(info) = store.application.rooms.get_mut(&room_id) else {
+                return Err(UIError::Application(IambError::UnknownRoom(room_id)));
+            };
 
-            // TODO: fetch members
-            // store.application.need_load.need_members(room.id().to_owned());
+            let room = RoomState::new(info.room().clone(), None, store);
+
             Ok(room.into())
         }
     }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1527,7 +1527,7 @@ mod tests {
             tags: vec![],
             alias: None,
             name: "Room 1",
-            unread: UnreadInfo { unread: false, latest: None },
+            unread: UnreadInfo { latest: None, notifications: 0, highlights: 0 },
             invite: false,
         };
 
@@ -1537,8 +1537,9 @@ mod tests {
             alias: None,
             name: "Room 2",
             unread: UnreadInfo {
-                unread: false,
                 latest: Some(40usize.try_into().unwrap()),
+                notifications: 0,
+                highlights: 0,
             },
             invite: false,
         };
@@ -1549,8 +1550,9 @@ mod tests {
             alias: None,
             name: "Room 3",
             unread: UnreadInfo {
-                unread: false,
                 latest: Some(20usize.try_into().unwrap()),
+                notifications: 0,
+                highlights: 0,
             },
             invite: false,
         };

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -326,6 +326,7 @@ macro_rules! delegate {
             IambWindow::Welcome($id) => $e,
             IambWindow::ChatList($id) => $e,
             IambWindow::UnreadList($id) => $e,
+            IambWindow::InviteList($id) => $e,
         }
     };
 }
@@ -340,6 +341,7 @@ pub enum IambWindow {
     Welcome(WelcomeState),
     ChatList(ChatListState),
     UnreadList(UnreadListState),
+    InviteList(InviteListState),
 }
 
 impl IambWindow {
@@ -404,13 +406,14 @@ impl IambWindow {
     }
 }
 
-pub type DirectListState = ListState<GenericChatItem<UndifferentiatedItem>, IambInfo>;
+pub type DirectListState = ListState<GenericChatItem, IambInfo>;
 pub type MemberListState = ListState<MemberItem, IambInfo>;
-pub type RoomListState = ListState<GenericChatItem<UndifferentiatedItem>, IambInfo>;
-pub type ChatListState = ListState<GenericChatItem<ChatItem>, IambInfo>;
-pub type UnreadListState = ListState<GenericChatItem<ChatItem>, IambInfo>;
+pub type RoomListState = ListState<GenericChatItem, IambInfo>;
+pub type ChatListState = ListState<GenericChatItem, IambInfo>;
+pub type UnreadListState = ListState<GenericChatItem, IambInfo>;
 pub type SpaceListState = ListState<SpaceItem, IambInfo>;
 pub type VerifyListState = ListState<VerifyItem, IambInfo>;
+pub type InviteListState = ListState<GenericChatItem, IambInfo>;
 
 impl From<RoomState> for IambWindow {
     fn from(room: RoomState) -> Self {
@@ -498,7 +501,14 @@ impl WindowOps<IambInfo> for IambWindow {
                     .dms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, UndifferentiatedItem))
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::None,
+                        )
+                    })
                     .collect::<Vec<_>>();
                 let fields = &store.application.settings.tunables.sort.dms;
                 let mut collator = Collator::default();
@@ -541,7 +551,14 @@ impl WindowOps<IambInfo> for IambWindow {
                     .rooms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, UndifferentiatedItem))
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::None,
+                        )
+                    })
                     .collect::<Vec<_>>();
                 let fields = &store.application.settings.tunables.sort.rooms;
                 let mut collator = Collator::default();
@@ -562,7 +579,14 @@ impl WindowOps<IambInfo> for IambWindow {
                     .rooms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, ChatItem::Room))
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::Room,
+                        )
+                    })
                     .collect::<Vec<_>>();
 
                 let dms = store
@@ -571,9 +595,26 @@ impl WindowOps<IambInfo> for IambWindow {
                     .dms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, ChatItem::Dm));
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::Dm,
+                        )
+                    });
 
                 items.extend(dms);
+
+                let invites = store
+                    .application
+                    .sync_info
+                    .invites
+                    .iter()
+                    .filter_map(|room_id| store.application.worker.client.get_room(room_id))
+                    .map(|room| GenericChatItem::new(room, None, store, ItemTypeTag::Invite));
+
+                items.extend(invites);
 
                 let fields = &store.application.settings.tunables.sort.chats;
                 let mut collator = Collator::default();
@@ -594,7 +635,14 @@ impl WindowOps<IambInfo> for IambWindow {
                     .rooms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, ChatItem::Room))
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::Room,
+                        )
+                    })
                     .filter(RoomLikeItem::is_unread)
                     .collect::<Vec<_>>();
 
@@ -604,7 +652,14 @@ impl WindowOps<IambInfo> for IambWindow {
                     .dms
                     .iter()
                     .filter_map(|room_id| store.application.rooms.get(room_id))
-                    .map(|info| GenericChatItem::new(info, store, ChatItem::Dm))
+                    .map(|info| {
+                        GenericChatItem::new(
+                            info.room().clone(),
+                            Some(info),
+                            store,
+                            ItemTypeTag::Dm,
+                        )
+                    })
                     .filter(RoomLikeItem::is_unread);
 
                 items.extend(dms);
@@ -617,6 +672,27 @@ impl WindowOps<IambInfo> for IambWindow {
 
                 List::new(store)
                     .empty_message("You do not have any unreads yet")
+                    .empty_alignment(Alignment::Center)
+                    .focus(focused)
+                    .render(area, buf, state);
+            },
+            IambWindow::InviteList(state) => {
+                let mut items = store
+                    .application
+                    .sync_info
+                    .invites
+                    .iter()
+                    .filter_map(|room_id| store.application.worker.client.get_room(room_id))
+                    .map(|room| GenericChatItem::new(room, None, store, ItemTypeTag::None))
+                    .collect::<Vec<_>>();
+                let fields = &store.application.settings.tunables.sort.invites;
+                let mut collator = Collator::default();
+                items.sort_by(|a, b| room_fields_cmp(a, b, fields, &mut collator));
+
+                state.set(items);
+
+                List::new(store)
+                    .empty_message("You don't have any invites")
                     .empty_alignment(Alignment::Center)
                     .focus(focused)
                     .render(area, buf, state);
@@ -674,6 +750,7 @@ impl WindowOps<IambInfo> for IambWindow {
             IambWindow::Welcome(w) => w.dup(store).into(),
             IambWindow::ChatList(w) => IambWindow::ChatList(w.dup(store)),
             IambWindow::UnreadList(w) => IambWindow::UnreadList(w.dup(store)),
+            IambWindow::InviteList(w) => IambWindow::InviteList(w.dup(store)),
         }
     }
 
@@ -715,6 +792,7 @@ impl Window<IambInfo> for IambWindow {
             IambWindow::Welcome(_) => IambId::Welcome,
             IambWindow::ChatList(_) => IambId::ChatList,
             IambWindow::UnreadList(_) => IambId::UnreadList,
+            IambWindow::InviteList(_) => IambId::InviteList,
         }
     }
 
@@ -727,6 +805,7 @@ impl Window<IambInfo> for IambWindow {
             IambWindow::Welcome(_) => bold_spans("Welcome to iamb"),
             IambWindow::ChatList(_) => bold_spans("DMs & Rooms"),
             IambWindow::UnreadList(_) => bold_spans("Unread Messages"),
+            IambWindow::InviteList(_) => bold_spans("Invites"),
 
             IambWindow::Room(w) => {
                 let title = store.application.get_room_title(w.id());
@@ -755,6 +834,7 @@ impl Window<IambInfo> for IambWindow {
             IambWindow::Welcome(_) => bold_spans("Welcome to iamb"),
             IambWindow::ChatList(_) => bold_spans("DMs & Rooms"),
             IambWindow::UnreadList(_) => bold_spans("Unread Messages"),
+            IambWindow::InviteList(_) => bold_spans("Invites"),
 
             IambWindow::Room(w) => w.get_title(store),
             IambWindow::MemberList(state, room_id, _) => {
@@ -823,6 +903,11 @@ impl Window<IambInfo> for IambWindow {
 
                 return Ok(IambWindow::UnreadList(list));
             },
+            IambId::InviteList => {
+                let list = InviteListState::new(IambBufferId::InviteList, vec![]);
+
+                return Ok(IambWindow::InviteList(list));
+            },
         }
     }
 
@@ -852,64 +937,49 @@ impl Window<IambInfo> for IambWindow {
     }
 }
 
-pub trait ItemType: Clone {
-    fn is_dm(&self) -> bool;
-    fn show_marker(&self) -> bool;
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ChatItem {
+pub enum ItemTypeTag {
+    Invite,
     Room,
     Dm,
+    None,
 }
 
-impl ItemType for ChatItem {
-    fn is_dm(&self) -> bool {
+impl ItemTypeTag {
+    fn text(&self) -> Option<&'static str> {
         match self {
-            Self::Room => false,
-            Self::Dm => true,
+            Self::None => None,
+            Self::Invite => Some("Invite"),
+            Self::Room => Some("Room"),
+            Self::Dm => Some("DM"),
         }
-    }
-
-    fn show_marker(&self) -> bool {
-        true
-    }
-}
-
-/// Eiter a dm-only or a room-only item
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UndifferentiatedItem;
-
-impl ItemType for UndifferentiatedItem {
-    fn is_dm(&self) -> bool {
-        false
-    }
-
-    fn show_marker(&self) -> bool {
-        false
     }
 }
 
 #[derive(Clone)]
-pub struct GenericChatItem<T: ItemType> {
+pub struct GenericChatItem {
     room: MatrixRoom,
     name: String,
     tags: Option<Tags>,
     alias: Option<OwnedRoomAliasId>,
-    unread: UnreadInfo,
-    is_dm: T,
+    unread: Option<UnreadInfo>,
+    iamb_tag: ItemTypeTag,
 }
 
-impl<T: ItemType> GenericChatItem<T> {
-    fn new(info: &RoomInfo, store: &ProgramStore, is_dm: T) -> Self {
-        let unread = info.unreads(&store.application.settings);
-        let tags = info.tags.clone();
+impl GenericChatItem {
+    fn new(
+        room: MatrixRoom,
+        info: Option<&RoomInfo>,
+        store: &ProgramStore,
+        iamb_tag: ItemTypeTag,
+    ) -> Self {
+        let unread = info.map(|info| info.unreads(&store.application.settings));
+        let tags = info.and_then(|info| info.tags.clone());
 
-        let room = info.room().clone();
         let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
         let alias = room.canonical_alias();
 
-        Self { room, name, tags, alias, is_dm, unread }
+        Self { room, name, tags, alias, iamb_tag, unread }
     }
 
     #[inline]
@@ -923,7 +993,7 @@ impl<T: ItemType> GenericChatItem<T> {
     }
 }
 
-impl<T: ItemType> RoomLikeItem for GenericChatItem<T> {
+impl RoomLikeItem for GenericChatItem {
     fn name(&self) -> &str {
         &self.name
     }
@@ -945,11 +1015,11 @@ impl<T: ItemType> RoomLikeItem for GenericChatItem<T> {
     }
 
     fn recent_ts(&self) -> Option<&MessageTimeStamp> {
-        self.unread.latest()
+        self.unread.as_ref()?.latest()
     }
 
     fn is_unread(&self) -> bool {
-        self.unread.is_unread()
+        self.unread.as_ref().is_some_and(|u| u.is_unread())
     }
 
     fn is_invite(&self) -> bool {
@@ -957,30 +1027,25 @@ impl<T: ItemType> RoomLikeItem for GenericChatItem<T> {
     }
 }
 
-impl<T: ItemType> Display for GenericChatItem<T> {
+impl Display for GenericChatItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name())
     }
 }
 
-impl<T: ItemType> ListItem<IambInfo> for GenericChatItem<T> {
+impl ListItem<IambInfo> for GenericChatItem {
     fn show(
         &self,
         selected: bool,
         _: &ViewportContext<ListCursor>,
         _: &mut ProgramStore,
     ) -> Text<'_> {
-        let unread = self.unread.is_unread();
         let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(self.name(), unread, style);
+        let (name, mut labels) = name_and_labels(self.name(), self.is_unread(), style);
         let mut spans = vec![name];
 
-        if self.is_dm.show_marker() {
-            labels.push(if self.is_dm.is_dm() {
-                vec![Span::styled("DM", style)]
-            } else {
-                vec![Span::styled("Room", style)]
-            });
+        if let Some(tag) = self.iamb_tag.text() {
+            labels.push(vec![Span::styled(tag, style)]);
         }
 
         if let Some(tags) = &self.tags() {
@@ -996,7 +1061,7 @@ impl<T: ItemType> ListItem<IambInfo> for GenericChatItem<T> {
     }
 }
 
-impl<T: ItemType> Promptable<ProgramContext, ProgramStore, IambInfo> for GenericChatItem<T> {
+impl Promptable<ProgramContext, ProgramStore, IambInfo> for GenericChatItem {
     fn prompt(
         &mut self,
         act: &PromptAction,

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1622,6 +1622,8 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for MemberItem {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto as _;
+
     use super::*;
     use matrix_sdk::ruma::{room_alias_id, server_name};
 
@@ -1753,7 +1755,7 @@ mod tests {
             name: "Room 2",
             unread: UnreadInfo {
                 unread: false,
-                latest: Some(MessageTimeStamp::OriginServer(40u32.into())),
+                latest: Some(40usize.try_into().unwrap()),
             },
             invite: false,
         };
@@ -1765,7 +1767,7 @@ mod tests {
             name: "Room 3",
             unread: UnreadInfo {
                 unread: false,
-                latest: Some(MessageTimeStamp::OriginServer(20u32.into())),
+                latest: Some(20usize.try_into().unwrap()),
             },
             invite: false,
         };

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -161,7 +161,7 @@ impl ChatState {
         let key = self.reply_to.as_ref()?;
         let msg = thread.get(key)?;
 
-        if let MessageEvent::Original(ev) = &msg.event {
+        if let MessageEvent::Original(ev) = msg.event() {
             Some(ev)
         } else {
             None
@@ -212,7 +212,7 @@ impl ChatState {
                 Err(UIError::NeedConfirm(prompt))
             },
             MessageAction::Download(filename, flags) => {
-                if let MessageEvent::Original(ev) = &msg.event {
+                if let MessageEvent::Original(ev) = msg.event() {
                     let media = client.media();
 
                     let mut filename = match (filename, &settings.dirs.downloads) {
@@ -231,11 +231,11 @@ impl ChatState {
                                 return Err(IambError::NoAttachment.into());
                             }
 
-                            let links = if let Some(html) = &msg.html {
+                            let links = if let Some(html) = msg.html() {
                                 html.get_links()
                             } else {
                                 linkify::LinkFinder::new()
-                                    .links(&msg.event.body())
+                                    .links(&msg.event().body())
                                     .filter_map(|u| Url::parse(u.as_str()).ok())
                                     .scan(TreeGenState { link_num: 0 }, |state, u| {
                                         state.next_link_char().map(|c| (c, u))
@@ -294,7 +294,7 @@ impl ChatState {
 
                         fs::write(filename.as_path(), bytes.as_slice())?;
 
-                        msg.downloaded = true;
+                        msg.set_downloaded();
                     } else if !flags.contains(DownloadFlags::OPEN) {
                         let msg = format!(
                             "The file {} already exists; add ! to end of command to overwrite it.",
@@ -334,14 +334,14 @@ impl ChatState {
                 Err(IambError::NoAttachment.into())
             },
             MessageAction::Edit => {
-                if msg.sender != settings.profile.user_id {
+                if msg.sender() != settings.profile.user_id {
                     let msg = "Cannot edit messages sent by someone else";
                     let err = UIError::Failure(msg.into());
 
                     return Err(err);
                 }
 
-                let ev = match &msg.event {
+                let ev = match msg.event() {
                     MessageEvent::Original(ev) => &ev.content,
                     MessageEvent::Local(_, ev) => ev.deref(),
                     _ => {
@@ -386,7 +386,7 @@ impl ChatState {
                 };
 
                 let room = self.get_joined(&store.application.worker)?;
-                let event_id = match &msg.event {
+                let event_id = match msg.event() {
                     MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
                     MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
                     MessageEvent::Original(ev) => ev.event_id.clone(),
@@ -424,7 +424,7 @@ impl ChatState {
                 }
 
                 let room = self.get_joined(&store.application.worker)?;
-                let event_id = match &msg.event {
+                let event_id = match msg.event() {
                     MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
                     MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
                     MessageEvent::Original(ev) => ev.event_id.clone(),
@@ -487,7 +487,7 @@ impl ChatState {
                 };
 
                 let room = self.get_joined(&store.application.worker)?;
-                let event_id = match &msg.event {
+                let event_id = match msg.event() {
                     MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
                     MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
                     MessageEvent::Original(ev) => ev.event_id.clone(),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -854,7 +854,8 @@ impl StatefulWidget for Chat<'_> {
                 #[allow(unused)]
                 self.store.application.rooms.get(state.id()).and_then(|room| {
                     let sender = todo!();
-                    let user = self.store.application.settings.get_user_span(sender, room);
+                    let display_name = todo!();
+                    let user = self.store.application.settings.get_user_span(sender, display_name);
                     let prefix = match (editing.is_some(), thread.is_some()) {
                         (true, false) => Span::from("Editing reply to "),
                         (true, true) => Span::from("Editing reply in thread to "),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -2,6 +2,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Weak;
 
 use edit::edit_with_builder as external_edit;
 use edit::Builder;
@@ -422,17 +423,32 @@ impl ChatState {
                     Err(err)
                 }
             },
-            #[allow(unused)]
             MessageAction::Replied => {
-                let Some(reply) = msg.reply_to() else {
+                let Some(reply_to) = msg.reply_to() else {
                     let msg = "Selected message is not a reply";
                     return Err(UIError::Failure(msg.into()));
                 };
 
-                // maybe switch to event focused timeline
-                let key = todo!();
+                let key = self.scrollback.get_key(info).unwrap();
+                let Some(reply_to) = thread.range_messages(..key).find_map(|(key, item)| {
+                    if item.event_id() == Some(&reply_to) {
+                        Some(key)
+                    } else {
+                        None
+                    }
+                }) else {
+                    if let Some(store) = Weak::upgrade(&worker.store) {
+                        thread.paginate_backwards(store);
+                    }
 
-                self.scrollback.goto_message(key);
+                    let msg = "Replied to message will be loaded in the background";
+                    let err = UIError::Failure(msg.into());
+                    return Err(err);
+                };
+
+                // TODO: maybe switch to event focused timeline
+
+                self.scrollback.goto_message(reply_to);
                 Ok(None)
             },
             MessageAction::Unreact(reaction, literal) => {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -188,7 +188,7 @@ impl ChatState {
                             return Err(IambError::NoAttachment.into());
                         }
 
-                        let links = if let Some(html) = thread.get_html(&msg.item().identifier()) {
+                        let links = if let Some(html) = info.get_html(&msg.item().identifier()) {
                             html.get_links()
                         } else {
                             linkify::LinkFinder::new()

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -104,12 +104,14 @@ impl ChatState {
     ) -> IambResult<Self> {
         let room_id = room.room_id().to_owned();
 
-        let Some(info) = store.application.rooms.get_mut(&room_id) else {
+        let ChatStore { rooms, settings, previews, worker, .. } = &mut store.application;
+
+        let Some(info) = rooms.get_mut(&room_id) else {
             return Err(UIError::Application(IambError::UnknownRoom(room_id)));
         };
 
         if let Some(root) = thread.as_deref() {
-            info.ensure_thread(root, &store.application.worker)
+            info.ensure_thread(root, settings, previews, worker)
                 .map_err(IambError::from)?;
         }
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -106,15 +106,14 @@ impl ChatState {
     ) -> IambResult<Self> {
         let room_id = room.room_id().to_owned();
 
-        let ChatStore { rooms, settings, previews, worker, .. } = &mut store.application;
+        let ChatStore { rooms, worker, .. } = &mut store.application;
 
         let Some(info) = rooms.get_mut(&room_id) else {
             return Err(UIError::Application(IambError::UnknownRoom(room_id)));
         };
 
         if let Some(root) = thread.as_deref() {
-            info.ensure_thread(root, settings, previews, worker)
-                .map_err(IambError::from)?;
+            info.ensure_thread(root, worker).map_err(IambError::from)?;
         }
 
         let scrollback = ScrollbackState::new(room_id.clone(), thread.clone());
@@ -146,12 +145,6 @@ impl ChatState {
         self.reply_to = None;
         self.editing = None;
         self.tbox.reset()
-    }
-
-    pub fn refresh_room(&mut self, store: &mut ProgramStore) {
-        if let Some(room) = store.application.worker.client.get_room(self.id()) {
-            self.room = room;
-        }
     }
 
     pub async fn message_command(

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -97,14 +97,28 @@ pub struct ChatState {
 }
 
 impl ChatState {
-    pub fn new(room: MatrixRoom, thread: Option<OwnedEventId>, store: &mut ProgramStore) -> Self {
+    pub fn new(
+        room: MatrixRoom,
+        thread: Option<OwnedEventId>,
+        store: &mut ProgramStore,
+    ) -> IambResult<Self> {
         let room_id = room.room_id().to_owned();
+
+        let Some(info) = store.application.rooms.get_mut(&room_id) else {
+            return Err(UIError::Application(IambError::UnknownRoom(room_id)));
+        };
+
+        if let Some(root) = thread.as_deref() {
+            info.ensure_thread(root, &store.application.worker)
+                .map_err(IambError::from)?;
+        }
+
         let scrollback = ScrollbackState::new(room_id.clone(), thread.clone());
         let id = IambBufferId::Room(room_id.clone(), thread, RoomFocus::MessageBar);
         let ebuf = store.load_buffer(id);
         let tbox = TextBoxState::new(ebuf);
 
-        ChatState {
+        Ok(ChatState {
             room_id,
             room,
 
@@ -117,7 +131,7 @@ impl ChatState {
 
             reply_to: None,
             editing: None,
-        }
+        })
     }
 
     pub fn thread(&self) -> Option<&OwnedEventId> {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -282,6 +282,7 @@ impl ChatState {
 
                 Ok(info.into())
             },
+            #[allow(unused)]
             MessageAction::Edit => {
                 if !msg.item().is_editable() {
                     let msg = "Cannot edit this message";
@@ -390,9 +391,8 @@ impl ChatState {
                 };
 
                 let Some(key) = info.get_message_key(&reply) else {
-                    store.application.need_load.need_message(self.room_id.clone(), reply);
-                    let msg = "Replied to message will be loaded in the background";
-                    return Err(UIError::Failure(msg.into()));
+                    // maybe switch to event focused timeline
+                    todo!();
                 };
 
                 self.scrollback.goto_message(key.clone());

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -161,7 +161,7 @@ impl ChatState {
         let Some(thread) = self.scrollback.get_thread(info) else {
             return Err(IambError::NoSelectedRoom.into());
         };
-        let msg = self.scrollback.get(info).ok_or(IambError::NoSelectedMessage)?;
+        let msg = self.scrollback.get(info, settings).ok_or(IambError::NoSelectedMessage)?;
 
         match act {
             MessageAction::Cancel(skip_confirm) => {
@@ -317,16 +317,18 @@ impl ChatState {
                     return Err(err);
                 };
 
-                let key = self.scrollback.get_key(info).unwrap();
+                let key = self.scrollback.get_key(info, settings).unwrap();
 
                 if let Some(reply_to) = msg.reply_to() {
-                    let Some(reply_to) = thread.range_messages(..key).find_map(|(key, item)| {
-                        if item.event_id() == Some(&reply_to) {
-                            Some(key)
-                        } else {
-                            None
-                        }
-                    }) else {
+                    let Some(reply_to) =
+                        thread.range_messages(..key, settings).find_map(|(key, item)| {
+                            if item.event_id() == Some(&reply_to) {
+                                Some(key)
+                            } else {
+                                None
+                            }
+                        })
+                    else {
                         let msg = "Replied to message not loaded";
                         let err = UIError::Failure(msg.into());
 
@@ -339,7 +341,7 @@ impl ChatState {
                 }
 
                 self.tbox.set_text(text);
-                self.editing = self.scrollback.get_key(info);
+                self.editing = self.scrollback.get_key(info, settings);
                 self.focus = RoomFocus::MessageBar;
 
                 Ok(None)
@@ -407,7 +409,7 @@ impl ChatState {
             },
             MessageAction::Reply => {
                 if msg.event_id().is_some() {
-                    let key = self.scrollback.get_key(info).unwrap();
+                    let key = self.scrollback.get_key(info, settings).unwrap();
                     self.reply_to = Some(key);
                     self.focus = RoomFocus::MessageBar;
                     Ok(None)
@@ -424,14 +426,16 @@ impl ChatState {
                     return Err(UIError::Failure(msg.into()));
                 };
 
-                let key = self.scrollback.get_key(info).unwrap();
-                let Some(reply_to) = thread.range_messages(..key).find_map(|(key, item)| {
-                    if item.event_id() == Some(&reply_to) {
-                        Some(key)
-                    } else {
-                        None
-                    }
-                }) else {
+                let key = self.scrollback.get_key(info, settings).unwrap();
+                let Some(reply_to) =
+                    thread.range_messages(..key, settings).find_map(|(key, item)| {
+                        if item.event_id() == Some(&reply_to) {
+                            Some(key)
+                        } else {
+                            None
+                        }
+                    })
+                else {
                     if let Some(store) = Weak::upgrade(&worker.store) {
                         thread.paginate_backwards(store);
                     }

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -564,9 +564,9 @@ impl ChatState {
 
                 let mut msg = text_to_message(msg);
 
-                if let Some((_, event_id)) = &self.editing {
+                if let Some(key) = &self.editing {
                     msg.relates_to = Some(Relation::Replacement(Replacement::new(
-                        event_id.clone(),
+                        key.event_id().to_owned(),
                         msg.msgtype.clone().into(),
                     )));
 
@@ -649,7 +649,7 @@ impl ChatState {
 
         if show_echo {
             let user = store.application.settings.profile.user_id.clone();
-            let key = (MessageTimeStamp::LocalEcho, event_id.clone());
+            let key = MessageKey::new(MessageTimeStamp::LocalEcho, event_id.clone());
             let msg = MessageEvent::Local(event_id, msg.into());
             let msg = Message::new(msg, user, MessageTimeStamp::LocalEcho);
             let thread = self.scrollback.get_thread_mut(info);

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -165,7 +165,9 @@ impl ChatState {
         let Some(info) = rooms.get(&self.room_id) else {
             return Err(IambError::NoSelectedRoom.into());
         };
-        let thread = self.scrollback.get_thread(info).unwrap(); // TODO
+        let Some(thread) = self.scrollback.get_thread(info) else {
+            return Err(IambError::NoSelectedRoom.into());
+        };
         let msg = self.scrollback.get(info).ok_or(IambError::NoSelectedMessage)?;
 
         match act {
@@ -509,8 +511,9 @@ impl ChatState {
         let Some(info) = store.application.rooms.get(self.id()) else {
             return Err(IambError::NoSelectedRoom.into());
         };
-        // TODO: don't unwrap?
-        let thread = info.get_thread(self.scrollback.thread().map(|id| &**id)).unwrap();
+        let Some(thread) = info.get_thread(self.scrollback.thread().map(|id| &**id)) else {
+            return Err(IambError::NoSelectedRoom.into());
+        };
 
         let timeline = thread.timeline();
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -1,7 +1,6 @@
 //! Window for Matrix rooms
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use edit::edit_with_builder as external_edit;
@@ -20,12 +19,11 @@ use matrix_sdk::{
     media::{MediaFormat, MediaRequestParameters},
     room::Room as MatrixRoom,
     ruma::{
-        events::room::message::{MessageType, OriginalRoomMessageEvent, RoomMessageEventContent},
+        events::room::message::{MessageType, RoomMessageEventContent},
         OwnedEventId,
         OwnedRoomId,
         RoomId,
     },
-    RoomState,
 };
 
 use ratatui::{
@@ -75,12 +73,10 @@ use crate::base::{
     ProgramContext,
     ProgramStore,
     RoomFocus,
-    RoomInfo,
     SendAction,
 };
 
-use crate::message::{text_to_message, MessageEvent, MessageKey, TreeGenState};
-use crate::worker::Requester;
+use crate::message::{text_to_message, TreeGenState};
 
 use super::scrollback::{Scrollback, ScrollbackState};
 
@@ -96,7 +92,7 @@ pub struct ChatState {
     scrollback: ScrollbackState,
     focus: RoomFocus,
 
-    reply_to: Option<MessageKey>,
+    reply_to: Option<OwnedEventId>,
     editing: Option<TimelineEventItemId>,
 }
 
@@ -128,30 +124,6 @@ impl ChatState {
         self.scrollback.thread()
     }
 
-    fn get_joined(&self, worker: &Requester) -> Result<MatrixRoom, IambError> {
-        let Some(room) = worker.client.get_room(self.id()) else {
-            return Err(IambError::NotJoined);
-        };
-
-        if room.state() == RoomState::Joined {
-            Ok(room)
-        } else {
-            Err(IambError::NotJoined)
-        }
-    }
-
-    fn get_reply_to<'a>(&self, info: &'a RoomInfo) -> Option<&'a OriginalRoomMessageEvent> {
-        let thread = self.scrollback.get_thread(info)?;
-        let key = self.reply_to.as_ref()?;
-        let msg = thread.get(key)?;
-
-        if let MessageEvent::Original(ev) = msg.event() {
-            Some(ev)
-        } else {
-            None
-        }
-    }
-
     fn reset(&mut self) -> EditRope {
         self.reply_to = None;
         self.editing = None;
@@ -172,11 +144,8 @@ impl ChatState {
     ) -> IambResult<EditInfo> {
         let ChatStore { worker, rooms, settings, .. } = &mut store.application;
         let client = &worker.client;
-
         let info = rooms.get_or_default(self.room_id.clone());
-
         let thread = self.scrollback.get_thread(info).unwrap(); // TODO
-
         let msg = self.scrollback.get(info).ok_or(IambError::NoSelectedMessage)?;
 
         match act {
@@ -198,160 +167,146 @@ impl ChatState {
                 Err(UIError::NeedConfirm(prompt))
             },
             MessageAction::Download(filename, flags) => {
-                if let MessageEvent::Original(ev) = msg.event() {
-                    let media = client.media();
+                let Some(ev) = msg.item().content().as_message() else {
+                    return Err(IambError::NoAttachment.into());
+                };
+                let media = client.media();
 
-                    let mut filename = match (filename, &settings.dirs.downloads) {
-                        (Some(f), _) => PathBuf::from(f),
-                        (None, Some(downloads)) => downloads.clone(),
-                        (None, None) => return Err(IambError::NoDownloadDir.into()),
-                    };
+                let mut filename = match (filename, &settings.dirs.downloads) {
+                    (Some(f), _) => PathBuf::from(f),
+                    (None, Some(downloads)) => downloads.clone(),
+                    (None, None) => return Err(IambError::NoDownloadDir.into()),
+                };
 
-                    let (source, msg_filename) = match &ev.content.msgtype {
-                        MessageType::Audio(c) => (c.source.clone(), c.filename()),
-                        MessageType::File(c) => (c.source.clone(), c.filename()),
-                        MessageType::Image(c) => (c.source.clone(), c.filename()),
-                        MessageType::Video(c) => (c.source.clone(), c.filename()),
-                        _ => {
-                            if !flags.contains(DownloadFlags::OPEN) {
-                                return Err(IambError::NoAttachment.into());
-                            }
-
-                            let links = if let Some(html) = msg.html() {
-                                html.get_links()
-                            } else {
-                                linkify::LinkFinder::new()
-                                    .links(&msg.event().body())
-                                    .filter_map(|u| Url::parse(u.as_str()).ok())
-                                    .scan(TreeGenState { link_num: 0 }, |state, u| {
-                                        state.next_link_char().map(|c| (c, u))
-                                    })
-                                    .collect()
-                            };
-
-                            if links.is_empty() {
-                                return Err(IambError::NoAttachment.into());
-                            }
-
-                            let choices = links
-                                .into_iter()
-                                .map(|l| {
-                                    let url = l.1.to_string();
-                                    let act = IambAction::OpenLink(url.clone()).into();
-                                    MultiChoiceItem::new(l.0, url, vec![act])
-                                })
-                                .collect();
-                            let dialog = MultiChoice::new(choices);
-                            let err = UIError::NeedConfirm(Box::new(dialog));
-
-                            return Err(err);
-                        },
-                    };
-
-                    if filename.is_dir() {
-                        filename.push(msg_filename.replace(std::path::MAIN_SEPARATOR_STR, "_"));
-                    }
-
-                    if filename.exists() && !flags.contains(DownloadFlags::FORCE) {
-                        // Find an incrementally suffixed filename, e.g. image-2.jpg -> image-3.jpg
-                        if let Some(stem) = filename.file_stem().and_then(OsStr::to_str) {
-                            let ext = filename.extension();
-                            let mut filename_incr = filename.clone();
-                            for n in 1..=1000 {
-                                if let Some(ext) = ext.and_then(OsStr::to_str) {
-                                    filename_incr.set_file_name(format!("{stem}-{n}.{ext}"));
-                                } else {
-                                    filename_incr.set_file_name(format!("{stem}-{n}"));
-                                }
-
-                                if !filename_incr.exists() {
-                                    filename = filename_incr;
-                                    break;
-                                }
-                            }
+                let (source, msg_filename) = match &ev.msgtype() {
+                    MessageType::Audio(c) => (c.source.clone(), c.filename()),
+                    MessageType::File(c) => (c.source.clone(), c.filename()),
+                    MessageType::Image(c) => (c.source.clone(), c.filename()),
+                    MessageType::Video(c) => (c.source.clone(), c.filename()),
+                    _ => {
+                        if !flags.contains(DownloadFlags::OPEN) {
+                            return Err(IambError::NoAttachment.into());
                         }
-                    }
 
-                    if !filename.exists() || flags.contains(DownloadFlags::FORCE) {
-                        let req = MediaRequestParameters { source, format: MediaFormat::File };
+                        let links = if let Some(html) = msg.html() {
+                            html.get_links()
+                        } else {
+                            linkify::LinkFinder::new()
+                                .links(&msg.body())
+                                .filter_map(|u| Url::parse(u.as_str()).ok())
+                                .scan(TreeGenState { link_num: 0 }, |state, u| {
+                                    state.next_link_char().map(|c| (c, u))
+                                })
+                                .collect()
+                        };
 
-                        let bytes =
-                            media.get_media_content(&req, true).await.map_err(IambError::from)?;
+                        if links.is_empty() {
+                            return Err(IambError::NoAttachment.into());
+                        }
 
-                        fs::write(filename.as_path(), bytes.as_slice())?;
-
-                        let msg =
-                            self.scrollback.get_mut(info).ok_or(IambError::NoSelectedMessage)?;
-                        msg.set_downloaded();
-                    } else if !flags.contains(DownloadFlags::OPEN) {
-                        let msg = format!(
-                            "The file {} already exists; add ! to end of command to overwrite it.",
-                            filename.display()
-                        );
-                        let err = UIError::Failure(msg);
+                        let choices = links
+                            .into_iter()
+                            .map(|l| {
+                                let url = l.1.to_string();
+                                let act = IambAction::OpenLink(url.clone()).into();
+                                MultiChoiceItem::new(l.0, url, vec![act])
+                            })
+                            .collect();
+                        let dialog = MultiChoice::new(choices);
+                        let err = UIError::NeedConfirm(Box::new(dialog));
 
                         return Err(err);
-                    }
+                    },
+                };
 
-                    let info = if flags.contains(DownloadFlags::OPEN) {
-                        let target = filename.clone().into_os_string();
-                        match open_command(
-                            store.application.settings.tunables.open_command.as_ref(),
-                            target,
-                        ) {
-                            Ok(_) => {
-                                InfoMessage::from(format!(
-                                    "Attachment downloaded to {} and opened",
-                                    filename.display()
-                                ))
-                            },
-                            Err(err) => {
-                                return Err(err);
-                            },
-                        }
-                    } else {
-                        InfoMessage::from(format!(
-                            "Attachment downloaded to {}",
-                            filename.display()
-                        ))
-                    };
-
-                    return Ok(info.into());
+                if filename.is_dir() {
+                    filename.push(msg_filename.replace(std::path::MAIN_SEPARATOR_STR, "_"));
                 }
 
-                Err(IambError::NoAttachment.into())
+                if filename.exists() && !flags.contains(DownloadFlags::FORCE) {
+                    // Find an incrementally suffixed filename, e.g. image-2.jpg -> image-3.jpg
+                    if let Some(stem) = filename.file_stem().and_then(OsStr::to_str) {
+                        let ext = filename.extension();
+                        let mut filename_incr = filename.clone();
+                        for n in 1..=1000 {
+                            if let Some(ext) = ext.and_then(OsStr::to_str) {
+                                filename_incr.set_file_name(format!("{stem}-{n}.{ext}"));
+                            } else {
+                                filename_incr.set_file_name(format!("{stem}-{n}"));
+                            }
+
+                            if !filename_incr.exists() {
+                                filename = filename_incr;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if !filename.exists() || flags.contains(DownloadFlags::FORCE) {
+                    let req = MediaRequestParameters { source, format: MediaFormat::File };
+
+                    let bytes =
+                        media.get_media_content(&req, true).await.map_err(IambError::from)?;
+
+                    fs::write(filename.as_path(), bytes.as_slice())?;
+
+                    let msg = self.scrollback.get_mut(info).ok_or(IambError::NoSelectedMessage)?;
+                    msg.set_downloaded();
+                } else if !flags.contains(DownloadFlags::OPEN) {
+                    let msg = format!(
+                        "The file {} already exists; add ! to end of command to overwrite it.",
+                        filename.display()
+                    );
+                    let err = UIError::Failure(msg);
+
+                    return Err(err);
+                }
+
+                let info = if flags.contains(DownloadFlags::OPEN) {
+                    let target = filename.clone().into_os_string();
+                    match open_command(
+                        store.application.settings.tunables.open_command.as_ref(),
+                        target,
+                    ) {
+                        Ok(_) => {
+                            InfoMessage::from(format!(
+                                "Attachment downloaded to {} and opened",
+                                filename.display()
+                            ))
+                        },
+                        Err(err) => {
+                            return Err(err);
+                        },
+                    }
+                } else {
+                    InfoMessage::from(format!("Attachment downloaded to {}", filename.display()))
+                };
+
+                Ok(info.into())
             },
             MessageAction::Edit => {
-                if msg.sender() != Some(&settings.profile.user_id) {
-                    let msg = "Cannot edit messages sent by someone else";
+                if !msg.item().is_editable() {
+                    let msg = "Cannot edit this message";
                     let err = UIError::Failure(msg.into());
 
                     return Err(err);
                 }
 
-                let ev = match msg.event() {
-                    MessageEvent::Original(ev) => &ev.content,
-                    MessageEvent::Local(_, ev) => ev.deref(),
-                    _ => {
-                        let msg = "Cannot edit a redacted message";
-                        let err = UIError::Failure(msg.into());
+                let Some(text) = msg.item().content().as_message().and_then(|msg| {
+                    match msg.msgtype() {
+                        MessageType::Text(msg) => Some(msg.body.as_str()),
+                        _ => None,
+                    }
+                }) else {
+                    let msg = "Cannot edit a non-text message";
+                    let err = UIError::Failure(msg.into());
 
-                        return Err(err);
-                    },
-                };
-
-                let text = match &ev.msgtype {
-                    MessageType::Text(msg) => msg.body.as_str(),
-                    _ => {
-                        let msg = "Cannot edit a non-text message";
-                        let err = UIError::Failure(msg.into());
-
-                        return Err(err);
-                    },
+                    return Err(err);
                 };
 
                 self.tbox.set_text(text);
-                self.reply_to = msg.reply_to().and_then(|id| info.get_message_key(&id)).cloned();
+                self.reply_to = msg.reply_to();
                 self.editing = todo!();
                 self.focus = RoomFocus::MessageBar;
 
@@ -373,14 +328,8 @@ impl ChatState {
                     return Err(UIError::NeedConfirm(prompt));
                 };
 
-                let Some(event_timeline_item) = msg.item().as_event() else {
-                    let msg = "You can only react to a message.".to_owned();
-                    let err = UIError::Failure(msg);
-
-                    return Err(err);
-                };
-
-                if event_timeline_item
+                if msg
+                    .item()
                     .content()
                     .reactions()
                     .and_then(|reactions| reactions.get(&emoji))
@@ -394,7 +343,7 @@ impl ChatState {
 
                 thread
                     .timeline()
-                    .toggle_reaction(&event_timeline_item.identifier(), &emoji)
+                    .toggle_reaction(&msg.item().identifier(), &emoji)
                     .await
                     .map_err(IambError::from)?;
 
@@ -410,32 +359,32 @@ impl ChatState {
                     return Err(UIError::NeedConfirm(prompt));
                 }
 
-                let room = self.get_joined(worker)?;
-                let event_id = match msg.event() {
-                    MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
-                    MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
-                    MessageEvent::Original(ev) => ev.event_id.clone(),
-                    MessageEvent::Local(event_id, _) => event_id.clone(),
-                    MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Redacted(_) => {
-                        let msg = "Cannot redact already redacted message";
-                        let err = UIError::Failure(msg.into());
+                if msg.item().content().is_redacted() {
+                    let msg = "Cannot redact already redacted message";
+                    let err = UIError::Failure(msg.into());
 
-                        return Err(err);
-                    },
-                };
+                    return Err(err);
+                }
 
-                let event_id = event_id.as_ref();
-                let reason = reason.as_deref();
-                let _ = room.redact(event_id, reason, None).await.map_err(IambError::from)?;
+                thread
+                    .timeline()
+                    .redact(&msg.item().identifier(), reason.as_deref())
+                    .await
+                    .map_err(IambError::from)?;
 
                 Ok(None)
             },
             MessageAction::Reply => {
-                self.reply_to = self.scrollback.get_key(info);
-                self.focus = RoomFocus::MessageBar;
+                if let Some(event_id) = msg.item().event_id() {
+                    self.reply_to = Some(event_id.to_owned());
+                    self.focus = RoomFocus::MessageBar;
+                    Ok(None)
+                } else {
+                    let msg = "Cannot reply to a local echo";
+                    let err = UIError::Failure(msg.into());
 
-                Ok(None)
+                    Err(err)
+                }
             },
             MessageAction::Replied => {
                 let Some(reply) = msg.reply_to() else {
@@ -473,11 +422,7 @@ impl ChatState {
                     None => None,
                 };
 
-                let Some(event_timeline_item) = msg.item().as_event() else {
-                    return Ok(None);
-                };
-
-                let reactions = event_timeline_item.content().reactions();
+                let reactions = msg.item().content().reactions();
 
                 let reactions = reactions
                     .iter()
@@ -495,7 +440,7 @@ impl ChatState {
                 for reaction in reactions {
                     thread
                         .timeline()
-                        .toggle_reaction(&event_timeline_item.identifier(), reaction)
+                        .toggle_reaction(&msg.item().identifier(), reaction)
                         .await
                         .map_err(IambError::from)?;
                 }
@@ -546,9 +491,9 @@ impl ChatState {
                         .edit(key, EditedContent::RoomMessage(msg))
                         .await
                         .map_err(IambError::from)?;
-                } else if let Some(m) = self.get_reply_to(info) {
+                } else if let Some(reply_to) = &self.reply_to {
                     timeline
-                        .send_reply(msg, m.event_id.clone())
+                        .send_reply(msg, reply_to.to_owned())
                         .await
                         .map_err(IambError::from)?;
                 } else {
@@ -893,11 +838,12 @@ impl StatefulWidget for Chat<'_> {
             (None, None, Some(_)) => Some(Line::from("Replying in thread")),
             (Some(_), None, None) => Some(Line::from("Editing message")),
             (Some(_), None, Some(_)) => Some(Line::from("Editing message in thread")),
-            (editing, Some(_), thread) => {
+            (editing, Some(_), thread) =>
+            {
+                #[allow(unused)]
                 self.store.application.rooms.get(state.id()).and_then(|room| {
-                    let msg = state.get_reply_to(room)?;
-                    let user =
-                        self.store.application.settings.get_user_span(msg.sender.as_ref(), room);
+                    let sender = todo!();
+                    let user = self.store.application.settings.get_user_span(sender, room);
                     let prefix = match (editing.is_some(), thread.is_some()) {
                         (true, false) => Span::from("Editing reply to "),
                         (true, true) => Span::from("Editing reply in thread to "),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -76,7 +76,7 @@ use crate::base::{
     SendAction,
 };
 
-use crate::message::{text_to_message, TreeGenState};
+use crate::message::{text_to_message, MessageExt, TreeGenState};
 
 use super::scrollback::{Scrollback, ScrollbackState};
 
@@ -188,7 +188,7 @@ impl ChatState {
                             return Err(IambError::NoAttachment.into());
                         }
 
-                        let links = if let Some(html) = msg.html() {
+                        let links = if let Some(html) = thread.get_html(msg.item().event_id()) {
                             html.get_links()
                         } else {
                             linkify::LinkFinder::new()
@@ -250,9 +250,6 @@ impl ChatState {
                         media.get_media_content(&req, true).await.map_err(IambError::from)?;
 
                     fs::write(filename.as_path(), bytes.as_slice())?;
-
-                    let msg = self.scrollback.get_mut(info).ok_or(IambError::NoSelectedMessage)?;
-                    msg.set_downloaded();
                 } else if !flags.contains(DownloadFlags::OPEN) {
                     let msg = format!(
                         "The file {} already exists; add ! to end of command to overwrite it.",

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -8,7 +8,7 @@ use edit::Builder;
 use matrix_sdk::room::edit::EditedContent;
 use matrix_sdk::ruma::events::AnyMessageLikeEventContent;
 use matrix_sdk::EncryptionState;
-use matrix_sdk_ui::timeline::{AttachmentConfig, AttachmentSource, TimelineEventItemId};
+use matrix_sdk_ui::timeline::{AttachmentConfig, AttachmentSource};
 use modalkit::editing::store::RegisterError;
 use ratatui::style::{Color, Style};
 use std::process::Command;
@@ -76,7 +76,8 @@ use crate::base::{
     SendAction,
 };
 
-use crate::message::{text_to_message, MessageExt, TreeGenState};
+use crate::message::{text_to_message, MessageExt, MessageKey, TreeGenState};
+use crate::util::TimelineDetailsExt;
 
 use super::scrollback::{Scrollback, ScrollbackState};
 
@@ -92,8 +93,8 @@ pub struct ChatState {
     scrollback: ScrollbackState,
     focus: RoomFocus,
 
-    reply_to: Option<OwnedEventId>,
-    editing: Option<TimelineEventItemId>,
+    reply_to: Option<MessageKey>,
+    editing: Option<MessageKey>,
 }
 
 impl ChatState {
@@ -300,7 +301,6 @@ impl ChatState {
 
                 Ok(info.into())
             },
-            #[allow(unused)]
             MessageAction::Edit => {
                 if !msg.is_editable() {
                     let msg = "Cannot edit this message";
@@ -321,9 +321,29 @@ impl ChatState {
                     return Err(err);
                 };
 
+                let key = self.scrollback.get_key(info).unwrap();
+
+                if let Some(reply_to) = msg.reply_to() {
+                    let Some(reply_to) = thread.range_messages(..key).find_map(|(key, item)| {
+                        if item.event_id() == Some(&reply_to) {
+                            Some(key)
+                        } else {
+                            None
+                        }
+                    }) else {
+                        let msg = "Replied to message not loaded";
+                        let err = UIError::Failure(msg.into());
+
+                        return Err(err);
+                    };
+
+                    self.reply_to = Some(reply_to);
+                } else {
+                    self.reply_to = None;
+                }
+
                 self.tbox.set_text(text);
-                self.reply_to = msg.reply_to();
-                self.editing = todo!();
+                self.editing = self.scrollback.get_key(info);
                 self.focus = RoomFocus::MessageBar;
 
                 Ok(None)
@@ -390,8 +410,9 @@ impl ChatState {
                 Ok(None)
             },
             MessageAction::Reply => {
-                if let Some(event_id) = msg.event_id() {
-                    self.reply_to = Some(event_id.to_owned());
+                if msg.event_id().is_some() {
+                    let key = self.scrollback.get_key(info).unwrap();
+                    self.reply_to = Some(key);
                     self.focus = RoomFocus::MessageBar;
                     Ok(None)
                 } else {
@@ -401,18 +422,17 @@ impl ChatState {
                     Err(err)
                 }
             },
+            #[allow(unused)]
             MessageAction::Replied => {
                 let Some(reply) = msg.reply_to() else {
                     let msg = "Selected message is not a reply";
                     return Err(UIError::Failure(msg.into()));
                 };
 
-                let Some(key) = info.get_message_key(&reply) else {
-                    // maybe switch to event focused timeline
-                    todo!();
-                };
+                // maybe switch to event focused timeline
+                let key = todo!();
 
-                self.scrollback.goto_message(key.clone());
+                self.scrollback.goto_message(key);
                 Ok(None)
             },
             MessageAction::Unreact(reaction, literal) => {
@@ -474,10 +494,9 @@ impl ChatState {
             return Err(IambError::NoSelectedRoom.into());
         };
         // TODO: don't unwrap?
-        let timeline = info
-            .get_thread(self.scrollback.thread().map(|id| &**id))
-            .unwrap()
-            .timeline();
+        let thread = info.get_thread(self.scrollback.thread().map(|id| &**id)).unwrap();
+
+        let timeline = thread.timeline();
 
         match act {
             SendAction::Submit | SendAction::SubmitFromEditor => {
@@ -503,11 +522,27 @@ impl ChatState {
                 let msg = text_to_message(msg);
 
                 if let Some(key) = &self.editing {
+                    let Some(editing) = thread.get_message(key).map(|event| event.identifier())
+                    else {
+                        self.editing = None;
+                        return Err(UIError::Failure(
+                            "Edited message not found. Please retry".into(),
+                        ));
+                    };
+
                     timeline
-                        .edit(key, EditedContent::RoomMessage(msg))
+                        .edit(&editing, EditedContent::RoomMessage(msg))
                         .await
                         .map_err(IambError::from)?;
-                } else if let Some(reply_to) = &self.reply_to {
+                } else if let Some(key) = &self.reply_to {
+                    let Some(reply_to) = thread.get_message(key).and_then(|event| event.event_id())
+                    else {
+                        self.reply_to = None;
+                        return Err(UIError::Failure(
+                            "Replied to message not found. Please retry".into(),
+                        ));
+                    };
+
                     timeline
                         .send_reply(msg, reply_to.to_owned())
                         .await
@@ -851,26 +886,38 @@ impl StatefulWidget for Chat<'_> {
         // Determine whether we have a description to show for the message bar.
         let desc_spans = match (&state.editing, &state.reply_to, state.thread()) {
             (None, None, None) => None,
-            (None, None, Some(_)) => Some(Line::from("Replying in thread")),
+            (None, None, Some(_)) => Some(Line::from("Writing in thread")),
             (Some(_), None, None) => Some(Line::from("Editing message")),
             (Some(_), None, Some(_)) => Some(Line::from("Editing message in thread")),
-            (editing, Some(_), thread) =>
-            {
-                #[allow(unused)]
-                self.store.application.rooms.get(state.id()).and_then(|room| {
-                    let sender = todo!();
-                    let display_name = todo!();
-                    let user = self.store.application.settings.get_user_span(sender, display_name);
-                    let prefix = match (editing.is_some(), thread.is_some()) {
-                        (true, false) => Span::from("Editing reply to "),
-                        (true, true) => Span::from("Editing reply in thread to "),
-                        (false, false) => Span::from("Replying to "),
-                        (false, true) => Span::from("Replying in thread to "),
-                    };
-                    let spans = Line::from(vec![prefix, user]);
+            (editing, Some(reply_to), thread) => {
+                let orig_sender = self
+                    .store
+                    .application
+                    .rooms
+                    .get(state.id())
+                    .and_then(|info| info.get_thread(state.thread().map(|id| &**id)))
+                    .and_then(|thread| thread.get_message(reply_to))
+                    .map(|msg| {
+                        let sender = msg.sender();
+                        let display_name = msg
+                            .sender_profile()
+                            .ready()
+                            .and_then(|profile| profile.display_name.as_deref());
+                        self.store.application.settings.get_user_span(sender, display_name)
+                    });
+                let prefix = match (editing.is_some(), thread.is_some()) {
+                    (true, false) => Span::from("Editing reply"),
+                    (true, true) => Span::from("Editing reply in thread"),
+                    (false, false) => Span::from("Replying"),
+                    (false, true) => Span::from("Replying in thread"),
+                };
 
-                    spans.into()
-                })
+                if let Some(orig_sender) = orig_sender {
+                    let infix = Span::from(" to ");
+                    Line::from(vec![prefix, infix, orig_sender]).into()
+                } else {
+                    Line::from(vec![prefix]).into()
+                }
             },
         };
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -183,7 +183,7 @@ impl ChatState {
                 Err(UIError::NeedConfirm(prompt))
             },
             MessageAction::Download(filename, flags) => {
-                let Some(ev) = msg.item().content().as_message() else {
+                let Some(ev) = msg.content().as_message() else {
                     return Err(IambError::NoAttachment.into());
                 };
                 let media = client.media();
@@ -204,7 +204,7 @@ impl ChatState {
                             return Err(IambError::NoAttachment.into());
                         }
 
-                        let links = if let Some(html) = info.get_html(&msg.item().identifier()) {
+                        let links = if let Some(html) = info.get_html(&msg.identifier()) {
                             html.get_links()
                         } else {
                             linkify::LinkFinder::new()
@@ -300,14 +300,14 @@ impl ChatState {
             },
             #[allow(unused)]
             MessageAction::Edit => {
-                if !msg.item().is_editable() {
+                if !msg.is_editable() {
                     let msg = "Cannot edit this message";
                     let err = UIError::Failure(msg.into());
 
                     return Err(err);
                 }
 
-                let Some(text) = msg.item().content().as_message().and_then(|msg| {
+                let Some(text) = msg.content().as_message().and_then(|msg| {
                     match msg.msgtype() {
                         MessageType::Text(msg) => Some(msg.body.as_str()),
                         _ => None,
@@ -343,7 +343,6 @@ impl ChatState {
                 };
 
                 if msg
-                    .item()
                     .content()
                     .reactions()
                     .and_then(|reactions| reactions.get(&emoji))
@@ -357,7 +356,7 @@ impl ChatState {
 
                 thread
                     .timeline()
-                    .toggle_reaction(&msg.item().identifier(), &emoji)
+                    .toggle_reaction(&msg.identifier(), &emoji)
                     .await
                     .map_err(IambError::from)?;
 
@@ -373,7 +372,7 @@ impl ChatState {
                     return Err(UIError::NeedConfirm(prompt));
                 }
 
-                if msg.item().content().is_redacted() {
+                if msg.content().is_redacted() {
                     let msg = "Cannot redact already redacted message";
                     let err = UIError::Failure(msg.into());
 
@@ -382,14 +381,14 @@ impl ChatState {
 
                 thread
                     .timeline()
-                    .redact(&msg.item().identifier(), reason.as_deref())
+                    .redact(&msg.identifier(), reason.as_deref())
                     .await
                     .map_err(IambError::from)?;
 
                 Ok(None)
             },
             MessageAction::Reply => {
-                if let Some(event_id) = msg.item().event_id() {
+                if let Some(event_id) = msg.event_id() {
                     self.reply_to = Some(event_id.to_owned());
                     self.focus = RoomFocus::MessageBar;
                     Ok(None)
@@ -435,7 +434,7 @@ impl ChatState {
                     None => None,
                 };
 
-                let reactions = msg.item().content().reactions();
+                let reactions = msg.content().reactions();
 
                 let reactions = reactions
                     .iter()
@@ -453,7 +452,7 @@ impl ChatState {
                 for reaction in reactions {
                     thread
                         .timeline()
-                        .toggle_reaction(&msg.item().identifier(), reaction)
+                        .toggle_reaction(&msg.identifier(), reaction)
                         .await
                         .map_err(IambError::from)?;
                 }

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -20,8 +20,6 @@ use matrix_sdk::{
     media::{MediaFormat, MediaRequestParameters},
     room::Room as MatrixRoom,
     ruma::{
-        events::reaction::ReactionEventContent,
-        events::relation::Annotation,
         events::room::message::{MessageType, OriginalRoomMessageEvent, RoomMessageEventContent},
         OwnedEventId,
         OwnedRoomId,
@@ -65,6 +63,7 @@ use modalkit::errors::{EditError, EditResult, UIError};
 use modalkit::prelude::*;
 
 use crate::base::{
+    ChatStore,
     DownloadFlags,
     IambAction,
     IambBufferId,
@@ -171,12 +170,14 @@ impl ChatState {
         _: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
-        let client = &store.application.worker.client;
+        let ChatStore { worker, rooms, settings, .. } = &mut store.application;
+        let client = &worker.client;
 
-        let settings = &store.application.settings;
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = rooms.get_or_default(self.room_id.clone());
 
-        let msg = self.scrollback.get_mut(info).ok_or(IambError::NoSelectedMessage)?;
+        let thread = self.scrollback.get_thread(info).unwrap(); // TODO
+
+        let msg = self.scrollback.get(info).ok_or(IambError::NoSelectedMessage)?;
 
         match act {
             MessageAction::Cancel(skip_confirm) => {
@@ -279,6 +280,8 @@ impl ChatState {
 
                         fs::write(filename.as_path(), bytes.as_slice())?;
 
+                        let msg =
+                            self.scrollback.get_mut(info).ok_or(IambError::NoSelectedMessage)?;
                         msg.set_downloaded();
                     } else if !flags.contains(DownloadFlags::OPEN) {
                         let msg = format!(
@@ -370,31 +373,30 @@ impl ChatState {
                     return Err(UIError::NeedConfirm(prompt));
                 };
 
-                let room = self.get_joined(&store.application.worker)?;
-                let event_id = match msg.event() {
-                    MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
-                    MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
-                    MessageEvent::Original(ev) => ev.event_id.clone(),
-                    MessageEvent::Local(event_id, _) => event_id.clone(),
-                    MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Redacted(_) => {
-                        let msg = "Cannot react to a redacted message";
-                        let err = UIError::Failure(msg.into());
+                let Some(event_timeline_item) = msg.item().as_event() else {
+                    let msg = "You can only react to a message.".to_owned();
+                    let err = UIError::Failure(msg);
 
-                        return Err(err);
-                    },
+                    return Err(err);
                 };
 
-                if info.user_reactions_contains(&settings.profile.user_id, &event_id, &emoji) {
+                if event_timeline_item
+                    .content()
+                    .reactions()
+                    .and_then(|reactions| reactions.get(&emoji))
+                    .is_some_and(|reactions| reactions.contains_key(&settings.profile.user_id))
+                {
                     let msg = format!("You’ve already reacted to this message with {emoji}");
                     let err = UIError::Failure(msg);
 
                     return Err(err);
                 }
 
-                let reaction = Annotation::new(event_id, emoji);
-                let msg = ReactionEventContent::new(reaction);
-                let _ = room.send(msg).await.map_err(IambError::from)?;
+                thread
+                    .timeline()
+                    .toggle_reaction(&event_timeline_item.identifier(), &emoji)
+                    .await
+                    .map_err(IambError::from)?;
 
                 Ok(None)
             },
@@ -408,7 +410,7 @@ impl ChatState {
                     return Err(UIError::NeedConfirm(prompt));
                 }
 
-                let room = self.get_joined(&store.application.worker)?;
+                let room = self.get_joined(worker)?;
                 let event_id = match msg.event() {
                     MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
                     MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
@@ -471,44 +473,31 @@ impl ChatState {
                     None => None,
                 };
 
-                let room = self.get_joined(&store.application.worker)?;
-                let event_id = match msg.event() {
-                    MessageEvent::EncryptedOriginal(ev) => ev.event_id.clone(),
-                    MessageEvent::EncryptedRedacted(ev) => ev.event_id.clone(),
-                    MessageEvent::Original(ev) => ev.event_id.clone(),
-                    MessageEvent::Local(event_id, _) => event_id.clone(),
-                    MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Redacted(_) => {
-                        let msg = "Cannot unreact to a redacted message";
-                        let err = UIError::Failure(msg.into());
-
-                        return Err(err);
-                    },
+                let Some(event_timeline_item) = msg.item().as_event() else {
+                    return Ok(None);
                 };
 
-                let reactions = match info.reactions.get(&event_id) {
-                    Some(r) => r,
-                    None => return Ok(None),
-                };
+                let reactions = event_timeline_item.content().reactions();
 
-                let reactions = reactions.iter().filter_map(|(event_id, (reaction, user_id))| {
-                    if user_id != &settings.profile.user_id {
-                        return None;
-                    }
-
-                    if let Some(emoji) = &emoji {
-                        if emoji == reaction {
-                            return Some(event_id);
-                        } else {
-                            return None;
-                        }
-                    } else {
-                        return Some(event_id);
-                    }
-                });
+                let reactions = reactions
+                    .iter()
+                    .flat_map(|reactions| {
+                        reactions.iter().filter_map(|(key, users)| {
+                            if users.contains_key(&settings.profile.user_id) {
+                                Some(key)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .filter(|key| emoji.as_ref().is_none_or(|emoji| &emoji == key));
 
                 for reaction in reactions {
-                    let _ = room.redact(reaction, None, None).await.map_err(IambError::from)?;
+                    thread
+                        .timeline()
+                        .toggle_reaction(&event_timeline_item.identifier(), reaction)
+                        .await
+                        .map_err(IambError::from)?;
                 }
 
                 Ok(None)

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -158,7 +158,9 @@ impl ChatState {
     ) -> IambResult<EditInfo> {
         let ChatStore { worker, rooms, settings, .. } = &mut store.application;
         let client = &worker.client;
-        let info = rooms.get_or_default(self.room_id.clone());
+        let Some(info) = rooms.get(&self.room_id) else {
+            return Err(IambError::NoSelectedRoom.into());
+        };
         let thread = self.scrollback.get_thread(info).unwrap(); // TODO
         let msg = self.scrollback.get(info).ok_or(IambError::NoSelectedMessage)?;
 
@@ -467,7 +469,9 @@ impl ChatState {
         _: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
-        let info = store.application.rooms.get_or_default(self.id().to_owned());
+        let Some(info) = store.application.rooms.get(self.id()) else {
+            return Err(IambError::NoSelectedRoom.into());
+        };
         // TODO: don't unwrap?
         let timeline = info
             .get_thread(self.scrollback.thread().map(|id| &**id))

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -188,7 +188,7 @@ impl ChatState {
                             return Err(IambError::NoAttachment.into());
                         }
 
-                        let links = if let Some(html) = thread.get_html(msg.item().event_id()) {
+                        let links = if let Some(html) = thread.get_html(&msg.item().identifier()) {
                             html.get_links()
                         } else {
                             linkify::LinkFinder::new()

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -1,5 +1,4 @@
 //! Window for Matrix rooms
-use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::ops::Deref;
@@ -7,7 +6,10 @@ use std::path::{Path, PathBuf};
 
 use edit::edit_with_builder as external_edit;
 use edit::Builder;
+use matrix_sdk::room::edit::EditedContent;
+use matrix_sdk::ruma::events::AnyMessageLikeEventContent;
 use matrix_sdk::EncryptionState;
+use matrix_sdk_ui::timeline::{AttachmentConfig, AttachmentSource, TimelineEventItemId};
 use modalkit::editing::store::RegisterError;
 use ratatui::style::{Color, Style};
 use std::process::Command;
@@ -15,22 +17,12 @@ use tokio;
 use url::Url;
 
 use matrix_sdk::{
-    attachment::AttachmentConfig,
     media::{MediaFormat, MediaRequestParameters},
     room::Room as MatrixRoom,
     ruma::{
         events::reaction::ReactionEventContent,
-        events::relation::{Annotation, Replacement},
-        events::room::message::{
-            AddMentions,
-            ForwardThread,
-            MessageType,
-            OriginalRoomMessageEvent,
-            Relation,
-            ReplyWithinThread,
-            RoomMessageEventContent,
-            TextMessageEventContent,
-        },
+        events::relation::Annotation,
+        events::room::message::{MessageType, OriginalRoomMessageEvent, RoomMessageEventContent},
         OwnedEventId,
         OwnedRoomId,
         RoomId,
@@ -88,14 +80,7 @@ use crate::base::{
     SendAction,
 };
 
-use crate::message::{
-    text_to_message,
-    Message,
-    MessageEvent,
-    MessageKey,
-    MessageTimeStamp,
-    TreeGenState,
-};
+use crate::message::{text_to_message, MessageEvent, MessageKey, TreeGenState};
 use crate::worker::Requester;
 
 use super::scrollback::{Scrollback, ScrollbackState};
@@ -113,7 +98,7 @@ pub struct ChatState {
     focus: RoomFocus,
 
     reply_to: Option<MessageKey>,
-    editing: Option<MessageKey>,
+    editing: Option<TimelineEventItemId>,
 }
 
 impl ChatState {
@@ -364,7 +349,7 @@ impl ChatState {
 
                 self.tbox.set_text(text);
                 self.reply_to = msg.reply_to().and_then(|id| info.get_message_key(&id)).cloned();
-                self.editing = self.scrollback.get_key(info);
+                self.editing = todo!();
                 self.focus = RoomFocus::MessageBar;
 
                 Ok(None)
@@ -537,11 +522,14 @@ impl ChatState {
         _: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
-        let room = self.get_joined(&store.application.worker)?;
         let info = store.application.rooms.get_or_default(self.id().to_owned());
-        let mut show_echo = true;
+        // TODO: don't unwrap?
+        let timeline = info
+            .get_thread(self.scrollback.thread().map(|id| &**id))
+            .unwrap()
+            .timeline();
 
-        let (event_id, msg) = match act {
+        match act {
             SendAction::Submit | SendAction::SubmitFromEditor => {
                 let msg = self.tbox.get();
 
@@ -562,59 +550,37 @@ impl ChatState {
                     msg.trim_end().to_string()
                 };
 
-                let mut msg = text_to_message(msg);
+                let msg = text_to_message(msg);
 
                 if let Some(key) = &self.editing {
-                    msg.relates_to = Some(Relation::Replacement(Replacement::new(
-                        key.event_id().to_owned(),
-                        msg.msgtype.clone().into(),
-                    )));
-
-                    show_echo = false;
-                } else if let Some(thread_root) = self.scrollback.thread() {
-                    if let Some(m) = self.get_reply_to(info) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::Yes, AddMentions::No);
-                    } else if let Some(m) = info.get_thread_last(thread_root) {
-                        msg = msg.make_for_thread(m, ReplyWithinThread::No, AddMentions::No);
-                    } else {
-                        // Internal state is wonky?
-                    }
+                    timeline
+                        .edit(key, EditedContent::RoomMessage(msg))
+                        .await
+                        .map_err(IambError::from)?;
                 } else if let Some(m) = self.get_reply_to(info) {
-                    msg = msg.make_reply_to(m, ForwardThread::Yes, AddMentions::No);
+                    timeline
+                        .send_reply(msg, m.event_id.clone())
+                        .await
+                        .map_err(IambError::from)?;
+                } else {
+                    let msg = AnyMessageLikeEventContent::RoomMessage(
+                        RoomMessageEventContent::new(msg.msgtype),
+                    );
+                    timeline.send(msg).await.map_err(IambError::from)?;
                 }
-
-                // XXX: second parameter can be a locally unique transaction id.
-                // Useful for doing retries.
-                let resp = room.send(msg.clone()).await.map_err(IambError::from)?;
-                let event_id = resp.event_id;
 
                 // Reset message bar state now that it's been sent.
                 self.reset();
-
-                (event_id, msg)
             },
             SendAction::Upload(file) => {
                 let path = Path::new(file.as_str());
                 let mime = mime_guess::from_path(path).first_or(mime::APPLICATION_OCTET_STREAM);
+                let config = AttachmentConfig::default();
 
-                let bytes = fs::read(path)?;
-                let name = path
-                    .file_name()
-                    .map(OsStr::to_string_lossy)
-                    .unwrap_or_else(|| Cow::from("Attachment"));
-                let config = AttachmentConfig::new();
-
-                let resp = room
-                    .send_attachment(name.as_ref(), &mime, bytes, config)
+                timeline
+                    .send_attachment(AttachmentSource::File(path.to_owned()), mime, config)
                     .await
                     .map_err(IambError::from)?;
-
-                // Mock up the local echo message for the scrollback.
-                let msg = TextMessageEventContent::plain(format!("[Attached File: {name}]"));
-                let msg = MessageType::Text(msg);
-                let msg = RoomMessageEventContent::new(msg);
-
-                (resp.event_id, msg)
             },
             SendAction::UploadImage(width, height, bytes) => {
                 // Convert to png because arboard does not give us the mime type.
@@ -630,30 +596,14 @@ impl ChatState {
                         })?;
                 let mime = mime::IMAGE_PNG;
 
-                let name = "Clipboard.png";
-                let config = AttachmentConfig::new();
+                let filename = "Clipboard.png".to_string();
+                let config = AttachmentConfig::default();
 
-                let resp = room
-                    .send_attachment(name, &mime, bytes, config)
+                timeline
+                    .send_attachment(AttachmentSource::Data { bytes, filename }, mime, config)
                     .await
                     .map_err(IambError::from)?;
-
-                // Mock up the local echo message for the scrollback.
-                let msg = TextMessageEventContent::plain(format!("[Attached File: {name}]"));
-                let msg = MessageType::Text(msg);
-                let msg = RoomMessageEventContent::new(msg);
-
-                (resp.event_id, msg)
             },
-        };
-
-        if show_echo {
-            let user = store.application.settings.profile.user_id.clone();
-            let key = MessageKey::new(MessageTimeStamp::LocalEcho, event_id.clone());
-            let msg = MessageEvent::Local(event_id, msg.into());
-            let msg = Message::new(msg, user, MessageTimeStamp::LocalEcho);
-            let thread = self.scrollback.get_thread_mut(info);
-            thread.insert(key, msg);
         }
 
         // Jump to the end of the scrollback to show the message.

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -16,16 +16,10 @@ use std::process::Command;
 use tokio;
 use url::Url;
 
-use matrix_sdk::{
-    media::{MediaFormat, MediaRequestParameters},
-    room::Room as MatrixRoom,
-    ruma::{
-        events::room::message::{MessageType, RoomMessageEventContent},
-        OwnedEventId,
-        OwnedRoomId,
-        RoomId,
-    },
-};
+use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
+use matrix_sdk::room::Room as MatrixRoom;
+use matrix_sdk::ruma::events::room::message::MessageType;
+use matrix_sdk::ruma::{OwnedEventId, OwnedRoomId, RoomId};
 
 use ratatui::{
     buffer::Buffer,
@@ -564,9 +558,7 @@ impl ChatState {
                         .await
                         .map_err(IambError::from)?;
                 } else {
-                    let msg = AnyMessageLikeEventContent::RoomMessage(
-                        RoomMessageEventContent::new(msg.msgtype),
-                    );
+                    let msg = AnyMessageLikeEventContent::RoomMessage(msg.into());
                     timeline.send(msg).await.map_err(IambError::from)?;
                 }
 

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -334,7 +334,7 @@ impl ChatState {
                 Err(IambError::NoAttachment.into())
             },
             MessageAction::Edit => {
-                if msg.sender() != settings.profile.user_id {
+                if msg.sender() != Some(&settings.profile.user_id) {
                     let msg = "Cannot edit messages sent by someone else";
                     let err = UIError::Failure(msg.into());
 

--- a/src/windows/room/invite.rs
+++ b/src/windows/room/invite.rs
@@ -1,0 +1,156 @@
+use matrix_sdk::room::Invite;
+use matrix_sdk::Room as MatrixRoom;
+use modalkit::actions::{Editable, EditorAction, Jumpable, PromptAction, Promptable, Scrollable};
+use modalkit::editing::completion::CompletionList;
+use modalkit::errors::{EditError, EditResult, UIResult};
+use modalkit::prelude::{
+    CloseFlags,
+    EditInfo,
+    MoveDir1D,
+    PositionList,
+    ScrollStyle,
+    WordStyle,
+    WriteFlags,
+};
+use modalkit_ratatui::{TermOffset, TerminalCursor, WindowOps};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Paragraph, Widget};
+
+use crate::base::{IambError, IambInfo, IambResult, ProgramAction, ProgramContext, ProgramStore};
+
+pub struct InviteState {
+    room: MatrixRoom,
+    invite: Invite,
+}
+
+impl InviteState {
+    pub fn room(&self) -> &MatrixRoom {
+        &self.room
+    }
+
+    pub fn new(room: MatrixRoom, store: &mut ProgramStore) -> IambResult<Self> {
+        let invite = store
+            .application
+            .worker
+            .get_inviter(room.clone())
+            .map_err(IambError::from)?;
+
+        Ok(Self { room, invite })
+    }
+}
+
+impl WindowOps<IambInfo> for InviteState {
+    fn draw(&mut self, area: Rect, buf: &mut Buffer, _focused: bool, store: &mut ProgramStore) {
+        let inviter = &self.invite.inviter;
+
+        let name = match self.room().canonical_alias() {
+            Some(alias) => alias.to_string(),
+            None => format!("{:?}", store.application.get_room_title(self.room().room_id())),
+        };
+
+        let mut invited = vec![Span::from(format!("You have been invited to join {name}"))];
+
+        if let Some(inviter) = inviter {
+            invited.push(Span::from(" by "));
+            invited.push(
+                store
+                    .application
+                    .settings
+                    .get_user_span(inviter.user_id(), inviter.display_name()),
+            );
+        }
+
+        let l1 = Line::from(invited);
+        let l2 = Line::from(
+            "You can run `:invite accept` or `:invite reject` to accept or reject this invitation.",
+        );
+        let text = Text::from(vec![l1, l2]);
+
+        Paragraph::new(text).alignment(Alignment::Center).render(area, buf);
+    }
+
+    fn dup(&self, _store: &mut ProgramStore) -> Self {
+        Self {
+            room: self.room.clone(),
+            invite: self.invite.clone(),
+        }
+    }
+
+    fn close(&mut self, _flags: CloseFlags, _store: &mut ProgramStore) -> bool {
+        true
+    }
+
+    fn get_completions(&self) -> Option<CompletionList> {
+        None
+    }
+
+    fn get_cursor_word(&self, _style: &WordStyle) -> Option<String> {
+        None
+    }
+
+    fn get_selected_word(&self) -> Option<String> {
+        None
+    }
+
+    fn write(
+        &mut self,
+        _path: Option<&str>,
+        _flags: WriteFlags,
+        _store: &mut ProgramStore,
+    ) -> UIResult<EditInfo, IambInfo> {
+        Ok(None)
+    }
+}
+
+impl Editable<ProgramContext, ProgramStore, IambInfo> for InviteState {
+    fn editor_command(
+        &mut self,
+        _act: &EditorAction,
+        _ctx: &ProgramContext,
+        _store: &mut ProgramStore,
+    ) -> EditResult<EditInfo, IambInfo> {
+        Err(EditError::ReadOnly)
+    }
+}
+
+impl Jumpable<ProgramContext, IambInfo> for InviteState {
+    fn jump(
+        &mut self,
+        _list: PositionList,
+        _dir: MoveDir1D,
+        count: usize,
+        _ctx: &ProgramContext,
+    ) -> UIResult<usize, IambInfo> {
+        Ok(count)
+    }
+}
+
+impl Scrollable<ProgramContext, ProgramStore, IambInfo> for InviteState {
+    fn scroll(
+        &mut self,
+        _style: &ScrollStyle,
+        _ctx: &ProgramContext,
+        _store: &mut ProgramStore,
+    ) -> EditResult<EditInfo, IambInfo> {
+        Ok(None)
+    }
+}
+
+impl Promptable<ProgramContext, ProgramStore, IambInfo> for InviteState {
+    fn prompt(
+        &mut self,
+        _act: &PromptAction,
+        _ctx: &ProgramContext,
+        _store: &mut ProgramStore,
+    ) -> EditResult<Vec<(ProgramAction, ProgramContext)>, IambInfo> {
+        Ok(vec![])
+    }
+}
+
+impl TerminalCursor for InviteState {
+    fn get_term_cursor(&self) -> Option<TermOffset> {
+        None
+    }
+}

--- a/src/windows/room/invite.rs
+++ b/src/windows/room/invite.rs
@@ -107,11 +107,15 @@ impl WindowOps<IambInfo> for InviteState {
 impl Editable<ProgramContext, ProgramStore, IambInfo> for InviteState {
     fn editor_command(
         &mut self,
-        _act: &EditorAction,
-        _ctx: &ProgramContext,
+        act: &EditorAction,
+        ctx: &ProgramContext,
         _store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        Err(EditError::ReadOnly)
+        if act.is_readonly(ctx) {
+            Ok(None)
+        } else {
+            Err(EditError::ReadOnly)
+        }
     }
 }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -19,14 +19,13 @@ use matrix_sdk::{
                 name::RoomNameEventContent,
                 topic::RoomTopicEventContent,
             },
-            tag::{TagInfo, Tags},
+            tag::TagInfo,
         },
         OwnedEventId,
         OwnedRoomAliasId,
         OwnedUserId,
         RoomId,
     },
-    RoomDisplayName,
     RoomState as MatrixRoomState,
 };
 
@@ -137,18 +136,7 @@ impl From<SpaceState> for RoomState {
 }
 
 impl RoomState {
-    pub fn new(
-        room: MatrixRoom,
-        thread: Option<OwnedEventId>,
-        name: RoomDisplayName,
-        tags: Option<Tags>,
-        store: &mut ProgramStore,
-    ) -> Self {
-        let room_id = room.room_id().to_owned();
-        let info = store.application.rooms.get_or_default(room_id);
-        info.name = name.to_string();
-        info.tags = tags;
-
+    pub fn new(room: MatrixRoom, thread: Option<OwnedEventId>, store: &mut ProgramStore) -> Self {
         if room.is_space() {
             SpaceState::new(room).into()
         } else {

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -136,11 +136,15 @@ impl From<SpaceState> for RoomState {
 }
 
 impl RoomState {
-    pub fn new(room: MatrixRoom, thread: Option<OwnedEventId>, store: &mut ProgramStore) -> Self {
+    pub fn new(
+        room: MatrixRoom,
+        thread: Option<OwnedEventId>,
+        store: &mut ProgramStore,
+    ) -> IambResult<Self> {
         if room.is_space() {
-            SpaceState::new(room).into()
+            Ok(SpaceState::new(room).into())
         } else {
-            ChatState::new(room, thread, store).into()
+            Ok(ChatState::new(room, thread, store)?.into())
         }
     }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -152,7 +152,7 @@ impl RoomState {
         thread: Option<OwnedEventId>,
         store: &mut ProgramStore,
     ) -> IambResult<Self> {
-        if store.application.sync_info.invites.iter().any(|id| id == room.room_id()) {
+        if room.state() == matrix_sdk::RoomState::Invited {
             return Ok(InviteState::new(room, store)?.into());
         }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -26,15 +26,14 @@ use matrix_sdk::{
         OwnedUserId,
         RoomId,
     },
-    RoomState as MatrixRoomState,
 };
 
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Rect},
+    layout::Rect,
     style::{Modifier as StyleModifier, Style},
-    text::{Line, Span, Text},
-    widgets::{Paragraph, StatefulWidget, Widget},
+    text::{Line, Span},
+    widgets::StatefulWidget,
 };
 
 use modalkit::actions::{
@@ -51,21 +50,24 @@ use modalkit::prelude::*;
 use modalkit::{editing::completion::CompletionList, keybindings::dialog::PromptYesNo};
 use modalkit_ratatui::{TermOffset, TerminalCursor, WindowOps};
 
-use crate::base::{
-    IambAction,
-    IambError,
-    IambId,
-    IambInfo,
-    IambResult,
-    MemberUpdateAction,
-    MessageAction,
-    ProgramAction,
-    ProgramContext,
-    ProgramStore,
-    RoomAction,
-    RoomField,
-    SendAction,
-    SpaceAction,
+use crate::{
+    base::{
+        IambAction,
+        IambError,
+        IambId,
+        IambInfo,
+        IambResult,
+        MemberUpdateAction,
+        MessageAction,
+        ProgramAction,
+        ProgramContext,
+        ProgramStore,
+        RoomAction,
+        RoomField,
+        SendAction,
+        SpaceAction,
+    },
+    windows::room::invite::InviteState,
 };
 
 use self::chat::ChatState;
@@ -74,6 +76,7 @@ use self::space::{Space, SpaceState};
 use std::convert::TryFrom;
 
 mod chat;
+mod invite;
 mod scrollback;
 mod space;
 
@@ -82,6 +85,7 @@ macro_rules! delegate {
         match $s {
             RoomState::Chat($id) => $e,
             RoomState::Space($id) => $e,
+            RoomState::Invite($id) => $e,
         }
     };
 }
@@ -121,6 +125,7 @@ fn hist_visibility_mode(name: impl Into<String>) -> IambResult<HistoryVisibility
 pub enum RoomState {
     Chat(Box<ChatState>),
     Space(Box<SpaceState>),
+    Invite(Box<InviteState>),
 }
 
 impl From<ChatState> for RoomState {
@@ -135,12 +140,22 @@ impl From<SpaceState> for RoomState {
     }
 }
 
+impl From<InviteState> for RoomState {
+    fn from(invite: InviteState) -> Self {
+        RoomState::Invite(Box::new(invite))
+    }
+}
+
 impl RoomState {
     pub fn new(
         room: MatrixRoom,
         thread: Option<OwnedEventId>,
         store: &mut ProgramStore,
     ) -> IambResult<Self> {
+        if store.application.sync_info.invites.iter().any(|id| id == room.room_id()) {
+            return Ok(InviteState::new(room, store)?.into());
+        }
+
         if room.is_space() {
             Ok(SpaceState::new(room).into())
         } else {
@@ -151,52 +166,8 @@ impl RoomState {
     pub fn thread(&self) -> Option<&OwnedEventId> {
         match self {
             RoomState::Chat(chat) => chat.thread(),
-            RoomState::Space(_) => None,
+            RoomState::Space(_) | RoomState::Invite(_) => None,
         }
-    }
-
-    pub fn refresh_room(&mut self, store: &mut ProgramStore) {
-        match self {
-            RoomState::Chat(chat) => chat.refresh_room(store),
-            RoomState::Space(space) => space.refresh_room(store),
-        }
-    }
-
-    fn draw_invite(
-        &self,
-        invited: MatrixRoom,
-        area: Rect,
-        buf: &mut Buffer,
-        store: &mut ProgramStore,
-    ) {
-        let inviter = store.application.worker.get_inviter(invited.clone());
-
-        let name = match invited.canonical_alias() {
-            Some(alias) => alias.to_string(),
-            None => format!("{:?}", store.application.get_room_title(self.id())),
-        };
-
-        let mut invited = vec![Span::from(format!("You have been invited to join {name}"))];
-
-        if let Ok(Some(inviter)) = &inviter {
-            invited.push(Span::from(" by "));
-            invited.push(
-                store
-                    .application
-                    .settings
-                    .get_user_span(inviter.user_id(), inviter.display_name()),
-            );
-        }
-
-        let l1 = Line::from(invited);
-        let l2 = Line::from(
-            "You can run `:invite accept` or `:invite reject` to accept or reject this invitation.",
-        );
-        let text = Text::from(vec![l1, l2]);
-
-        Paragraph::new(text).alignment(Alignment::Center).render(area, buf);
-
-        return;
     }
 
     pub async fn message_command(
@@ -208,6 +179,7 @@ impl RoomState {
         match self {
             RoomState::Chat(chat) => chat.message_command(act, ctx, store).await,
             RoomState::Space(_) => Err(IambError::NoSelectedMessage.into()),
+            RoomState::Invite(_) => Err(IambError::NotJoined.into()),
         }
     }
 
@@ -220,6 +192,7 @@ impl RoomState {
         match self {
             RoomState::Space(space) => space.space_command(act, ctx, store).await,
             RoomState::Chat(_) => Err(IambError::NoSelectedSpace.into()),
+            RoomState::Invite(_) => Err(IambError::NotJoined.into()),
         }
     }
 
@@ -232,6 +205,7 @@ impl RoomState {
         match self {
             RoomState::Chat(chat) => chat.send_command(act, ctx, store).await,
             RoomState::Space(_) => Err(IambError::NoSelectedRoom.into()),
+            RoomState::Invite(_) => Err(IambError::NotJoined.into()),
         }
     }
 
@@ -243,21 +217,17 @@ impl RoomState {
     ) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
         match act {
             RoomAction::InviteAccept => {
-                if let Some(room) = store.application.worker.client.get_room(self.id()) {
-                    let details = room.invite_details().await.map_err(IambError::from)?;
-                    let details = details.invitee.event().original_content();
-                    let is_direct = details.and_then(|ev| ev.is_direct).unwrap_or_default();
+                let Self::Invite(invited) = self else {
+                    return Err(IambError::NotInvited.into());
+                };
 
-                    room.join().await.map_err(IambError::from)?;
+                let info = store.application.join_room(invited.room().room_id().to_string())?;
 
-                    if is_direct {
-                        room.set_is_direct(true).await.map_err(IambError::from)?;
-                    }
+                let room = Self::new(info.room().clone(), None, store)?;
 
-                    Ok(vec![])
-                } else {
-                    Err(IambError::NotInvited.into())
-                }
+                *self = room;
+
+                Ok(vec![])
             },
             RoomAction::InviteReject => {
                 if let Some(room) = store.application.worker.client.get_room(self.id()) {
@@ -682,7 +652,7 @@ impl RoomState {
     pub fn focus_toggle(&mut self) {
         match self {
             RoomState::Chat(chat) => chat.focus_toggle(),
-            RoomState::Space(_) => return,
+            RoomState::Space(_) | RoomState::Invite(_) => return,
         }
     }
 
@@ -690,14 +660,12 @@ impl RoomState {
         match self {
             RoomState::Chat(chat) => chat.room(),
             RoomState::Space(space) => space.room(),
+            RoomState::Invite(invite) => invite.room(),
         }
     }
 
     pub fn id(&self) -> &RoomId {
-        match self {
-            RoomState::Chat(chat) => chat.id(),
-            RoomState::Space(space) => space.id(),
-        }
+        self.room().room_id()
     }
 }
 
@@ -754,34 +722,21 @@ impl TerminalCursor for RoomState {
 
 impl WindowOps<IambInfo> for RoomState {
     fn draw(&mut self, area: Rect, buf: &mut Buffer, focused: bool, store: &mut ProgramStore) {
-        if self.room().state() == MatrixRoomState::Invited {
-            self.refresh_room(store);
-        }
-
-        if self.room().state() == MatrixRoomState::Invited {
-            self.draw_invite(self.room().clone(), area, buf, store);
-        }
-
         match self {
             RoomState::Chat(chat) => chat.draw(area, buf, focused, store),
             RoomState::Space(space) => {
                 Space::new(store).focus(focused).render(area, buf, space);
             },
+            RoomState::Invite(invite) => invite.draw(area, buf, focused, store),
         }
     }
 
     fn dup(&self, store: &mut ProgramStore) -> Self {
-        match self {
-            RoomState::Chat(chat) => RoomState::Chat(Box::new(chat.dup(store))),
-            RoomState::Space(space) => RoomState::Space(Box::new(space.dup(store))),
-        }
+        delegate!(self, w => w.dup(store).into())
     }
 
     fn close(&mut self, flags: CloseFlags, store: &mut ProgramStore) -> bool {
-        match self {
-            RoomState::Chat(chat) => chat.close(flags, store),
-            RoomState::Space(space) => space.close(flags, store),
-        }
+        delegate!(self, w => w.close(flags, store))
     }
 
     fn write(
@@ -790,31 +745,19 @@ impl WindowOps<IambInfo> for RoomState {
         flags: WriteFlags,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
-        match self {
-            RoomState::Chat(chat) => chat.write(path, flags, store),
-            RoomState::Space(space) => space.write(path, flags, store),
-        }
+        delegate!(self, w => w.write(path, flags, store))
     }
 
     fn get_completions(&self) -> Option<CompletionList> {
-        match self {
-            RoomState::Chat(chat) => chat.get_completions(),
-            RoomState::Space(space) => space.get_completions(),
-        }
+        delegate!(self, w => w.get_completions())
     }
 
     fn get_cursor_word(&self, style: &WordStyle) -> Option<String> {
-        match self {
-            RoomState::Chat(chat) => chat.get_cursor_word(style),
-            RoomState::Space(space) => space.get_cursor_word(style),
-        }
+        delegate!(self, w => w.get_cursor_word(style))
     }
 
     fn get_selected_word(&self) -> Option<String> {
-        match self {
-            RoomState::Chat(chat) => chat.get_selected_word(),
-            RoomState::Space(space) => space.get_selected_word(),
-        }
+        delegate!(self, w => w.get_selected_word())
     }
 }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -179,9 +179,13 @@ impl RoomState {
         let mut invited = vec![Span::from(format!("You have been invited to join {name}"))];
 
         if let Ok(Some(inviter)) = &inviter {
-            let info = store.application.rooms.get_or_default(self.id().to_owned());
             invited.push(Span::from(" by "));
-            invited.push(store.application.settings.get_user_span(inviter.user_id(), info));
+            invited.push(
+                store
+                    .application
+                    .settings
+                    .get_user_span(inviter.user_id(), inviter.display_name()),
+            );
         }
 
         let l1 = Line::from(invited);

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -146,7 +146,7 @@ impl RoomState {
     ) -> Self {
         let room_id = room.room_id().to_owned();
         let info = store.application.rooms.get_or_default(room_id);
-        info.name = name.to_string().into();
+        info.name = name.to_string();
         info.tags = tags;
 
         if room.is_space() {

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -145,7 +145,7 @@ impl RoomState {
         store: &mut ProgramStore,
     ) -> Self {
         let room_id = room.room_id().to_owned();
-        let info = store.application.get_room_info(room_id);
+        let info = store.application.rooms.get_or_default(room_id);
         info.name = name.to_string().into();
         info.tags = tags;
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,7 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageKey, Messages},
+    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -1347,6 +1347,14 @@ impl StatefulWidget for Scrollback<'_> {
 
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
+
+            if let ImageStatus::Loading(_, _) = &item.image_preview {
+                self.store
+                    .application
+                    .worker
+                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
+            }
+
             let (txt, [mut msg_preview, mut reply_preview]) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,8 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{ImageStatus, Message, MessageCursor, MessageKey, Messages},
+    message::{Message, MessageCursor, MessageKey, Messages},
+    preview::PreviewManager,
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -270,6 +271,7 @@ impl ScrollbackState {
         pos: MovePosition,
         info: &RoomInfo,
         settings: &ApplicationSettings,
+        previews: &PreviewManager,
     ) {
         let Some(thread) = self.get_thread(info) else {
             return;
@@ -292,7 +294,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     if key == &idx {
                         lines += len / 2;
@@ -315,7 +318,8 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
                     let prev = prevmsg(key, thread);
-                    let len = item.show(prev, sel, &self.viewctx, info, settings).lines.len();
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     lines += len;
 
@@ -338,7 +342,12 @@ impl ScrollbackState {
         self.jumped.push(self.cursor.clone());
     }
 
-    fn shift_cursor(&mut self, info: &RoomInfo, settings: &ApplicationSettings) {
+    fn shift_cursor(
+        &mut self,
+        info: &RoomInfo,
+        settings: &ApplicationSettings,
+        previews: &PreviewManager,
+    ) {
         let Some(thread) = self.get_thread(info) else {
             return;
         };
@@ -368,7 +377,10 @@ impl ScrollbackState {
                 break;
             }
 
-            lines += item.show(prev, false, &self.viewctx, info, settings).height().max(1);
+            lines += item
+                .show(prev, false, &self.viewctx, info, settings, previews)
+                .height()
+                .max(1);
 
             if lines >= self.viewctx.get_height() {
                 // We've reached the end of the viewport; move cursor into it.
@@ -1067,6 +1079,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
     ) -> EditResult<EditInfo, IambInfo> {
         let info = store.application.rooms.get_or_default(self.room_id.clone());
         let settings = &store.application.settings;
+        let previews = &store.application.previews;
         let mut corner = self.viewctx.corner.clone();
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
@@ -1094,7 +1107,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 for (key, item) in thread.range(..=&corner_key).rev() {
                     let sel = key == cursor_key;
                     let prev = prevmsg(key, thread);
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1122,7 +1135,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                 for (key, item) in thread.range(&corner_key..) {
                     let sel = key == cursor_key;
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1160,7 +1173,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         }
 
         self.viewctx.corner = corner;
-        self.shift_cursor(info, settings);
+        self.shift_cursor(info, settings, previews);
 
         Ok(None)
     }
@@ -1182,10 +1195,11 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
             Axis::Vertical => {
                 let info = store.application.rooms.get_or_default(self.room_id.clone());
                 let settings = &store.application.settings;
+                let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
                 if let Some(key) = self.cursor.to_key(thread).cloned() {
-                    self.scrollview(key, pos, info, settings);
+                    self.scrollview(key, pos, info, settings, previews);
                 }
 
                 Ok(None)
@@ -1345,18 +1359,33 @@ impl StatefulWidget for Scrollback<'_> {
         let mut sawit = false;
         let mut prev = prevmsg(&corner_key, thread);
 
+        // load image previews
+        for (_, item) in thread.range(&corner_key..).rev() {
+            if let Some(source) = &item.image_preview {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+            let reply = item
+                .reply_to()
+                .or_else(|| item.thread_root())
+                .and_then(|e| info.get_event(&e))
+                .and_then(|msg| msg.image_preview.as_ref());
+            if let Some(source) = reply {
+                self.store
+                    .application
+                    .previews
+                    .load(source, &self.store.application.worker);
+            }
+        }
+
+        let previews = &self.store.application.previews;
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            if let ImageStatus::Loading(_, _) = &item.image_preview {
-                self.store
-                    .application
-                    .worker
-                    .render_image(state.room_id.clone(), item.event.event_id().to_owned());
-            }
-
             let (txt, [mut msg_preview, mut reply_preview]) =
-                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings);
+                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
 
             let incomplete_ok = !full || !sel;
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -219,10 +219,8 @@ impl ScrollbackState {
         &self,
         range: EditRange<MessageCursor>,
         info: &'a RoomInfo,
-    ) -> impl Iterator<Item = (MessageKey, &'a TimelineItem)> {
-        let Some(thread) = self.get_thread(info) else {
-            todo!()
-        };
+    ) -> Option<impl Iterator<Item = (MessageKey, &'a TimelineItem)>> {
+        let thread = self.get_thread(info)?;
 
         let start = range.start.to_key(thread);
         let end = range.end.to_key(thread);
@@ -232,13 +230,13 @@ impl ScrollbackState {
         } else if let Some(last) = thread.last_key() {
             (last.clone(), last)
         } else {
-            return thread.range(..);
+            return Some(thread.range(..));
         };
 
         if range.inclusive {
-            thread.range(start..=end)
+            Some(thread.range(start..=end))
         } else {
-            thread.range(start..end)
+            Some(thread.range(start..end))
         }
     }
 
@@ -258,30 +256,25 @@ impl ScrollbackState {
                 // We are not near the top.
                 return false;
             }
-        } else {
-            todo!()
         }
 
-        match self.thread.as_ref() {
-            None => {
-                // Scrolled to top in non-thread, fetch.
-                true
-            },
-            Some(thread_root) => {
-                // Scrolled to top in thread, fetch until we have the thread root.
-                //
-                // Typically, if the user has entered a thread view, we should already have fetched
-                // all the way back to the thread root, but it is technically possible via :threads
-                // or when restoring a thread view in the layout at startup to not have the message
-                // yet.
+        if let Some(thread_root) = self.thread.as_ref() {
+            // Scrolled to top in thread, fetch until we have the thread root.
+            //
+            // Typically, if the user has entered a thread view, we should already have fetched
+            // all the way back to the thread root, but it is technically possible via :threads
+            // or when restoring a thread view in the layout at startup to not have the message
+            // yet.
 
-                thread
-                    .range_messages(..)
-                    .next()
-                    .map(|(_, item)| item)
-                    .and_then(|item| item.event_id())
-                    .is_none_or(|event_id| event_id != thread_root)
-            },
+            thread
+                .range_messages(..)
+                .next()
+                .map(|(_, item)| item)
+                .and_then(|item| item.event_id())
+                .is_none_or(|event_id| event_id != thread_root)
+        } else {
+            // Scrolled to top in non-thread, fetch.
+            true
         }
     }
 
@@ -833,6 +826,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                     for (_, msg) in self
                         .messages(range, info)
+                        .into_iter()
+                        .flatten()
                         .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
                     {
                         yanked += EditRope::from(msg.body());
@@ -1344,7 +1339,8 @@ impl StatefulWidget for Scrollback<'_> {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let Some(info) = self.store.application.rooms.get_mut(&state.room_id) else {
-            todo!()
+            tracing::warn!(room_id = ?state.room_id, "Open room not found in internal state");
+            return;
         };
         let settings = &self.store.application.settings;
         let area = if state.cursor.key.is_some() {
@@ -1362,6 +1358,7 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         let Some(thread) = state.get_thread(info) else {
+            tracing::warn!(room_id = ?state.room_id, root = ?state.thread(), "Open thread not found in internal state");
             return;
         };
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -63,6 +63,7 @@ use crate::{
     config::ApplicationSettings,
     message::{Message, MessageCursor, MessageExt, MessageKey, Messages, TimelineItemExt},
     preview::PreviewManager,
+    util::TimelineDetailsExt,
 };
 
 fn no_msgs() -> EditError<IambInfo> {
@@ -190,6 +191,10 @@ impl ScrollbackState {
     /// Set the dimensions and placement within the terminal window for this list.
     pub fn set_term_info(&mut self, area: Rect) {
         self.viewctx.dimensions = (area.width as usize, area.height as usize);
+    }
+
+    pub fn get_key(&self, info: &RoomInfo) -> Option<MessageKey> {
+        self.cursor.key.clone().or_else(|| self.get_thread(info)?.last_key())
     }
 
     pub fn get<'a>(&self, info: &'a RoomInfo) -> Option<&'a Message> {
@@ -1397,11 +1402,11 @@ impl StatefulWidget for Scrollback<'_> {
                     .previews
                     .load(source, &self.store.application.worker);
             }
-            if let Some(TimelineDetails::Ready(replied)) = item
+            if let Some(replied) = item
                 .content()
                 .as_msglike()
                 .and_then(|msg| msg.in_reply_to.as_ref())
-                .map(|details| &details.event)
+                .and_then(|details| details.event.ready())
             {
                 if let Some(source) = replied.image_preview() {
                     self.store

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -832,7 +832,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         _: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.get_room_info(self.room_id.clone());
+        let info = store.application.rooms.get_or_default(self.room_id.clone());
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
         let cursor = self.cursor.to_cursor(thread).ok_or_else(no_msgs)?;
         store.cursors.set_mark(self.id.clone(), name, cursor);
@@ -888,7 +888,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.get_room_info(self.room_id.clone());
+        let info = store.application.rooms.get_or_default(self.room_id.clone());
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
         match act {
@@ -1021,7 +1021,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<Vec<(Action<IambInfo>, ProgramContext)>, IambInfo> {
-        let info = store.application.get_room_info(self.room_id.clone());
+        let info = store.application.rooms.get_or_default(self.room_id.clone());
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
         let Some(msg) = self.cursor.to_key(thread).and_then(|key| thread.get_message(&key)) else {

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,4 +1,5 @@
 //! Message scrollback
+use matrix_sdk_ui::timeline::TimelineItem;
 use ratatui_image::Image;
 use regex::Regex;
 
@@ -54,7 +55,7 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageExt, MessageKey, Messages},
+    message::{Message, MessageCursor, MessageExt, MessageKey, Messages, TimelineItemExt},
     preview::PreviewManager,
 };
 
@@ -64,8 +65,8 @@ fn no_msgs() -> EditError<IambInfo> {
 }
 
 fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
-    let mut end = &pos;
-    let iter = thread.range(..=&pos).rev().enumerate();
+    let mut end = pos;
+    let iter = thread.range(..=&end).rev().enumerate();
 
     for (i, (key, _)) in iter {
         end = key;
@@ -81,7 +82,7 @@ fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
 fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
     let key = nth_key_before(pos, n, thread);
 
-    if matches!(thread.last_key_value(), Some((last, _)) if &key == last) {
+    if thread.last_key().is_some_and(|last| key == last) {
         MessageCursor::latest()
     } else {
         MessageCursor::from(key)
@@ -89,8 +90,8 @@ fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
 }
 
 fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<MessageKey> {
-    let mut end = &pos;
-    let mut iter = thread.range(&pos..).enumerate();
+    let mut end = pos;
+    let mut iter = thread.range(&end..).enumerate();
 
     for (i, (key, _)) in iter.by_ref() {
         end = key;
@@ -109,7 +110,7 @@ fn nth_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
 }
 
 fn prevmsg<'a>(key: &MessageKey, thread: &'a Messages) -> Option<&'a Message> {
-    thread.range(..key).next_back().map(|(_, v)| v)
+    thread.range_messages(..key).next_back().map(|(_, v)| v)
 }
 
 pub struct ScrollbackState {
@@ -158,7 +159,7 @@ impl ScrollbackState {
     }
 
     pub fn is_latest(&self) -> bool {
-        self.cursor.timestamp.is_none()
+        self.cursor.key.is_none()
     }
 
     pub fn goto_latest(&mut self) {
@@ -179,10 +180,10 @@ impl ScrollbackState {
     pub fn get<'a>(&self, info: &'a RoomInfo) -> Option<&'a Message> {
         let thread = self.get_thread(info)?;
 
-        if let Some(k) = &self.cursor.timestamp {
-            thread.get(k)
+        if let Some(k) = &self.cursor.key {
+            thread.get_message(k)
         } else {
-            thread.last()
+            thread.last_message()
         }
     }
 
@@ -198,9 +199,9 @@ impl ScrollbackState {
         &self,
         range: EditRange<MessageCursor>,
         info: &'a RoomInfo,
-    ) -> impl Iterator<Item = (&'a MessageKey, &'a Message)> {
+    ) -> impl Iterator<Item = (MessageKey, &'a TimelineItem)> {
         let Some(thread) = self.get_thread(info) else {
-            return Default::default();
+            todo!()
         };
 
         let start = range.start.to_key(thread);
@@ -208,8 +209,8 @@ impl ScrollbackState {
 
         let (start, end) = if let (Some(start), Some(end)) = (start, end) {
             (start, end)
-        } else if let Some((last, _)) = thread.last_key_value() {
-            (last, last)
+        } else if let Some(last) = thread.last_key() {
+            (last.clone(), last)
         } else {
             return thread.range(..);
         };
@@ -230,8 +231,8 @@ impl ScrollbackState {
             _ => {},
         }
 
-        let first_key = self.get_thread(info).and_then(|t| t.first_key_value()).map(|(k, _)| k);
-        let at_top = first_key == self.viewctx.corner.timestamp.as_ref();
+        let first_key = self.get_thread(info).and_then(|t| t.first_key());
+        let at_top = first_key == self.viewctx.corner.key;
 
         match (at_top, self.thread.as_ref()) {
             (false, _) => {
@@ -282,13 +283,13 @@ impl ScrollbackState {
 
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
-                    let prev = prevmsg(key, thread);
+                    let prev = prevmsg(&key, thread);
                     let len = item
                         .show(prev, sel, &self.viewctx, info, settings, previews, thread)
                         .lines
                         .len();
 
-                    if key == &idx {
+                    if key == idx {
                         lines += len / 2;
                     } else {
                         lines += len;
@@ -296,7 +297,7 @@ impl ScrollbackState {
 
                     if lines >= target {
                         // We've moved back far enough.
-                        self.viewctx.corner.timestamp = key.clone().into();
+                        self.viewctx.corner.key = key.into();
                         self.viewctx.corner.text_row = lines - target;
                         break;
                     }
@@ -308,7 +309,7 @@ impl ScrollbackState {
 
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
-                    let prev = prevmsg(key, thread);
+                    let prev = prevmsg(&key, thread);
                     let len = item
                         .show(prev, sel, &self.viewctx, info, settings, previews, thread)
                         .lines
@@ -318,7 +319,7 @@ impl ScrollbackState {
 
                     if lines >= target {
                         // We've moved back far enough.
-                        self.viewctx.corner.timestamp = key.clone().into();
+                        self.viewctx.corner.key = key.clone().into();
                         self.viewctx.corner.text_row = lines - target;
                         break;
                     }
@@ -345,13 +346,11 @@ impl ScrollbackState {
             return;
         };
 
-        let last_key = if let Some(k) = thread.last_key_value() {
-            k.0
-        } else {
+        let Some(last_key) = thread.last_key() else {
             return;
         };
 
-        let corner_key = self.viewctx.corner.timestamp.as_ref().unwrap_or(last_key);
+        let corner_key = self.viewctx.corner.key.as_ref().unwrap_or(&last_key);
 
         if self.cursor < self.viewctx.corner {
             // Cursor is above the viewport; move it inside.
@@ -361,11 +360,11 @@ impl ScrollbackState {
         // Check whether the cursor is below the viewport.
         let mut lines = 0;
 
-        let cursor_key = self.cursor.timestamp.as_ref().unwrap_or(last_key);
+        let cursor_key = self.cursor.key.as_ref().unwrap_or(&last_key);
         let mut prev = prevmsg(cursor_key, thread);
 
         for (idx, item) in thread.range(corner_key.clone()..) {
-            if idx == cursor_key {
+            if idx == *cursor_key {
                 // Cursor is already within the viewport.
                 break;
             }
@@ -381,6 +380,7 @@ impl ScrollbackState {
                 break;
             }
 
+            let item = todo!();
             prev = Some(item);
         }
     }
@@ -416,7 +416,7 @@ impl ScrollbackState {
             MoveType::BufferLineOffset => None,
             MoveType::BufferLinePercent => None,
             MoveType::BufferPos(MovePosition::Beginning) => {
-                let start = self.get_thread(info)?.first_key_value()?.0.clone();
+                let start = self.get_thread(info)?.first_key()?.clone();
 
                 Some(start.into())
             },
@@ -437,7 +437,7 @@ impl ScrollbackState {
                 }
             },
             MoveType::ViewportPos(MovePosition::Beginning) => {
-                return self.viewctx.corner.timestamp.as_ref().map(|k| k.clone().into());
+                return self.viewctx.corner.key.as_ref().map(|k| k.clone().into());
             },
             MoveType::ViewportPos(MovePosition::Middle) => {
                 // XXX: Need to calculate an accurate middle position.
@@ -483,8 +483,8 @@ impl ScrollbackState {
 
             RangeType::Buffer => {
                 let thread = self.get_thread(info)?;
-                let start = thread.first_key_value()?.0.clone();
-                let end = thread.last_key_value()?.0.clone();
+                let start = thread.first_key()?;
+                let end = thread.last_key()?;
 
                 Some(EditRange::inclusive(start.into(), end.into(), TargetShape::LineWise))
             },
@@ -496,7 +496,7 @@ impl ScrollbackState {
                     return None;
                 }
 
-                let mut end = &pos;
+                let mut end = pos.clone();
 
                 for (i, (key, _)) in thread.range(&pos..).enumerate() {
                     if i >= count {
@@ -526,12 +526,12 @@ impl ScrollbackState {
         let thread = self.get_thread(info)?;
         let mut mc = None;
 
-        for (key, msg) in thread.range(&start..) {
+        for (key, msg) in thread.range_messages(&start..) {
             if count == 0 {
                 break;
             }
 
-            if key == &start {
+            if key == start {
                 continue;
             }
 
@@ -557,7 +557,7 @@ impl ScrollbackState {
             return (None, false);
         };
 
-        for (key, msg) in thread.range(..&end).rev() {
+        for (key, msg) in thread.range_messages(..&end).rev() {
             if count == 0 {
                 break;
             }
@@ -798,7 +798,10 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 if let Some(range) = range {
                     let mut yanked = EditRope::from("");
 
-                    for (_, msg) in self.messages(range, info) {
+                    for (_, msg) in self
+                        .messages(range, info)
+                        .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
+                    {
                         yanked += EditRope::from(msg.body());
                         yanked += EditRope::from('\n');
                     }
@@ -1026,7 +1029,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         let info = store.application.get_room_info(self.room_id.clone());
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
-        let Some(key) = self.cursor.to_key(thread) else {
+        let Some(msg) = self.cursor.to_key(thread).and_then(|key| thread.get_message(&key)) else {
             let msg = "No message currently selected";
             let err = EditError::Failure(msg.into());
             return Err(err);
@@ -1039,12 +1042,15 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         "You are already in a thread. Use :reply to reply to a specific message.";
                     let err = EditError::Failure(msg.into());
                     Err(err)
-                } else {
-                    let root = key.event_id().to_owned();
+                } else if let Some(root) = msg.item().event_id() {
                     let room_id = self.room_id.clone();
-                    let id = IambId::Room(room_id, Some(root));
+                    let id = IambId::Room(room_id, Some(root.to_owned()));
                     let open = WindowAction::Switch(OpenTarget::Application(id));
                     Ok(vec![(open.into(), ctx.clone())])
+                } else {
+                    let msg = "Cannot create thread on local echo";
+                    let err = EditError::Failure(msg.into());
+                    Err(err)
                 }
             },
             PromptAction::Abort(..) => {
@@ -1076,14 +1082,12 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         let mut corner = self.viewctx.corner.clone();
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
-        let last_key = if let Some(k) = thread.last_key_value() {
-            k.0
-        } else {
+        let Some(last_key) = thread.last_key() else {
             return Ok(None);
         };
 
-        let corner_key = corner.timestamp.as_ref().unwrap_or(last_key).clone();
-        let cursor_key = self.cursor.timestamp.as_ref().unwrap_or(last_key);
+        let corner_key = corner.key.clone().unwrap_or(last_key.clone());
+        let cursor_key = self.cursor.key.as_ref().unwrap_or(&last_key);
 
         let count = ctx.resolve(count);
         let height = self.viewctx.get_height();
@@ -1095,27 +1099,27 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
         match dir {
             MoveDir2D::Up => {
-                let first_key = thread.first_key_value().map(|f| f.0.clone());
+                let first_key = thread.first_key();
 
                 for (key, item) in thread.range(..=&corner_key).rev() {
-                    let sel = key == cursor_key;
-                    let prev = prevmsg(key, thread);
+                    let sel = key == *cursor_key;
+                    let prev = prevmsg(&key, thread);
                     let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
-                    if key != &corner_key {
+                    if key != corner_key {
                         corner.text_row = max;
                     }
 
-                    corner.timestamp = key.clone().into();
+                    corner.key = key.clone().into();
 
                     if rows == 0 {
                         break;
                     } else if corner.text_row >= rows {
                         corner.text_row -= rows;
                         break;
-                    } else if corner.timestamp == first_key {
+                    } else if corner.key == first_key {
                         corner.text_row = 0;
                         break;
                     }
@@ -1127,18 +1131,19 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 let mut prev = prevmsg(&corner_key, thread);
 
                 for (key, item) in thread.range(&corner_key..) {
-                    let sel = key == cursor_key;
+                    let sel = key == *cursor_key;
                     let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
+                    let item = todo!();
                     prev = Some(item);
 
-                    if key != &corner_key {
+                    if key != corner_key {
                         corner.text_row = 0;
                     }
 
-                    corner.timestamp = key.clone().into();
+                    corner.key = key.clone().into();
 
                     if rows == 0 {
                         break;
@@ -1191,7 +1196,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
-                if let Some(key) = self.cursor.to_key(thread).cloned() {
+                if let Some(key) = self.cursor.to_key(thread) {
                     self.scrollview(key, pos, info, settings, previews);
                 }
 
@@ -1307,7 +1312,7 @@ impl StatefulWidget for Scrollback<'_> {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let info = self.store.application.rooms.get_or_default(state.room_id.clone());
         let settings = &self.store.application.settings;
-        let area = if state.cursor.timestamp.is_some() {
+        let area = if state.cursor.key.is_some() {
             render_jump_to_recent(area, buf, self.focused)
         } else {
             info.render_typing(area, buf, &self.store.application.settings)
@@ -1325,7 +1330,7 @@ impl StatefulWidget for Scrollback<'_> {
             return;
         };
 
-        if state.cursor.timestamp < state.viewctx.corner.timestamp {
+        if state.cursor.key < state.viewctx.corner.key {
             state.viewctx.corner = state.cursor.clone();
         }
 
@@ -1340,20 +1345,20 @@ impl StatefulWidget for Scrollback<'_> {
         };
 
         let corner = &state.viewctx.corner;
-        let corner_key = if let Some(k) = &corner.timestamp {
+        let corner_key = if let Some(k) = &corner.key {
             k.clone()
         } else {
             nth_key_before(cursor_key.clone(), height, thread)
         };
 
-        let foc = self.focused || cursor.timestamp.is_some();
-        let full = std::mem::take(&mut state.show_full_on_redraw) || cursor.timestamp.is_none();
+        let foc = self.focused || cursor.key.is_some();
+        let full = std::mem::take(&mut state.show_full_on_redraw) || cursor.key.is_none();
         let mut lines = vec![];
         let mut sawit = false;
         let mut prev = prevmsg(&corner_key, thread);
 
         // load image previews
-        for (_, item) in thread.range(&corner_key..).rev() {
+        for (_, item) in thread.range_messages(&corner_key..).rev() {
             if let Some(source) = item.image_preview() {
                 self.store
                     .application
@@ -1396,7 +1401,7 @@ impl StatefulWidget for Scrollback<'_> {
                     break;
                 }
 
-                if key == &corner_key && row < corner.text_row {
+                if key == corner_key && row < corner.text_row {
                     // Skip rows above the viewport corner.
                     continue;
                 }
@@ -1413,10 +1418,11 @@ impl StatefulWidget for Scrollback<'_> {
                     _ => None,
                 });
 
-                lines.push((key, row, line, line_preview));
+                lines.push((key.clone(), row, line, line_preview));
                 sawit |= sel;
             }
 
+            let item = todo!();
             prev = Some(item);
         }
 
@@ -1426,7 +1432,7 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         if let Some((key, row, _, _)) = lines.first() {
-            state.viewctx.corner.timestamp = Some((*key).clone());
+            state.viewctx.corner.key = Some((*key).clone());
             state.viewctx.corner.text_row = *row;
         }
 
@@ -1455,17 +1461,15 @@ impl StatefulWidget for Scrollback<'_> {
             }
         }
 
-        if self.room_focused &&
-            settings.tunables.read_receipt_send &&
-            state.cursor.timestamp.is_none()
-        {
+        if self.room_focused && settings.tunables.read_receipt_send && state.cursor.key.is_none() {
             // If the cursor is at the last message, then update the read marker.
-            if let Some((k, _)) = thread.last_key_value() {
-                info.set_receipt(
-                    thread.receipt_thread().clone(),
-                    settings.profile.user_id.clone(),
-                    k.event_id().to_owned(),
-                );
+            if let Some(_k) = thread.last_key() {
+                // info.set_receipt(
+                //     thread.receipt_thread().clone(),
+                //     settings.profile.user_id.clone(),
+                //     k.id().to_owned(),
+                // );
+                todo!()
             }
         }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -246,7 +246,7 @@ impl ScrollbackState {
         //         !info.keys.contains_key(thread_root)
         //     },
         // }
-        todo!()
+        false
     }
 
     fn scrollview(
@@ -1363,13 +1363,13 @@ impl StatefulWidget for Scrollback<'_> {
             //     .or_else(|| item.thread_root())
             //     .and_then(|e| info.get_event(&e))
             //     .and_then(|msg| msg.image_preview());
-            let reply = todo!();
-            if let Some(source) = reply {
-                self.store
-                    .application
-                    .previews
-                    .load(source, &self.store.application.worker);
-            }
+            // let reply = todo!();
+            // if let Some(source) = reply {
+            //     self.store
+            //         .application
+            //         .previews
+            //         .load(source, &self.store.application.worker);
+            // }
         }
 
         let previews = &self.store.application.previews;
@@ -1455,7 +1455,7 @@ impl StatefulWidget for Scrollback<'_> {
                 //     settings.profile.user_id.clone(),
                 //     k.id().to_owned(),
                 // );
-                todo!()
+                // todo!()
             }
         }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -252,7 +252,7 @@ impl ScrollbackState {
             todo!()
         }
 
-        let (_, item) = thread.range(..).next().unzip();
+        let item = thread.range_messages(..).next().map(|(_, item)| item);
 
         match self.thread.as_ref() {
             None => {
@@ -266,10 +266,8 @@ impl ScrollbackState {
                 // all the way back to the thread root, but it is technically possible via :threads
                 // or when restoring a thread view in the layout at startup to not have the message
                 // yet.
-                item.and_then(|item| item.as_event())
-                    .and_then(|item| item.event_id())
+                item.and_then(|item| item.event_id())
                     .is_none_or(|event_id| event_id != thread_root)
-                // TODO: check if this is correct
             },
         }
     }

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,7 +1,7 @@
 //! Message scrollback
 use std::sync::{Arc, Weak};
 
-use matrix_sdk_ui::timeline::{TimelineDetails, TimelineItem};
+use matrix_sdk_ui::timeline::TimelineDetails;
 use ratatui_image::Image;
 use regex::Regex;
 
@@ -61,7 +61,15 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageExt, MessageKey, Messages, TimelineItemExt},
+    message::{
+        Message,
+        MessageCursor,
+        MessageExt,
+        MessageItem,
+        MessageKey,
+        Messages,
+        TimelineItemExt,
+    },
     preview::PreviewManager,
     util::TimelineDetailsExt,
 };
@@ -219,7 +227,7 @@ impl ScrollbackState {
         &self,
         range: EditRange<MessageCursor>,
         info: &'a RoomInfo,
-    ) -> Option<impl Iterator<Item = (MessageKey, &'a TimelineItem)>> {
+    ) -> Option<impl Iterator<Item = (MessageKey, &'a MessageItem)>> {
         let thread = self.get_thread(info)?;
 
         let start = range.start.to_key(thread);
@@ -1576,25 +1584,10 @@ mod tests {
         // Search backwards to MSG2.
         scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
-        // assert_eq!(
-        //     std::mem::take(&mut store.application.need_load)
-        //         .into_iter()
-        //         .collect::<Vec<(OwnedRoomId, Need)>>()
-        //         .is_empty(),
-        //     true,
-        // );
-        todo!();
 
         // Can't go any further; need_load now contains the room ID.
         scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
-        // assert_eq!(
-        //     std::mem::take(&mut store.application.need_load)
-        //         .into_iter()
-        //         .collect::<Vec<(OwnedRoomId, Need)>>(),
-        //     vec![(room_id.clone(), Need { messages: Some(Vec::new()), members: false })]
-        // );
-        todo!();
 
         // Search forward twice to MSG1.
         scrollback.search(next, 2.into(), &ctx, &mut store).unwrap();
@@ -1708,24 +1701,24 @@ mod tests {
         scrollback
             .dirscroll(prev, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 1));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 0));
 
         scrollback
             .dirscroll(prev, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 0));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(DIVIDER1_KEY.clone(), 0));
 
         // Cannot scroll any further.
         scrollback
             .dirscroll(prev, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 0));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(DIVIDER1_KEY.clone(), 0));
 
         // Now scroll back down one line at a time.
         scrollback
             .dirscroll(next, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 1));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG2_KEY.clone(), 0));
 
         scrollback
             .dirscroll(next, ScrollSize::Cell, &1.into(), &ctx, &mut store)
@@ -1765,18 +1758,18 @@ mod tests {
         scrollback
             .dirscroll(next, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG1_KEY.clone(), 0));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(DIVIDER2_KEY.clone(), 0));
 
         scrollback
             .dirscroll(next, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG1_KEY.clone(), 1));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG1_KEY.clone(), 0));
 
         // Cannot scroll down any further.
         scrollback
             .dirscroll(next, ScrollSize::Cell, &1.into(), &ctx, &mut store)
             .unwrap();
-        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG1_KEY.clone(), 1));
+        assert_eq!(scrollback.viewctx.corner, MessageCursor::new(MSG1_KEY.clone(), 0));
 
         // Scroll up two Pages (eight lines).
         scrollback

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,4 +1,6 @@
 //! Message scrollback
+use std::sync::Weak;
+
 use matrix_sdk_ui::timeline::TimelineItem;
 use ratatui_image::Image;
 use regex::Regex;
@@ -230,32 +232,46 @@ impl ScrollbackState {
         }
     }
 
-    fn need_more_messages(&self, _info: &RoomInfo) -> bool {
-        // TODO: check current fetch status
+    fn need_more_messages(&self, thread: &Messages) -> bool {
+        if thread.fetching {
+            // We are currently fetching.
+            return false;
+        }
 
-        // let first_key = self.get_thread(info).and_then(|t| t.first_key());
-        // let at_top = first_key == self.viewctx.corner.key;
-        //
-        // match (at_top, self.thread.as_ref()) {
-        //     (false, _) => {
-        //         // Not scrolled to top, don't fetch.
-        //         false
-        //     },
-        //     (true, None) => {
-        //         // Scrolled to top in non-thread, fetch.
-        //         true
-        //     },
-        //     (true, Some(thread_root)) => {
-        //         // Scrolled to top in thread, fetch until we have the thread root.
-        //         //
-        //         // Typically, if the user has entered a thread view, we should already have fetched
-        //         // all the way back to the thread root, but it is technically possible via :threads
-        //         // or when restoring a thread view in the layout at startup to not have the message
-        //         // yet.
-        //         !info.keys.contains_key(thread_root)
-        //     },
-        // }
-        false
+        if thread.range(..).next().is_some_and(|(_, item)| item.is_timeline_start()) {
+            // We have fetched the start of the timeline.
+            return false;
+        }
+
+        if let Some(corner) = &self.viewctx.corner.key {
+            if thread.range(..corner).nth(10).is_some() {
+                // We are not near the top.
+                return false;
+            }
+        } else {
+            todo!()
+        }
+
+        let (_, item) = thread.range(..).next().unzip();
+
+        match self.thread.as_ref() {
+            None => {
+                // Scrolled to top in non-thread, fetch.
+                true
+            },
+            Some(thread_root) => {
+                // Scrolled to top in thread, fetch until we have the thread root.
+                //
+                // Typically, if the user has entered a thread view, we should already have fetched
+                // all the way back to the thread root, but it is technically possible via :threads
+                // or when restoring a thread view in the layout at startup to not have the message
+                // yet.
+                item.and_then(|item| item.as_event())
+                    .and_then(|item| item.event_id())
+                    .is_none_or(|event_id| event_id != thread_root)
+                // TODO: check if this is correct
+            },
+        }
     }
 
     fn scrollview(
@@ -1341,9 +1357,10 @@ impl StatefulWidget for Scrollback<'_> {
         let cursor_key = if let Some(k) = cursor.to_key(thread) {
             k
         } else {
-            if state.need_more_messages(info) {
-                // TODO: fetch history
-                // self.store.application.need_load.need_messages(state.room_id.to_owned());
+            if state.need_more_messages(thread) {
+                if let Some(store) = Weak::upgrade(&self.store.application.worker.store) {
+                    thread.paginate_backwards(store);
+                }
             }
             return;
         };
@@ -1472,11 +1489,11 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         // Check whether we should load older messages for this room.
-        if state.need_more_messages(info) {
+        if state.need_more_messages(thread) {
             // If the top of the screen is the older message, load more.
-            // self.store.application.need_load.need_messages(state.room_id.to_owned());
-
-            // TODO: fetch history
+            if let Some(store) = Weak::upgrade(&self.store.application.worker.store) {
+                thread.paginate_backwards(store);
+            }
         }
 
         info.draw_last = self.store.application.draw_curr;

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -189,7 +189,7 @@ impl ScrollbackState {
         if let Some(k) = &self.cursor.timestamp {
             thread.get_mut(k)
         } else {
-            thread.last_entry().map(|o| o.into_mut())
+            thread.last_mut()
         }
     }
 
@@ -1462,7 +1462,7 @@ impl StatefulWidget for Scrollback<'_> {
             // If the cursor is at the last message, then update the read marker.
             if let Some((k, _)) = thread.last_key_value() {
                 info.set_receipt(
-                    thread.1.clone(),
+                    thread.receipt_thread().clone(),
                     settings.profile.user_id.clone(),
                     k.event_id().to_owned(),
                 );

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -715,8 +715,9 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {
-                            // TODO: fetch messages
-                            // store.application.need_load.need_messages(self.room_id.clone());
+                            if let Some(store) = Weak::upgrade(&store.application.worker.store) {
+                                thread.paginate_backwards(store);
+                            }
                         }
                         mc
                     },
@@ -792,8 +793,9 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {
-                            // TODO: fetch messages
-                            // store.application.need_load.need_messages(self.room_id.to_owned());
+                            if let Some(store) = Weak::upgrade(&store.application.worker.store) {
+                                thread.paginate_backwards(store);
+                            }
                         }
 
                         mc.map(|c| self._range_to(c))

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -183,6 +183,16 @@ impl ScrollbackState {
             .or_else(|| self.get_thread(info)?.last_key_value().map(|kv| kv.0.clone()))
     }
 
+    pub fn get<'a>(&self, info: &'a RoomInfo) -> Option<&'a Message> {
+        let thread = self.get_thread(info)?;
+
+        if let Some(k) = &self.cursor.timestamp {
+            thread.get(k)
+        } else {
+            thread.last()
+        }
+    }
+
     pub fn get_mut<'a>(&mut self, info: &'a mut RoomInfo) -> Option<&'a mut Message> {
         let thread = self.get_thread_mut(info);
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -659,7 +659,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
         let key = self.cursor.to_key(thread).ok_or_else(no_msgs)?.clone();
 
@@ -857,7 +857,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         _: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
         let cursor = self.cursor.to_cursor(thread).ok_or_else(no_msgs)?;
         store.cursors.set_mark(self.id.clone(), name, cursor);
@@ -913,7 +913,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
         match act {
@@ -1046,7 +1046,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<Vec<(Action<IambInfo>, ProgramContext)>, IambInfo> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
         let Some(msg) = self.cursor.to_key(thread).and_then(|key| thread.get_message(&key)) else {
@@ -1096,7 +1096,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
-        let info = store.application.rooms.get_or_default(self.room_id.clone());
+        let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let settings = &store.application.settings;
         let previews = &store.application.previews;
         let mut corner = self.viewctx.corner.clone();
@@ -1210,7 +1210,8 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 Err(err)
             },
             Axis::Vertical => {
-                let info = store.application.rooms.get_or_default(self.room_id.clone());
+                let info =
+                    store.application.rooms.get(&self.room_id).expect("internal state invalid");
                 let settings = &store.application.settings;
                 let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
@@ -1329,7 +1330,9 @@ impl StatefulWidget for Scrollback<'_> {
     type State = ScrollbackState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let info = self.store.application.rooms.get_or_default(state.room_id.clone());
+        let Some(info) = self.store.application.rooms.get_mut(&state.room_id) else {
+            todo!()
+        };
         let settings = &self.store.application.settings;
         let area = if state.cursor.key.is_some() {
             render_jump_to_recent(area, buf, self.focused)

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,7 +1,7 @@
 //! Message scrollback
 use std::sync::{Arc, Weak};
 
-use matrix_sdk_ui::timeline::TimelineDetails;
+use matrix_sdk_ui::timeline::{TimelineDetails, VirtualTimelineItem};
 use ratatui_image::Image;
 use regex::Regex;
 
@@ -187,6 +187,9 @@ pub struct ScrollbackState {
     /// This is used to ensure that ^E/^Y work nicely when the cursor is currently
     /// on a multiline message.
     show_full_on_redraw: bool,
+
+    /// The lowest the user has scrolled in the timeline. Used to update the fully_read marker.
+    newest_seen: Option<(MessageKey, OwnedEventId)>,
 }
 
 impl ScrollbackState {
@@ -205,6 +208,7 @@ impl ScrollbackState {
             viewctx,
             jumped,
             show_full_on_redraw,
+            newest_seen: None,
         }
     }
 
@@ -674,6 +678,7 @@ impl WindowOps<IambInfo> for ScrollbackState {
             viewctx: self.viewctx.clone(),
             jumped: self.jumped.clone(),
             show_full_on_redraw: false,
+            newest_seen: self.newest_seen.clone(),
         }
     }
 
@@ -1429,7 +1434,7 @@ impl StatefulWidget for Scrollback<'_> {
             return;
         };
 
-        if state.cursor.key < state.viewctx.corner.key {
+        if state.cursor.key.is_some() && state.cursor.key < state.viewctx.corner.key {
             state.viewctx.corner = state.cursor.clone();
         }
 
@@ -1445,7 +1450,7 @@ impl StatefulWidget for Scrollback<'_> {
             return;
         };
 
-        let corner = &state.viewctx.corner;
+        let corner = state.viewctx.corner.clone();
         let corner_key = if let Some(k) = &corner.key {
             k.clone()
         } else {
@@ -1457,6 +1462,9 @@ impl StatefulWidget for Scrollback<'_> {
         let mut lines = vec![];
         let mut sawit = false;
         let mut prev = prev_sender(&corner_key, thread, settings);
+        let mut newest_seen = None;
+        let mut seen_fully_read = false;
+        let mut scrolled_above_fully_read = false;
 
         // load image previews and replies
         for (_, item) in thread.range_messages(&corner_key.., settings).rev() {
@@ -1505,6 +1513,10 @@ impl StatefulWidget for Scrollback<'_> {
         let previews = &self.store.application.previews;
         for (key, item) in thread.range(&corner_key.., settings) {
             let sel = key == cursor_key;
+            if matches!(item.as_virtual(), Some(VirtualTimelineItem::ReadMarker)) {
+                seen_fully_read = true;
+                scrolled_above_fully_read = sawit;
+            }
 
             let (txt, [mut msg_preview, mut reply_preview]) =
                 item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
@@ -1537,9 +1549,17 @@ impl StatefulWidget for Scrollback<'_> {
 
                 lines.push((key.clone(), row, line, line_preview));
                 sawit |= sel;
+
+                newest_seen = item.as_event().and_then(|item| item.event_id()).or(newest_seen);
             }
 
             prev = item.sender();
+
+            if let Some(event_id) = item.as_event().and_then(|item| item.event_id()) {
+                if state.newest_seen.as_ref().map(|s| &s.0) < Some(&key) {
+                    state.newest_seen = Some((key, event_id.to_owned()));
+                }
+            }
         }
 
         if lines.len() > height {
@@ -1577,25 +1597,66 @@ impl StatefulWidget for Scrollback<'_> {
             }
         }
 
-        if self.room_focused && settings.tunables.read_receipt_send && state.cursor.key.is_none() {
-            // If the cursor is at the last message, then update the read marker.
+        // update read markers
+        if self.room_focused {
+            if let Some(newest_seen) = newest_seen {
+                let receipt = if settings.tunables.read_receipt_send {
+                    ReceiptType::Read
+                } else {
+                    ReceiptType::ReadPrivate
+                };
 
-            let receipt = if settings.tunables.read_receipt_send {
-                ReceiptType::Read
-            } else {
-                ReceiptType::ReadPrivate
-            };
+                let timeline = Arc::clone(thread.timeline());
+                let newest_seen = newest_seen.to_owned();
 
-            let timeline = Arc::clone(thread.timeline());
+                tokio::spawn(async move {
+                    // The timeline checks whether the receipt is older than the current one
+                    if let Err(err) = timeline.send_single_receipt(receipt, newest_seen).await {
+                        tracing::warn!(
+                            room_id = ?timeline.room().room_id(),
+                            "unable to send read receipt: {err}"
+                        );
+                    }
+                });
+            }
+        }
 
-            tokio::spawn(async move {
-                if let Err(err) = timeline.mark_as_read(receipt).await {
-                    tracing::warn!(
-                        room_id = ?timeline.room().room_id(),
-                        "unable to send read receipt: {err}"
-                    );
+        // only update fully_read marker on main thread
+        if self.room_focused && state.thread().is_none() {
+            if state.cursor.key.is_none() && seen_fully_read && corner.key.is_some() {
+                // Update fully_read marker if the timeline is scrolled to the bottom and the
+                // fully_read marker is visible
+
+                let timeline = Arc::clone(thread.timeline());
+
+                tokio::spawn(async move {
+                    if let Err(err) = timeline.mark_as_read(ReceiptType::FullyRead).await {
+                        tracing::warn!(
+                            room_id = ?timeline.room().room_id(),
+                            "unable to update fully read marker: {err}"
+                        );
+                    }
+                });
+            } else if scrolled_above_fully_read {
+                // Update fully_read marker if the the user scrolled past it
+
+                if let Some((_, fully_read)) = &state.newest_seen {
+                    let timeline = Arc::clone(thread.timeline());
+                    let fully_read = fully_read.to_owned();
+
+                    tokio::spawn(async move {
+                        // The timeline checks whether the receipt is older than the current one
+                        if let Err(err) =
+                            timeline.send_single_receipt(ReceiptType::FullyRead, fully_read).await
+                        {
+                            tracing::warn!(
+                                room_id = ?timeline.room().room_id(),
+                                "unable to update fully read marker: {err}"
+                            );
+                        }
+                    });
                 }
-            });
+            }
         }
 
         // Check whether we should load older messages for this room.

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -50,7 +50,6 @@ use crate::{
         IambResult,
         ProgramContext,
         ProgramStore,
-        RoomFetchStatus,
         RoomFocus,
         RoomInfo,
     },
@@ -222,37 +221,32 @@ impl ScrollbackState {
         }
     }
 
-    fn need_more_messages(&self, info: &RoomInfo) -> bool {
-        match info.fetch_id {
-            // Don't fetch if we've already hit the end of history.
-            RoomFetchStatus::Done => return false,
-            // Fetch at least once if we're viewing a room.
-            RoomFetchStatus::NotStarted => return true,
-            _ => {},
-        }
+    fn need_more_messages(&self, _info: &RoomInfo) -> bool {
+        // TODO: check current fetch status
 
-        let first_key = self.get_thread(info).and_then(|t| t.first_key());
-        let at_top = first_key == self.viewctx.corner.key;
-
-        match (at_top, self.thread.as_ref()) {
-            (false, _) => {
-                // Not scrolled to top, don't fetch.
-                false
-            },
-            (true, None) => {
-                // Scrolled to top in non-thread, fetch.
-                true
-            },
-            (true, Some(thread_root)) => {
-                // Scrolled to top in thread, fetch until we have the thread root.
-                //
-                // Typically, if the user has entered a thread view, we should already have fetched
-                // all the way back to the thread root, but it is technically possible via :threads
-                // or when restoring a thread view in the layout at startup to not have the message
-                // yet.
-                !info.keys.contains_key(thread_root)
-            },
-        }
+        // let first_key = self.get_thread(info).and_then(|t| t.first_key());
+        // let at_top = first_key == self.viewctx.corner.key;
+        //
+        // match (at_top, self.thread.as_ref()) {
+        //     (false, _) => {
+        //         // Not scrolled to top, don't fetch.
+        //         false
+        //     },
+        //     (true, None) => {
+        //         // Scrolled to top in non-thread, fetch.
+        //         true
+        //     },
+        //     (true, Some(thread_root)) => {
+        //         // Scrolled to top in thread, fetch until we have the thread root.
+        //         //
+        //         // Typically, if the user has entered a thread view, we should already have fetched
+        //         // all the way back to the thread root, but it is technically possible via :threads
+        //         // or when restoring a thread view in the layout at startup to not have the message
+        //         // yet.
+        //         !info.keys.contains_key(thread_root)
+        //     },
+        // }
+        todo!()
     }
 
     fn scrollview(
@@ -694,7 +688,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {
-                            store.application.need_load.need_messages(self.room_id.clone());
+                            // TODO: fetch messages
+                            // store.application.need_load.need_messages(self.room_id.clone());
                         }
                         mc
                     },
@@ -770,7 +765,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {
-                            store.application.need_load.need_messages(self.room_id.to_owned());
+                            // TODO: fetch messages
+                            // store.application.need_load.need_messages(self.room_id.to_owned());
                         }
 
                         mc.map(|c| self._range_to(c))
@@ -1303,6 +1299,7 @@ impl<'a> Scrollback<'a> {
 impl StatefulWidget for Scrollback<'_> {
     type State = ScrollbackState;
 
+    #[allow(unused)]
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let info = self.store.application.rooms.get_or_default(state.room_id.clone());
         let settings = &self.store.application.settings;
@@ -1333,7 +1330,8 @@ impl StatefulWidget for Scrollback<'_> {
             k
         } else {
             if state.need_more_messages(info) {
-                self.store.application.need_load.need_messages(state.room_id.to_owned());
+                // TODO: fetch history
+                // self.store.application.need_load.need_messages(state.room_id.to_owned());
             }
             return;
         };
@@ -1359,11 +1357,13 @@ impl StatefulWidget for Scrollback<'_> {
                     .previews
                     .load(source, &self.store.application.worker);
             }
-            let reply = item
-                .reply_to()
-                .or_else(|| item.thread_root())
-                .and_then(|e| info.get_event(&e))
-                .and_then(|msg| msg.image_preview());
+            // TODO: use `InReplyToDetails::event`
+            // let reply = item
+            //     .reply_to()
+            //     .or_else(|| item.thread_root())
+            //     .and_then(|e| info.get_event(&e))
+            //     .and_then(|msg| msg.image_preview());
+            let reply = todo!();
             if let Some(source) = reply {
                 self.store
                     .application
@@ -1462,7 +1462,9 @@ impl StatefulWidget for Scrollback<'_> {
         // Check whether we should load older messages for this room.
         if state.need_more_messages(info) {
             // If the top of the screen is the older message, load more.
-            self.store.application.need_load.need_messages(state.room_id.to_owned());
+            // self.store.application.need_load.need_messages(state.room_id.to_owned());
+
+            // TODO: fetch history
         }
 
         info.draw_last = self.store.application.draw_curr;
@@ -1472,7 +1474,7 @@ impl StatefulWidget for Scrollback<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{base::Need, tests::*};
+    use crate::tests::*;
 
     #[tokio::test]
     async fn test_search_messages() {
@@ -1502,23 +1504,25 @@ mod tests {
         // Search backwards to MSG2.
         scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
-        assert_eq!(
-            std::mem::take(&mut store.application.need_load)
-                .into_iter()
-                .collect::<Vec<(OwnedRoomId, Need)>>()
-                .is_empty(),
-            true,
-        );
+        // assert_eq!(
+        //     std::mem::take(&mut store.application.need_load)
+        //         .into_iter()
+        //         .collect::<Vec<(OwnedRoomId, Need)>>()
+        //         .is_empty(),
+        //     true,
+        // );
+        todo!();
 
         // Can't go any further; need_load now contains the room ID.
         scrollback.search(prev, 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(scrollback.cursor, MSG2_KEY.clone().into());
-        assert_eq!(
-            std::mem::take(&mut store.application.need_load)
-                .into_iter()
-                .collect::<Vec<(OwnedRoomId, Need)>>(),
-            vec![(room_id.clone(), Need { messages: Some(Vec::new()), members: false })]
-        );
+        // assert_eq!(
+        //     std::mem::take(&mut store.application.need_load)
+        //         .into_iter()
+        //         .collect::<Vec<(OwnedRoomId, Need)>>(),
+        //     vec![(room_id.clone(), Need { messages: Some(Vec::new()), members: false })]
+        // );
+        todo!();
 
         // Search forward twice to MSG1.
         scrollback.search(next, 2.into(), &ctx, &mut store).unwrap();

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1047,7 +1047,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     let err = EditError::Failure(msg.into());
                     Err(err)
                 } else {
-                    let root = key.1.clone();
+                    let root = key.event_id().to_owned();
                     let room_id = self.room_id.clone();
                     let id = IambId::Room(room_id, Some(root));
                     let open = WindowAction::Switch(OpenTarget::Application(id));
@@ -1425,8 +1425,8 @@ impl StatefulWidget for Scrollback<'_> {
             let _ = lines.drain(..n);
         }
 
-        if let Some(((ts, event_id), row, _, _)) = lines.first() {
-            state.viewctx.corner.timestamp = Some((*ts, event_id.clone()));
+        if let Some((key, row, _, _)) = lines.first() {
+            state.viewctx.corner.timestamp = Some((*key).clone());
             state.viewctx.corner.text_row = *row;
         }
 
@@ -1434,7 +1434,7 @@ impl StatefulWidget for Scrollback<'_> {
         let x = area.left();
 
         let mut image_previews = vec![];
-        for ((_, _), _, txt, line_preview) in lines.into_iter() {
+        for (_, _, txt, line_preview) in lines.into_iter() {
             let _ = buf.set_line(x, y, &txt, area.width);
             if let Some((backend, msg_x, _)) = line_preview {
                 image_previews.push((x + msg_x, y, backend));
@@ -1461,7 +1461,11 @@ impl StatefulWidget for Scrollback<'_> {
         {
             // If the cursor is at the last message, then update the read marker.
             if let Some((k, _)) = thread.last_key_value() {
-                info.set_receipt(thread.1.clone(), settings.profile.user_id.clone(), k.1.clone());
+                info.set_receipt(
+                    thread.1.clone(),
+                    settings.profile.user_id.clone(),
+                    k.event_id().to_owned(),
+                );
             }
         }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1572,6 +1572,11 @@ impl StatefulWidget for Scrollback<'_> {
             state.viewctx.corner.text_row = *row;
         }
 
+        if lines.len() < height {
+            state.viewctx.corner.key = None;
+            state.viewctx.corner.text_row = 0;
+        }
+
         let mut y = area.top();
         let x = area.left();
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -3,7 +3,7 @@ use matrix_sdk_ui::timeline::TimelineItem;
 use ratatui_image::Image;
 use regex::Regex;
 
-use matrix_sdk::ruma::{OwnedEventId, OwnedRoomId};
+use matrix_sdk::ruma::{OwnedEventId, OwnedRoomId, UserId};
 
 use modalkit_ratatui::{ScrollActions, TerminalCursor, WindowOps};
 use ratatui::{
@@ -109,8 +109,8 @@ fn nth_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
     nth_key_after(pos, n, thread).map(MessageCursor::from).unwrap_or_default()
 }
 
-fn prevmsg<'a>(key: &MessageKey, thread: &'a Messages) -> Option<&'a Message> {
-    thread.range_messages(..key).next_back().map(|(_, v)| v)
+fn prev_sender<'a>(key: &MessageKey, thread: &'a Messages) -> Option<&'a UserId> {
+    thread.range(..key).next_back().and_then(|(_, msg)| msg.sender())
 }
 
 pub struct ScrollbackState {
@@ -283,11 +283,9 @@ impl ScrollbackState {
 
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
-                    let prev = prevmsg(&key, thread);
-                    let len = item
-                        .show(prev, sel, &self.viewctx, info, settings, previews, thread)
-                        .lines
-                        .len();
+                    let prev = prev_sender(&key, thread);
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     if key == idx {
                         lines += len / 2;
@@ -309,11 +307,9 @@ impl ScrollbackState {
 
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
-                    let prev = prevmsg(&key, thread);
-                    let len = item
-                        .show(prev, sel, &self.viewctx, info, settings, previews, thread)
-                        .lines
-                        .len();
+                    let prev = prev_sender(&key, thread);
+                    let len =
+                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
                     lines += len;
 
@@ -361,7 +357,7 @@ impl ScrollbackState {
         let mut lines = 0;
 
         let cursor_key = self.cursor.key.as_ref().unwrap_or(&last_key);
-        let mut prev = prevmsg(cursor_key, thread);
+        let mut prev = prev_sender(cursor_key, thread);
 
         for (idx, item) in thread.range(corner_key.clone()..) {
             if idx == *cursor_key {
@@ -370,7 +366,7 @@ impl ScrollbackState {
             }
 
             lines += item
-                .show(prev, false, &self.viewctx, info, settings, previews, thread)
+                .show(prev, false, &self.viewctx, info, settings, previews)
                 .height()
                 .max(1);
 
@@ -380,8 +376,7 @@ impl ScrollbackState {
                 break;
             }
 
-            let item = todo!();
-            prev = Some(item);
+            prev = item.sender();
         }
     }
 
@@ -1103,8 +1098,8 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                 for (key, item) in thread.range(..=&corner_key).rev() {
                     let sel = key == *cursor_key;
-                    let prev = prevmsg(&key, thread);
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
+                    let prev = prev_sender(&key, thread);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1128,16 +1123,15 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 }
             },
             MoveDir2D::Down => {
-                let mut prev = prevmsg(&corner_key, thread);
+                let mut prev = prev_sender(&corner_key, thread);
 
                 for (key, item) in thread.range(&corner_key..) {
                     let sel = key == *cursor_key;
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
-                    let item = todo!();
-                    prev = Some(item);
+                    prev = item.sender();
 
                     if key != corner_key {
                         corner.text_row = 0;
@@ -1355,7 +1349,7 @@ impl StatefulWidget for Scrollback<'_> {
         let full = std::mem::take(&mut state.show_full_on_redraw) || cursor.key.is_none();
         let mut lines = vec![];
         let mut sawit = false;
-        let mut prev = prevmsg(&corner_key, thread);
+        let mut prev = prev_sender(&corner_key, thread);
 
         // load image previews
         for (_, item) in thread.range_messages(&corner_key..).rev() {
@@ -1382,15 +1376,8 @@ impl StatefulWidget for Scrollback<'_> {
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            let (txt, [mut msg_preview, mut reply_preview]) = item.show_with_preview(
-                prev,
-                foc && sel,
-                &state.viewctx,
-                info,
-                settings,
-                previews,
-                thread,
-            );
+            let (txt, [mut msg_preview, mut reply_preview]) =
+                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
 
             let incomplete_ok = !full || !sel;
 
@@ -1422,8 +1409,7 @@ impl StatefulWidget for Scrollback<'_> {
                 sawit |= sel;
             }
 
-            let item = todo!();
-            prev = Some(item);
+            prev = item.sender();
         }
 
         if lines.len() > height {

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,7 +1,7 @@
 //! Message scrollback
 use std::sync::{Arc, Weak};
 
-use matrix_sdk_ui::timeline::TimelineItem;
+use matrix_sdk_ui::timeline::{TimelineDetails, TimelineItem};
 use ratatui_image::Image;
 use regex::Regex;
 
@@ -257,8 +257,6 @@ impl ScrollbackState {
             todo!()
         }
 
-        let item = thread.range_messages(..).next().map(|(_, item)| item);
-
         match self.thread.as_ref() {
             None => {
                 // Scrolled to top in non-thread, fetch.
@@ -271,7 +269,12 @@ impl ScrollbackState {
                 // all the way back to the thread root, but it is technically possible via :threads
                 // or when restoring a thread view in the layout at startup to not have the message
                 // yet.
-                item.and_then(|item| item.event_id())
+
+                thread
+                    .range_messages(..)
+                    .next()
+                    .map(|(_, item)| item)
+                    .and_then(|item| item.event_id())
                     .is_none_or(|event_id| event_id != thread_root)
             },
         }
@@ -1067,7 +1070,7 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         "You are already in a thread. Use :reply to reply to a specific message.";
                     let err = EditError::Failure(msg.into());
                     Err(err)
-                } else if let Some(root) = msg.item().event_id() {
+                } else if let Some(root) = msg.event_id() {
                     let room_id = self.room_id.clone();
                     let id = IambId::Room(room_id, Some(root.to_owned()));
                     let open = WindowAction::Switch(OpenTarget::Application(id));
@@ -1386,7 +1389,7 @@ impl StatefulWidget for Scrollback<'_> {
         let mut sawit = false;
         let mut prev = prev_sender(&corner_key, thread);
 
-        // load image previews
+        // load image previews and replies
         for (_, item) in thread.range_messages(&corner_key..).rev() {
             if let Some(source) = item.image_preview() {
                 self.store
@@ -1394,19 +1397,40 @@ impl StatefulWidget for Scrollback<'_> {
                     .previews
                     .load(source, &self.store.application.worker);
             }
-            // TODO: use `InReplyToDetails::event`
-            // let reply = item
-            //     .reply_to()
-            //     .or_else(|| item.thread_root())
-            //     .and_then(|e| info.get_event(&e))
-            //     .and_then(|msg| msg.image_preview());
-            // let reply = todo!();
-            // if let Some(source) = reply {
-            //     self.store
-            //         .application
-            //         .previews
-            //         .load(source, &self.store.application.worker);
-            // }
+            if let Some(TimelineDetails::Ready(replied)) = item
+                .content()
+                .as_msglike()
+                .and_then(|msg| msg.in_reply_to.as_ref())
+                .map(|details| &details.event)
+            {
+                if let Some(source) = replied.image_preview() {
+                    self.store
+                        .application
+                        .previews
+                        .load(source, &self.store.application.worker);
+                }
+            }
+
+            if let Some(TimelineDetails::Unavailable) = item
+                .content()
+                .as_msglike()
+                .and_then(|msg| msg.in_reply_to.as_ref())
+                .map(|details| &details.event)
+            {
+                if let Some(event_id) = item.event_id() {
+                    let timeline = Arc::clone(thread.timeline());
+                    let event_id = event_id.to_owned();
+                    tokio::spawn(async move {
+                        if let Err(err) = timeline.fetch_details_for_event(&event_id).await {
+                            tracing::warn!(
+                                room_id = ?timeline.room().room_id(),
+                                ?event_id,
+                                "unable to load reply: {err}"
+                            );
+                        }
+                    });
+                }
+            }
         }
 
         let previews = &self.store.application.previews;

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -176,13 +176,6 @@ impl ScrollbackState {
         self.viewctx.dimensions = (area.width as usize, area.height as usize);
     }
 
-    pub fn get_key(&self, info: &mut RoomInfo) -> Option<MessageKey> {
-        self.cursor
-            .timestamp
-            .clone()
-            .or_else(|| self.get_thread(info)?.last_key_value().map(|kv| kv.0.clone()))
-    }
-
     pub fn get<'a>(&self, info: &'a RoomInfo) -> Option<&'a Message> {
         let thread = self.get_thread(info)?;
 
@@ -552,7 +545,7 @@ impl ScrollbackState {
                 continue;
             }
 
-            if needle.is_match(msg.event().body().as_ref()) {
+            if needle.is_match(msg.body().as_ref()) {
                 mc = MessageCursor::from(key.clone()).into();
                 count -= 1;
             }
@@ -579,7 +572,7 @@ impl ScrollbackState {
                 break;
             }
 
-            if needle.is_match(msg.event().body().as_ref()) {
+            if needle.is_match(msg.body().as_ref()) {
                 mc = MessageCursor::from(key.clone()).into();
                 count -= 1;
             }
@@ -816,7 +809,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     let mut yanked = EditRope::from("");
 
                     for (_, msg) in self.messages(range, info) {
-                        yanked += EditRope::from(msg.event().body());
+                        yanked += EditRope::from(msg.body());
                         yanked += EditRope::from('\n');
                     }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -54,7 +54,7 @@ use crate::{
         RoomInfo,
     },
     config::ApplicationSettings,
-    message::{Message, MessageCursor, MessageKey, Messages},
+    message::{Message, MessageCursor, MessageExt, MessageKey, Messages},
     preview::PreviewManager,
 };
 
@@ -186,26 +186,12 @@ impl ScrollbackState {
         }
     }
 
-    pub fn get_mut<'a>(&mut self, info: &'a mut RoomInfo) -> Option<&'a mut Message> {
-        let thread = self.get_thread_mut(info);
-
-        if let Some(k) = &self.cursor.timestamp {
-            thread.get_mut(k)
-        } else {
-            thread.last_mut()
-        }
-    }
-
     pub fn thread(&self) -> Option<&OwnedEventId> {
         self.thread.as_ref()
     }
 
     pub fn get_thread<'a>(&self, info: &'a RoomInfo) -> Option<&'a Messages> {
         info.get_thread(self.thread.as_deref())
-    }
-
-    pub fn get_thread_mut<'a>(&self, info: &'a mut RoomInfo) -> &'a mut Messages {
-        info.get_thread_mut(self.thread.clone())
     }
 
     pub fn messages<'a>(
@@ -297,8 +283,10 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = selidx == key;
                     let prev = prevmsg(key, thread);
-                    let len =
-                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
+                    let len = item
+                        .show(prev, sel, &self.viewctx, info, settings, previews, thread)
+                        .lines
+                        .len();
 
                     if key == &idx {
                         lines += len / 2;
@@ -321,8 +309,10 @@ impl ScrollbackState {
                 for (key, item) in thread.range(..=&idx).rev() {
                     let sel = key == selidx;
                     let prev = prevmsg(key, thread);
-                    let len =
-                        item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
+                    let len = item
+                        .show(prev, sel, &self.viewctx, info, settings, previews, thread)
+                        .lines
+                        .len();
 
                     lines += len;
 
@@ -381,7 +371,7 @@ impl ScrollbackState {
             }
 
             lines += item
-                .show(prev, false, &self.viewctx, info, settings, previews)
+                .show(prev, false, &self.viewctx, info, settings, previews, thread)
                 .height()
                 .max(1);
 
@@ -1110,7 +1100,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 for (key, item) in thread.range(..=&corner_key).rev() {
                     let sel = key == cursor_key;
                     let prev = prevmsg(key, thread);
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1138,7 +1128,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
                 for (key, item) in thread.range(&corner_key..) {
                     let sel = key == cursor_key;
-                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
+                    let txt = item.show(prev, sel, &self.viewctx, info, settings, previews, thread);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
 
@@ -1387,8 +1377,15 @@ impl StatefulWidget for Scrollback<'_> {
         for (key, item) in thread.range(&corner_key..) {
             let sel = key == cursor_key;
 
-            let (txt, [mut msg_preview, mut reply_preview]) =
-                item.show_with_preview(prev, foc && sel, &state.viewctx, info, settings, previews);
+            let (txt, [mut msg_preview, mut reply_preview]) = item.show_with_preview(
+                prev,
+                foc && sel,
+                &state.viewctx,
+                info,
+                settings,
+                previews,
+                thread,
+            );
 
             let incomplete_ok = !full || !sel;
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1572,7 +1572,7 @@ impl StatefulWidget for Scrollback<'_> {
             state.viewctx.corner.text_row = *row;
         }
 
-        if lines.len() < height {
+        if lines.len() < height && state.cursor.key.is_none() {
             state.viewctx.corner.key = None;
             state.viewctx.corner.text_row = 0;
         }

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -79,9 +79,14 @@ fn no_msgs() -> EditError<IambInfo> {
     EditError::Failure(msg.to_string())
 }
 
-fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
+fn nth_key_before(
+    pos: MessageKey,
+    n: usize,
+    thread: &Messages,
+    settings: &ApplicationSettings,
+) -> MessageKey {
     let mut end = pos;
-    let iter = thread.range(..=&end).rev().enumerate();
+    let iter = thread.range_filtered(..=&end, settings.filter_hidden()).rev().enumerate();
 
     for (i, (key, _)) in iter {
         end = key;
@@ -94,9 +99,14 @@ fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
     end.clone()
 }
 
-fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
+fn nth_before(
+    pos: MessageKey,
+    n: usize,
+    thread: &Messages,
+    settings: &ApplicationSettings,
+) -> MessageCursor {
     let mut end = pos;
-    let iter = thread.range_messages(..=end.clone()).rev().enumerate();
+    let iter = thread.range_messages(..=end.clone(), settings).rev().enumerate();
 
     for (i, (key, _)) in iter {
         end = key;
@@ -106,16 +116,21 @@ fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
         }
     }
 
-    if thread.last_key().is_some_and(|last| end == last) {
+    if thread.last_key(settings).is_some_and(|last| end == last) {
         MessageCursor::latest()
     } else {
         MessageCursor::from(end)
     }
 }
 
-fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<MessageKey> {
+fn nth_key_after(
+    pos: MessageKey,
+    n: usize,
+    thread: &Messages,
+    settings: &ApplicationSettings,
+) -> Option<MessageKey> {
     let mut end = pos;
-    let mut iter = thread.range_messages(end.clone()..).enumerate();
+    let mut iter = thread.range_messages(end.clone().., settings).enumerate();
 
     for (i, (key, _)) in iter.by_ref() {
         end = key;
@@ -129,12 +144,23 @@ fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<Message
     iter.next().map(|_| end)
 }
 
-fn nth_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
-    nth_key_after(pos, n, thread).map(MessageCursor::from).unwrap_or_default()
+fn nth_after(
+    pos: MessageKey,
+    n: usize,
+    thread: &Messages,
+    settings: &ApplicationSettings,
+) -> MessageCursor {
+    nth_key_after(pos, n, thread, settings)
+        .map(MessageCursor::from)
+        .unwrap_or_default()
 }
 
-fn prev_sender<'a>(key: &MessageKey, thread: &'a Messages) -> Option<&'a UserId> {
-    thread.range(..key).next_back().and_then(|(_, msg)| msg.sender())
+fn prev_sender<'a>(
+    key: &MessageKey,
+    thread: &'a Messages,
+    settings: &ApplicationSettings,
+) -> Option<&'a UserId> {
+    thread.range(..key, settings).next_back().and_then(|(_, msg)| msg.sender())
 }
 
 pub struct ScrollbackState {
@@ -201,17 +227,24 @@ impl ScrollbackState {
         self.viewctx.dimensions = (area.width as usize, area.height as usize);
     }
 
-    pub fn get_key(&self, info: &RoomInfo) -> Option<MessageKey> {
-        self.cursor.key.clone().or_else(|| self.get_thread(info)?.last_key())
+    pub fn get_key(&self, info: &RoomInfo, settings: &ApplicationSettings) -> Option<MessageKey> {
+        self.cursor
+            .key
+            .clone()
+            .or_else(|| self.get_thread(info)?.last_key(settings))
     }
 
-    pub fn get<'a>(&self, info: &'a RoomInfo) -> Option<&'a Message> {
+    pub fn get<'a>(
+        &self,
+        info: &'a RoomInfo,
+        settings: &ApplicationSettings,
+    ) -> Option<&'a Message> {
         let thread = self.get_thread(info)?;
 
         if let Some(k) = &self.cursor.key {
             thread.get_message(k)
         } else {
-            thread.last_message()
+            thread.last_message(settings)
         }
     }
 
@@ -227,40 +260,46 @@ impl ScrollbackState {
         &self,
         range: EditRange<MessageCursor>,
         info: &'a RoomInfo,
+        settings: &ApplicationSettings,
     ) -> Option<impl Iterator<Item = (MessageKey, &'a MessageItem)>> {
         let thread = self.get_thread(info)?;
+        let filter = settings.filter_hidden();
 
-        let start = range.start.to_key(thread);
-        let end = range.end.to_key(thread);
+        let start = range.start.to_key(thread, settings);
+        let end = range.end.to_key(thread, settings);
 
         let (start, end) = if let (Some(start), Some(end)) = (start, end) {
             (start, end)
-        } else if let Some(last) = thread.last_key() {
+        } else if let Some(last) = thread.last_key(settings) {
             (last.clone(), last)
         } else {
-            return Some(thread.range(..));
+            return Some(thread.range_filtered(.., filter));
         };
 
         if range.inclusive {
-            Some(thread.range(start..=end))
+            Some(thread.range_filtered(start..=end, filter))
         } else {
-            Some(thread.range(start..end))
+            Some(thread.range_filtered(start..end, filter))
         }
     }
 
-    fn need_more_messages(&self, thread: &Messages) -> bool {
+    fn need_more_messages(&self, thread: &Messages, settings: &ApplicationSettings) -> bool {
         if thread.fetching {
             // We are currently fetching.
             return false;
         }
 
-        if thread.range(..).next().is_some_and(|(_, item)| item.is_timeline_start()) {
+        if thread
+            .range(.., settings)
+            .next()
+            .is_some_and(|(_, item)| item.is_timeline_start())
+        {
             // We have fetched the start of the timeline.
             return false;
         }
 
         if let Some(corner) = &self.viewctx.corner.key {
-            if thread.range(..corner).nth(10).is_some() {
+            if thread.range(..corner, settings).nth(10).is_some() {
                 // We are not near the top.
                 return false;
             }
@@ -275,7 +314,7 @@ impl ScrollbackState {
             // yet.
 
             thread
-                .range_messages(..)
+                .range_messages(.., settings)
                 .next()
                 .map(|(_, item)| item)
                 .and_then(|item| item.event_id())
@@ -298,7 +337,7 @@ impl ScrollbackState {
             return;
         };
 
-        let selidx = if let Some(key) = self.cursor.to_key(thread) {
+        let selidx = if let Some(key) = self.cursor.to_key(thread, settings) {
             key
         } else {
             return;
@@ -312,9 +351,9 @@ impl ScrollbackState {
                 let mut lines = 0;
                 let target = self.viewctx.get_height() / 2;
 
-                for (key, item) in thread.range(..=&idx).rev() {
+                for (key, item) in thread.range(..=&idx, settings).rev() {
                     let sel = selidx == key;
-                    let prev = prev_sender(&key, thread);
+                    let prev = prev_sender(&key, thread, settings);
                     let len =
                         item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
@@ -336,9 +375,9 @@ impl ScrollbackState {
                 let mut lines = 0;
                 let target = self.viewctx.get_height();
 
-                for (key, item) in thread.range(..=&idx).rev() {
+                for (key, item) in thread.range(..=&idx, settings).rev() {
                     let sel = key == selidx;
-                    let prev = prev_sender(&key, thread);
+                    let prev = prev_sender(&key, thread, settings);
                     let len =
                         item.show(prev, sel, &self.viewctx, info, settings, previews).lines.len();
 
@@ -373,7 +412,7 @@ impl ScrollbackState {
             return;
         };
 
-        let Some(last_key) = thread.last_key() else {
+        let Some(last_key) = thread.last_key(settings) else {
             return;
         };
 
@@ -388,9 +427,9 @@ impl ScrollbackState {
         let mut lines = 0;
 
         let cursor_key = self.cursor.key.as_ref().unwrap_or(&last_key);
-        let mut prev = prev_sender(cursor_key, thread);
+        let mut prev = prev_sender(cursor_key, thread, settings);
 
-        for (idx, item) in thread.range(corner_key.clone()..) {
+        for (idx, item) in thread.range(corner_key.clone().., settings) {
             if idx == *cursor_key {
                 // Cursor is already within the viewport.
                 break;
@@ -422,6 +461,7 @@ impl ScrollbackState {
         count: &Count,
         ctx: &ProgramContext,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> Option<MessageCursor> {
         let count = ctx.resolve(count);
 
@@ -442,7 +482,7 @@ impl ScrollbackState {
             MoveType::BufferLineOffset => None,
             MoveType::BufferLinePercent => None,
             MoveType::BufferPos(MovePosition::Beginning) => {
-                let start = self.get_thread(info)?.range_messages(..).next()?.0;
+                let start = self.get_thread(info)?.range_messages(.., settings).next()?.0;
 
                 Some(start.into())
             },
@@ -458,14 +498,14 @@ impl ScrollbackState {
                 let thread = self.get_thread(info)?;
 
                 match dir {
-                    MoveDir1D::Previous => nth_before(pos, count, thread).into(),
-                    MoveDir1D::Next => nth_after(pos, count, thread).into(),
+                    MoveDir1D::Previous => nth_before(pos, count, thread, settings).into(),
+                    MoveDir1D::Next => nth_after(pos, count, thread, settings).into(),
                 }
             },
             MoveType::ViewportPos(MovePosition::Beginning) => {
                 let corner = self.viewctx.corner.key.as_ref()?;
 
-                let key = self.get_thread(info)?.range_messages(corner..).next()?.0;
+                let key = self.get_thread(info)?.range_messages(corner.., settings).next()?.0;
 
                 Some(key.into())
             },
@@ -489,8 +529,9 @@ impl ScrollbackState {
         count: &Count,
         ctx: &ProgramContext,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> Option<EditRange<MessageCursor>> {
-        let other = self.movement(pos.clone(), movement, count, ctx, info)?;
+        let other = self.movement(pos.clone(), movement, count, ctx, info, settings)?;
 
         Some(EditRange::inclusive(pos.into(), other, TargetShape::LineWise))
     }
@@ -499,10 +540,10 @@ impl ScrollbackState {
         &self,
         pos: MessageKey,
         range: &RangeType,
-        _: bool,
         count: &Count,
         ctx: &ProgramContext,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> Option<EditRange<MessageCursor>> {
         match range {
             RangeType::Bracketed(_, _) => None,
@@ -513,8 +554,8 @@ impl ScrollbackState {
 
             RangeType::Buffer => {
                 let thread = self.get_thread(info)?;
-                let start = thread.first_key()?;
-                let end = thread.last_key()?;
+                let start = thread.first_key(settings)?;
+                let end = thread.last_key(settings)?;
 
                 Some(EditRange::inclusive(start.into(), end.into(), TargetShape::LineWise))
             },
@@ -528,7 +569,7 @@ impl ScrollbackState {
 
                 let mut end = pos.clone();
 
-                for (i, (key, _)) in thread.range(&pos..).enumerate() {
+                for (i, (key, _)) in thread.range(&pos.., settings).enumerate() {
                     if i >= count {
                         break;
                     }
@@ -552,11 +593,12 @@ impl ScrollbackState {
         needle: &Regex,
         mut count: usize,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> Option<MessageCursor> {
         let thread = self.get_thread(info)?;
         let mut mc = None;
 
-        for (key, msg) in thread.range_messages(&start..) {
+        for (key, msg) in thread.range_messages(&start.., settings) {
             if count == 0 {
                 break;
             }
@@ -580,6 +622,7 @@ impl ScrollbackState {
         needle: &Regex,
         mut count: usize,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> (Option<MessageCursor>, bool) {
         let mut mc = None;
 
@@ -587,7 +630,7 @@ impl ScrollbackState {
             return (None, false);
         };
 
-        for (key, msg) in thread.range_messages(..&end).rev() {
+        for (key, msg) in thread.range_messages(..&end, settings).rev() {
             if count == 0 {
                 break;
             }
@@ -608,10 +651,11 @@ impl ScrollbackState {
         needle: &Regex,
         count: usize,
         info: &RoomInfo,
+        settings: &ApplicationSettings,
     ) -> (Option<MessageCursor>, bool) {
         match dir {
-            MoveDir1D::Next => (self.find_message_next(key, needle, count, info), false),
-            MoveDir1D::Previous => self.find_message_prev(key, needle, count, info),
+            MoveDir1D::Next => (self.find_message_next(key, needle, count, info, settings), false),
+            MoveDir1D::Previous => self.find_message_prev(key, needle, count, info, settings),
         }
     }
 }
@@ -673,9 +717,11 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         ctx: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
+        let settings = &store.application.settings;
+
         let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
-        let key = self.cursor.to_key(thread).ok_or_else(no_msgs)?.clone();
+        let key = self.cursor.to_key(thread, settings).ok_or_else(no_msgs)?.clone();
 
         match operation {
             EditAction::Motion => {
@@ -687,8 +733,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     EditTarget::CurrentPosition | EditTarget::Selection => {
                         return Ok(None);
                     },
-                    EditTarget::Boundary(rt, inc, term, count) => {
-                        self.range(key, rt, *inc, count, ctx, info).map(|r| {
+                    EditTarget::Boundary(rt, _, term, count) => {
+                        self.range(key, rt, count, ctx, info, settings).map(|r| {
                             match term {
                                 MoveTerminus::Beginning => r.start,
                                 MoveTerminus::End => r.end,
@@ -699,7 +745,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let mark = ctx.resolve(mark);
                         let cursor = store.cursors.get_mark(self.id.clone(), mark)?;
 
-                        if let Some(mc) = MessageCursor::from_cursor(&cursor, thread) {
+                        if let Some(mc) = MessageCursor::from_cursor(&cursor, thread, settings) {
                             Some(mc)
                         } else {
                             let msg = "Failed to restore mark";
@@ -708,7 +754,9 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                             return Err(err);
                         }
                     },
-                    EditTarget::Motion(mt, count) => self.movement(key, mt, count, ctx, info),
+                    EditTarget::Motion(mt, count) => {
+                        self.movement(key, mt, count, ctx, info, settings)
+                    },
                     EditTarget::Range(_, _, _) => {
                         return Err(EditError::Failure("Cannot use ranges in a list".to_string()));
                     },
@@ -727,7 +775,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let lsearch = store.registers.get_last_search().to_string();
                         let needle = Regex::new(lsearch.as_ref())?;
 
-                        let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
+                        let (mc, needs_load) =
+                            self.find_message(key, dir, &needle, count, info, settings);
                         if needs_load {
                             if let Some(store) = Weak::upgrade(&store.application.worker.store) {
                                 thread.paginate_backwards(store);
@@ -763,8 +812,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     EditTarget::CurrentPosition | EditTarget::Selection => {
                         Some(self._range_to(key.into()))
                     },
-                    EditTarget::Boundary(rt, inc, term, count) => {
-                        self.range(key, rt, *inc, count, ctx, info).map(|r| {
+                    EditTarget::Boundary(rt, _, term, count) => {
+                        self.range(key, rt, count, ctx, info, settings).map(|r| {
                             self._range_to(match term {
                                 MoveTerminus::Beginning => r.start,
                                 MoveTerminus::End => r.end,
@@ -775,7 +824,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let mark = ctx.resolve(mark);
                         let cursor = store.cursors.get_mark(self.id.clone(), mark)?;
 
-                        if let Some(c) = MessageCursor::from_cursor(&cursor, thread) {
+                        if let Some(c) = MessageCursor::from_cursor(&cursor, thread, settings) {
                             self._range_to(c).into()
                         } else {
                             let msg = "Failed to restore mark";
@@ -785,10 +834,10 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         }
                     },
                     EditTarget::Motion(mt, count) => {
-                        self.range_of_movement(key, mt, count, ctx, info)
+                        self.range_of_movement(key, mt, count, ctx, info, settings)
                     },
-                    EditTarget::Range(rt, inc, count) => {
-                        self.range(key, rt, *inc, count, ctx, info)
+                    EditTarget::Range(rt, _, count) => {
+                        self.range(key, rt, count, ctx, info, settings)
                     },
                     EditTarget::Search(SearchType::Char(_), _, _) => {
                         let msg = "Cannot perform character search in a list";
@@ -805,7 +854,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let lsearch = store.registers.get_last_search().to_string();
                         let needle = Regex::new(lsearch.as_ref())?;
 
-                        let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
+                        let (mc, needs_load) =
+                            self.find_message(key, dir, &needle, count, info, settings);
                         if needs_load {
                             if let Some(store) = Weak::upgrade(&store.application.worker.store) {
                                 thread.paginate_backwards(store);
@@ -833,7 +883,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     let mut yanked = EditRope::from("");
 
                     for (_, msg) in self
-                        .messages(range, info)
+                        .messages(range, info, settings)
                         .into_iter()
                         .flatten()
                         .filter_map(|(key, item)| item.as_event().map(|event| (key, event)))
@@ -873,9 +923,10 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         _: &ProgramContext,
         store: &mut ProgramStore,
     ) -> EditResult<EditInfo, IambInfo> {
+        let settings = &store.application.settings;
         let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
-        let cursor = self.cursor.to_cursor(thread).ok_or_else(no_msgs)?;
+        let cursor = self.cursor.to_cursor(thread, settings).ok_or_else(no_msgs)?;
         store.cursors.set_mark(self.id.clone(), name, cursor);
 
         Ok(None)
@@ -931,6 +982,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
     ) -> EditResult<EditInfo, IambInfo> {
         let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
+        let settings = &store.application.settings;
 
         match act {
             CursorAction::Close(_) => Ok(None),
@@ -948,7 +1000,9 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     self.push_jump();
                 }
 
-                if let Some(mc) = MessageCursor::from_cursor(ngroup.leader.cursor(), thread) {
+                if let Some(mc) =
+                    MessageCursor::from_cursor(ngroup.leader.cursor(), thread, settings)
+                {
                     self.cursor = mc;
 
                     Ok(None)
@@ -963,7 +1017,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 let reg = ctx.get_register().unwrap_or(Register::UnnamedCursorGroup);
 
                 // Lists don't have groups; override any previously saved group.
-                let cursor = self.cursor.to_cursor(thread).ok_or_else(|| {
+                let cursor = self.cursor.to_cursor(thread, settings).ok_or_else(|| {
                     let msg = "Cannot save position in message history";
                     EditError::Failure(msg.into())
                 })?;
@@ -1064,8 +1118,13 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
     ) -> EditResult<Vec<(Action<IambInfo>, ProgramContext)>, IambInfo> {
         let info = store.application.rooms.get(&self.room_id).expect("internal state invalid");
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
+        let settings = &store.application.settings;
 
-        let Some(msg) = self.cursor.to_key(thread).and_then(|key| thread.get_message(&key)) else {
+        let Some(msg) = self
+            .cursor
+            .to_key(thread, settings)
+            .and_then(|key| thread.get_message(&key))
+        else {
             let msg = "No message currently selected";
             let err = EditError::Failure(msg.into());
             return Err(err);
@@ -1118,7 +1177,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
         let mut corner = self.viewctx.corner.clone();
         let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
-        let Some(last_key) = thread.last_key() else {
+        let Some(last_key) = thread.last_key(settings) else {
             return Ok(None);
         };
 
@@ -1135,11 +1194,11 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
 
         match dir {
             MoveDir2D::Up => {
-                let first_key = thread.first_key();
+                let first_key = thread.first_key(settings);
 
-                for (key, item) in thread.range(..=&corner_key).rev() {
+                for (key, item) in thread.range(..=&corner_key, settings).rev() {
                     let sel = key == *cursor_key;
-                    let prev = prev_sender(&key, thread);
+                    let prev = prev_sender(&key, thread, settings);
                     let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
                     let max = len.saturating_sub(1);
@@ -1164,9 +1223,9 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 }
             },
             MoveDir2D::Down => {
-                let mut prev = prev_sender(&corner_key, thread);
+                let mut prev = prev_sender(&corner_key, thread, settings);
 
-                for (key, item) in thread.range(&corner_key..) {
+                for (key, item) in thread.range(&corner_key.., settings) {
                     let sel = key == *cursor_key;
                     let txt = item.show(prev, sel, &self.viewctx, info, settings, previews);
                     let len = txt.height().max(1);
@@ -1232,7 +1291,7 @@ impl ScrollActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                 let previews = &store.application.previews;
                 let thread = self.get_thread(info).ok_or_else(no_msgs)?;
 
-                if let Some(key) = self.cursor.to_key(thread) {
+                if let Some(key) = self.cursor.to_key(thread, settings) {
                     self.scrollview(key, pos, info, settings, previews);
                 }
 
@@ -1375,10 +1434,10 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         let cursor = &state.cursor;
-        let cursor_key = if let Some(k) = cursor.to_key(thread) {
+        let cursor_key = if let Some(k) = cursor.to_key(thread, settings) {
             k
         } else {
-            if state.need_more_messages(thread) {
+            if state.need_more_messages(thread, settings) {
                 if let Some(store) = Weak::upgrade(&self.store.application.worker.store) {
                     thread.paginate_backwards(store);
                 }
@@ -1390,17 +1449,17 @@ impl StatefulWidget for Scrollback<'_> {
         let corner_key = if let Some(k) = &corner.key {
             k.clone()
         } else {
-            nth_key_before(cursor_key.clone(), height, thread)
+            nth_key_before(cursor_key.clone(), height, thread, settings)
         };
 
         let foc = self.focused || cursor.key.is_some();
         let full = std::mem::take(&mut state.show_full_on_redraw) || cursor.key.is_none();
         let mut lines = vec![];
         let mut sawit = false;
-        let mut prev = prev_sender(&corner_key, thread);
+        let mut prev = prev_sender(&corner_key, thread, settings);
 
         // load image previews and replies
-        for (_, item) in thread.range_messages(&corner_key..).rev() {
+        for (_, item) in thread.range_messages(&corner_key.., settings).rev() {
             if let Some(source) = item.image_preview() {
                 self.store
                     .application
@@ -1444,7 +1503,7 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         let previews = &self.store.application.previews;
-        for (key, item) in thread.range(&corner_key..) {
+        for (key, item) in thread.range(&corner_key.., settings) {
             let sel = key == cursor_key;
 
             let (txt, [mut msg_preview, mut reply_preview]) =
@@ -1540,7 +1599,7 @@ impl StatefulWidget for Scrollback<'_> {
         }
 
         // Check whether we should load older messages for this room.
-        if state.need_more_messages(thread) {
+        if state.need_more_messages(thread, settings) {
             // If the top of the screen is the older message, load more.
             if let Some(store) = Weak::upgrade(&self.store.application.worker.store) {
                 thread.paginate_backwards(store);
@@ -1651,19 +1710,19 @@ mod tests {
 
         // Set a terminal width of 60, and height of 4, rendering in scrollback as:
         //
-        //       |------------------------------------------------------------|
-        // MSG2: |                Wednesday, December 31 1969                 |
-        //       |           @user2:example.com  helium                       |
-        // MSG3: |           @user2:example.com  this                         |
-        //       |                               is                           |
-        //       |                               a                            |
-        //       |                               multiline                    |
-        //       |                               message                      |
-        // MSG4: |           @user1:example.com  help                         |
-        // MSG5: |           @user2:example.com  character                    |
-        // MSG1: |                   XXXday, Month NN 20XX                    |
-        //       |           @user1:example.com  writhe                       |
-        //       |------------------------------------------------------------|
+        //           |------------------------------------------------------------|
+        // _divider1 |                Wednesday, December 31 1969                 |
+        // MSG2:     |           @user2:example.com  helium                       |
+        // MSG3:     |           @user2:example.com  this                         |
+        //           |                               is                           |
+        //           |                               a                            |
+        //           |                               multiline                    |
+        //           |                               message                      |
+        // MSG4:     |           @user1:example.com  help                         |
+        // MSG5:     |           @user2:example.com  character                    |
+        // _divider2 |                   XXXday, Month NN 20XX                    |
+        // MSG1:     |           @user1:example.com  writhe                       |
+        //           |------------------------------------------------------------|
         let area = Rect::new(0, 0, 60, 5);
         let mut buffer = Buffer::empty(area);
         scrollback.draw(area, &mut buffer, true, &mut store);

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1623,6 +1623,12 @@ impl StatefulWidget for Scrollback<'_> {
                         );
                     }
                 });
+
+                if let Some(notification_handles) =
+                    self.store.application.open_notifications.remove(&state.room_id)
+                {
+                    tokio::task::spawn_blocking(|| std::mem::drop(notification_handles));
+                };
             }
         }
 

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -542,7 +542,7 @@ impl ScrollbackState {
                 continue;
             }
 
-            if needle.is_match(msg.event.body().as_ref()) {
+            if needle.is_match(msg.event().body().as_ref()) {
                 mc = MessageCursor::from(key.clone()).into();
                 count -= 1;
             }
@@ -569,7 +569,7 @@ impl ScrollbackState {
                 break;
             }
 
-            if needle.is_match(msg.event.body().as_ref()) {
+            if needle.is_match(msg.event().body().as_ref()) {
                 mc = MessageCursor::from(key.clone()).into();
                 count -= 1;
             }
@@ -806,7 +806,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                     let mut yanked = EditRope::from("");
 
                     for (_, msg) in self.messages(range, info) {
-                        yanked += EditRope::from(msg.event.body());
+                        yanked += EditRope::from(msg.event().body());
                         yanked += EditRope::from('\n');
                     }
 
@@ -1361,7 +1361,7 @@ impl StatefulWidget for Scrollback<'_> {
 
         // load image previews
         for (_, item) in thread.range(&corner_key..).rev() {
-            if let Some(source) = &item.image_preview {
+            if let Some(source) = item.image_preview() {
                 self.store
                     .application
                     .previews
@@ -1371,7 +1371,7 @@ impl StatefulWidget for Scrollback<'_> {
                 .reply_to()
                 .or_else(|| item.thread_root())
                 .and_then(|e| info.get_event(&e))
-                .and_then(|msg| msg.image_preview.as_ref());
+                .and_then(|msg| msg.image_preview());
             if let Some(source) = reply {
                 self.store
                     .application

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -79,18 +79,27 @@ fn nth_key_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageKey {
 }
 
 fn nth_before(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
-    let key = nth_key_before(pos, n, thread);
+    let mut end = pos;
+    let iter = thread.range_messages(..=end.clone()).rev().enumerate();
 
-    if thread.last_key().is_some_and(|last| key == last) {
+    for (i, (key, _)) in iter {
+        end = key;
+
+        if i >= n {
+            break;
+        }
+    }
+
+    if thread.last_key().is_some_and(|last| end == last) {
         MessageCursor::latest()
     } else {
-        MessageCursor::from(key)
+        MessageCursor::from(end)
     }
 }
 
 fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<MessageKey> {
     let mut end = pos;
-    let mut iter = thread.range(&end..).enumerate();
+    let mut iter = thread.range_messages(end.clone()..).enumerate();
 
     for (i, (key, _)) in iter.by_ref() {
         end = key;
@@ -101,7 +110,7 @@ fn nth_key_after(pos: MessageKey, n: usize, thread: &Messages) -> Option<Message
     }
 
     // Avoid returning the key if it's at the end.
-    iter.next().map(|_| end.clone())
+    iter.next().map(|_| end)
 }
 
 fn nth_after(pos: MessageKey, n: usize, thread: &Messages) -> MessageCursor {
@@ -405,7 +414,7 @@ impl ScrollbackState {
             MoveType::BufferLineOffset => None,
             MoveType::BufferLinePercent => None,
             MoveType::BufferPos(MovePosition::Beginning) => {
-                let start = self.get_thread(info)?.first_key()?.clone();
+                let start = self.get_thread(info)?.range_messages(..).next()?.0;
 
                 Some(start.into())
             },
@@ -426,7 +435,11 @@ impl ScrollbackState {
                 }
             },
             MoveType::ViewportPos(MovePosition::Beginning) => {
-                return self.viewctx.corner.key.as_ref().map(|k| k.clone().into());
+                let corner = self.viewctx.corner.key.as_ref()?;
+
+                let key = self.get_thread(info)?.range_messages(corner..).next()?.0;
+
+                Some(key.into())
             },
             MoveType::ViewportPos(MovePosition::Middle) => {
                 // XXX: Need to calculate an accurate middle position.
@@ -1299,7 +1312,6 @@ impl<'a> Scrollback<'a> {
 impl StatefulWidget for Scrollback<'_> {
     type State = ScrollbackState;
 
-    #[allow(unused)]
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let info = self.store.application.rooms.get_or_default(state.room_id.clone());
         let settings = &self.store.application.settings;

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1,11 +1,16 @@
 //! Message scrollback
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 
 use matrix_sdk_ui::timeline::TimelineItem;
 use ratatui_image::Image;
 use regex::Regex;
 
-use matrix_sdk::ruma::{OwnedEventId, OwnedRoomId, UserId};
+use matrix_sdk::ruma::{
+    api::client::receipt::create_receipt::v3::ReceiptType,
+    OwnedEventId,
+    OwnedRoomId,
+    UserId,
+};
 
 use modalkit_ratatui::{ScrollActions, TerminalCursor, WindowOps};
 use ratatui::{
@@ -1481,14 +1486,23 @@ impl StatefulWidget for Scrollback<'_> {
 
         if self.room_focused && settings.tunables.read_receipt_send && state.cursor.key.is_none() {
             // If the cursor is at the last message, then update the read marker.
-            if let Some(_k) = thread.last_key() {
-                // info.set_receipt(
-                //     thread.receipt_thread().clone(),
-                //     settings.profile.user_id.clone(),
-                //     k.id().to_owned(),
-                // );
-                // todo!()
-            }
+
+            let receipt = if settings.tunables.read_receipt_send {
+                ReceiptType::Read
+            } else {
+                ReceiptType::ReadPrivate
+            };
+
+            let timeline = Arc::clone(thread.timeline());
+
+            tokio::spawn(async move {
+                if let Err(err) = timeline.mark_as_read(receipt).await {
+                    tracing::warn!(
+                        room_id = ?timeline.room().room_id(),
+                        "unable to send read receipt: {err}"
+                    );
+                }
+            });
         }
 
         // Check whether we should load older messages for this room.

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -6,10 +6,7 @@ use std::time::{Duration, Instant};
 use matrix_sdk::ruma::events::space::child::SpaceChildEventContent;
 use matrix_sdk::ruma::events::StateEventType;
 use matrix_sdk::ruma::OwnedSpaceChildOrder;
-use matrix_sdk::{
-    room::Room as MatrixRoom,
-    ruma::{OwnedRoomId, RoomId},
-};
+use matrix_sdk::{room::Room as MatrixRoom, ruma::OwnedRoomId};
 
 use modalkit::prelude::{EditInfo, InfoMessage};
 use ratatui::{
@@ -60,18 +57,8 @@ impl SpaceState {
         SpaceState { room_id, room, list, last_fetch }
     }
 
-    pub fn refresh_room(&mut self, store: &mut ProgramStore) {
-        if let Some(room) = store.application.worker.client.get_room(self.id()) {
-            self.room = room;
-        }
-    }
-
     pub fn room(&self) -> &MatrixRoom {
         &self.room
-    }
-
-    pub fn id(&self) -> &RoomId {
-        &self.room_id
     }
 
     pub fn dup(&self, store: &mut ProgramStore) -> Self {

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -35,7 +35,7 @@ use crate::base::{
     SpaceAction,
 };
 
-use crate::windows::{room_fields_cmp, ChatItem, GenericChatItem, RoomLikeItem};
+use crate::windows::{room_fields_cmp, GenericChatItem, ItemTypeTag, RoomLikeItem};
 
 const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 
@@ -43,7 +43,7 @@ const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 pub struct SpaceState {
     room_id: OwnedRoomId,
     room: MatrixRoom,
-    list: ListState<GenericChatItem<ChatItem>, IambInfo>,
+    list: ListState<GenericChatItem, IambInfo>,
     last_fetch: Option<Instant>,
 }
 
@@ -151,7 +151,7 @@ impl TerminalCursor for SpaceState {
 }
 
 impl Deref for SpaceState {
-    type Target = ListState<GenericChatItem<ChatItem>, IambInfo>;
+    type Target = ListState<GenericChatItem, IambInfo>;
 
     fn deref(&self) -> &Self::Target {
         &self.list
@@ -209,13 +209,18 @@ impl StatefulWidget for Space<'_> {
                                 .iter()
                                 .any(|id| id == room_id)
                             {
-                                ChatItem::Dm
+                                ItemTypeTag::Dm
                             } else {
-                                ChatItem::Room
+                                ItemTypeTag::Room
                             };
 
                             if room_id != state.room_id {
-                                Some(GenericChatItem::new(info, self.store, is_dm))
+                                Some(GenericChatItem::new(
+                                    info.room().clone(),
+                                    Some(info),
+                                    self.store,
+                                    is_dm,
+                                ))
                             } else {
                                 None
                             }

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -38,7 +38,7 @@ use crate::base::{
     SpaceAction,
 };
 
-use crate::windows::{room_fields_cmp, RoomItem, RoomLikeItem};
+use crate::windows::{room_fields_cmp, ChatItem, GenericChatItem, RoomLikeItem};
 
 const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 
@@ -46,7 +46,7 @@ const SPACE_HIERARCHY_DEBOUNCE: Duration = Duration::from_secs(5);
 pub struct SpaceState {
     room_id: OwnedRoomId,
     room: MatrixRoom,
-    list: ListState<RoomItem, IambInfo>,
+    list: ListState<GenericChatItem<ChatItem>, IambInfo>,
     last_fetch: Option<Instant>,
 }
 
@@ -164,7 +164,7 @@ impl TerminalCursor for SpaceState {
 }
 
 impl Deref for SpaceState {
-    type Target = ListState<RoomItem, IambInfo>;
+    type Target = ListState<GenericChatItem<ChatItem>, IambInfo>;
 
     fn deref(&self) -> &Self::Target {
         &self.list
@@ -211,13 +211,24 @@ impl StatefulWidget for Space<'_> {
                 Ok(members) => {
                     let mut items = members
                         .into_iter()
-                        .filter_map(|id| {
-                            let (room, _, tags) =
-                                self.store.application.worker.get_room(id.clone()).ok()?;
-                            let room_info = std::sync::Arc::new((room, tags));
+                        .filter_map(|room_id| self.store.application.rooms.get(&room_id))
+                        .filter_map(|info| {
+                            let room_id = info.room().room_id();
+                            let is_dm = if self
+                                .store
+                                .application
+                                .sync_info
+                                .dms
+                                .iter()
+                                .any(|id| id == room_id)
+                            {
+                                ChatItem::Dm
+                            } else {
+                                ChatItem::Room
+                            };
 
-                            if id != state.room_id {
-                                Some(RoomItem::new(room_info, self.store))
+                            if room_id != state.room_id {
+                                Some(GenericChatItem::new(info, self.store, is_dm))
                             } else {
                                 None
                             }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -144,7 +144,7 @@ pub async fn create_room(
         // XXX: Once matrix-sdk uses ruma 0.8, then this can skip the cast.
         let algo = EventEncryptionAlgorithm::MegolmV1AesSha2;
         let content = RoomEncryptionEventContent::new(algo);
-        let encr = InitialStateEvent { content, state_key: EmptyStateKey };
+        let encr = InitialStateEvent::new(EmptyStateKey, content);
         let encr_raw = Raw::new(&encr).map_err(IambError::from)?;
         let encr_raw = encr_raw.cast::<AnyInitialStateEvent>();
         initial_state.push(encr_raw);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -61,7 +61,6 @@ use matrix_sdk::{
             typing::SyncTypingEvent,
             AnyInitialStateEvent,
             AnyMessageLikeEvent,
-            AnySyncStateEvent,
             AnyTimelineEvent,
             EmptyStateKey,
             InitialStateEvent,
@@ -342,8 +341,8 @@ fn load_insert(
                 }
 
                 match msg {
-                    AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomEncrypted(msg)) => {
-                        info.insert_encrypted(msg);
+                    AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomEncrypted(_)) => {
+                        todo!()
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(msg)) => {
                         info.insert_with_preview(msg, settings, previews, worker);
@@ -354,10 +353,8 @@ fn load_insert(
                     AnyTimelineEvent::MessageLike(_) => {
                         continue;
                     },
-                    AnyTimelineEvent::State(msg) => {
-                        if settings.tunables.state_event_display {
-                            info.insert_any_state(msg.into());
-                        }
+                    AnyTimelineEvent::State(_) => {
+                        todo!()
                     },
                 }
             }
@@ -1096,20 +1093,6 @@ impl ClientWorker {
                 }
             },
         );
-
-        if self.settings.tunables.state_event_display {
-            let _ = self.client.add_event_handler(
-                |ev: AnySyncStateEvent, room: MatrixRoom, store: Ctx<AsyncProgramStore>| {
-                    async move {
-                        let room_id = room.room_id();
-                        let mut locked = store.lock().await;
-
-                        let info = locked.application.get_room_info(room_id.to_owned());
-                        info.insert_any_state(ev);
-                    }
-                },
-            );
-        }
 
         let _ = self.client.add_event_handler(
             |ev: OriginalSyncRoomRedactionEvent,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -65,7 +65,6 @@ use matrix_sdk::{
     Client,
     ClientBuildError,
     Error as MatrixError,
-    RoomDisplayName,
     RoomMemberships,
 };
 
@@ -270,8 +269,9 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
                 .insert(alias.to_string(), room.room_id().to_owned());
         }
 
-        // pre-compute name for spaces
-        let name = room.display_name().await.unwrap_or(RoomDisplayName::Empty).to_string();
+        // pre-compute name
+        let _ = room.sync_members().await;
+        let _ = room.display_name().await;
 
         if room.is_space() {
             spaces.push(room.room_id().to_owned());
@@ -301,8 +301,6 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
             .rooms
             .get_mut(room.room_id())
             .expect("value should have been inserted");
-
-        info.name = name;
 
         match room.tags().await {
             Ok(tags) => info.tags = tags,
@@ -942,7 +940,17 @@ impl ClientWorker {
 
         self.sync_handle = tokio::spawn(async move {
             loop {
-                let settings = SyncSettings::default();
+                let mut room = RoomEventFilter::default();
+                room.lazy_load_options =
+                    LazyLoadOptions::Enabled { include_redundant_members: false };
+
+                let mut room_ev = RoomFilter::default();
+                room_ev.state = room;
+
+                let mut filter = FilterDefinition::default();
+                filter.room = room_ev;
+
+                let settings = SyncSettings::new().filter(filter.into());
 
                 let _ = client.sync(settings).await;
             }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -485,7 +485,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     locked.application.sync_info.dms = dms;
 
     for (room_id, name) in names {
-        locked.application.set_room_name(&room_id, &name);
+        locked.application.rooms.get_or_default(room_id).name = name.into();
     }
 }
 
@@ -982,7 +982,7 @@ impl ClientWorker {
                         .filter(|u| u != &locked.application.settings.profile.user_id)
                         .collect();
 
-                    locked.application.get_room_info(room_id).set_typing(users);
+                    locked.application.rooms.get_or_default(room_id).set_typing(users);
                 }
             },
         );
@@ -1061,7 +1061,7 @@ impl ClientWorker {
                     let sender = ev.sender().to_owned();
                     let _ = locked.application.presences.get_or_default(sender);
 
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
                     update_event_receipts(info, &room, ev.event_id()).await;
                     info.insert_reaction(ev.into_full_event(room_id.to_owned()));
                 }
@@ -1077,7 +1077,7 @@ impl ClientWorker {
 
                     let mut locked = store.lock().await;
 
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
                     for (event_id, receipts) in ev.content.0.into_iter() {
                         let Some(receipts) = receipts.get(&ReceiptType::Read) else {
                             continue;
@@ -1108,7 +1108,7 @@ impl ClientWorker {
                         .redaction;
 
                     let mut locked = store.lock().await;
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
                     info.redact(ev, rules);
                 }
             },
@@ -1134,7 +1134,7 @@ impl ClientWorker {
                         .unwrap_or_default();
 
                     let mut locked = store.lock().await;
-                    let info = locked.application.get_room_info(room_id.to_owned());
+                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
 
                     if ambiguous {
                         info.display_names.remove(&user_id);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -660,7 +660,6 @@ impl ClientWorker {
         let _ = self.client.add_event_handler(
             |ev: SyncTypingEvent, room: MatrixRoom, store: Ctx<AsyncProgramStore>| {
                 async move {
-                    let room_id = room.room_id().to_owned();
                     let mut locked = store.lock().await;
 
                     let mut users = vec![];
@@ -678,7 +677,9 @@ impl ClientWorker {
                         users.push((user_id, display_name));
                     }
 
-                    locked.application.rooms.get_or_default(room_id).set_typing(users);
+                    if let Some(info) = locked.application.rooms.get_mut(room.room_id()) {
+                        info.set_typing(users);
+                    }
                 }
             },
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,13 +5,12 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter};
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::OwnedEventId;
@@ -60,7 +59,6 @@ use matrix_sdk::{
         OwnedRoomId,
         OwnedRoomOrAliasId,
         OwnedUserId,
-        RoomId,
     },
     Client,
     ClientBuildError,
@@ -80,7 +78,6 @@ use crate::preview::load_image;
 use crate::{
     base::{
         AsyncProgramStore,
-        ChatStore,
         CreateRoomFlags,
         CreateRoomType,
         IambError,
@@ -179,82 +176,8 @@ pub async fn create_room(
     return Ok(resp.room_id().to_owned());
 }
 
-async fn run_plan(
-    client: &Client,
-    store: &AsyncProgramStore,
-    room_id: OwnedRoomId,
-    permits: &Semaphore,
-) {
-    let permit = permits.acquire().await;
-    let res = members_load(client, &room_id).await;
-    let mut locked = store.lock().await;
-    members_insert(room_id, res, locked.deref_mut());
-    drop(permit);
-}
-
-#[allow(unused)]
-async fn load_older(client: &Client, store: &AsyncProgramStore) -> usize {
-    // This is an arbitrary limit on how much work we do in parallel to avoid
-    // spawning too many tasks at startup and overwhelming the client. We
-    // should normally only surpass this limit at startup when doing an initial.
-    // fetch for each room.
-    const LIMIT: usize = 15;
-
-    // Plans are run in parallel. Any room *may* have several plans.
-    let plans: Vec<OwnedRoomId> = todo!();
-    let permits = Semaphore::new(LIMIT);
-
-    plans
-        .into_iter()
-        .map(|plan| run_plan(client, store, plan, &permits))
-        .collect::<FuturesUnordered<_>>()
-        .count()
-        .await
-}
-
-async fn members_load(client: &Client, room_id: &RoomId) -> IambResult<Vec<RoomMember>> {
-    if let Some(room) = client.get_room(room_id) {
-        Ok(room
-            .members_no_sync(RoomMemberships::all())
-            .await
-            .map_err(IambError::from)?)
-    } else {
-        Err(IambError::UnknownRoom(room_id.to_owned()).into())
-    }
-}
-
-fn members_insert(
-    room_id: OwnedRoomId,
-    res: IambResult<Vec<RoomMember>>,
-    store: &mut ProgramStore,
-) {
-    if let Ok(members) = res {
-        let ChatStore { rooms, .. } = &mut store.application;
-        let info = rooms.get_or_default(room_id);
-
-        for member in members {
-            let user_id = member.user_id();
-            let display_name =
-                member.display_name().map_or(user_id.to_string(), |str| str.to_string());
-            info.display_names.insert(user_id.to_owned(), display_name);
-        }
-    }
-    // else ???
-}
-
-async fn load_older_forever(_client: &Client, _store: &AsyncProgramStore) {
-    // Load any pending older messages or members every 2 seconds.
-    let mut interval = tokio::time::interval(Duration::from_secs(2));
-
-    loop {
-        interval.tick().await;
-        // load_older(client, store).await;
-    }
-}
-
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     // TODO: process invited rooms
-    // TODO: load members
 
     let mut spaces = vec![];
     let mut rooms = vec![];
@@ -740,12 +663,20 @@ impl ClientWorker {
                     let room_id = room.room_id().to_owned();
                     let mut locked = store.lock().await;
 
-                    let users = ev
-                        .content
-                        .user_ids
-                        .into_iter()
-                        .filter(|u| u != &locked.application.settings.profile.user_id)
-                        .collect();
+                    let mut users = vec![];
+
+                    for user_id in ev.content.user_ids {
+                        if user_id == locked.application.settings.profile.user_id {
+                            continue;
+                        }
+
+                        let display_name =
+                            room.get_member_no_sync(&user_id).await.ok().flatten().and_then(
+                                |member| member.display_name().map(|name| name.to_owned()),
+                            );
+
+                        users.push((user_id, display_name));
+                    }
 
                     locked.application.rooms.get_or_default(room_id).set_typing(users);
                 }
@@ -885,10 +816,9 @@ impl ClientWorker {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
 
-                let load = load_older_forever(&client, &store);
                 let room = refresh_rooms_forever(&client, &store);
                 let notifications = register_notifications(&client, &settings, &store);
-                let ((), (), ()) = tokio::join!(load, room, notifications);
+                let ((), ()) = tokio::join!(room, notifications);
             }
         })
         .into();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -178,6 +178,7 @@ pub async fn create_room(
 
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     // TODO: process invited rooms
+    // TODO: log errors
 
     let mut spaces = vec![];
     let mut rooms = vec![];

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use gethostname::gethostname;
+use matrix_sdk::room::Invite;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::OwnedEventId;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
@@ -110,7 +111,7 @@ pub async fn create_room(
     room_alias_name: Option<String>,
     rt: CreateRoomType,
     flags: CreateRoomFlags,
-) -> IambResult<OwnedRoomId> {
+) -> IambResult<MatrixRoom> {
     let mut creation_content = None;
     let mut initial_state = vec![];
     let mut is_direct = false;
@@ -173,17 +174,36 @@ pub async fn create_room(
         }
     }
 
-    return Ok(resp.room_id().to_owned());
+    return Ok(resp);
 }
 
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
-    // TODO: process invited rooms
-
     let mut spaces = vec![];
     let mut rooms = vec![];
     let mut dms = vec![];
+    let mut invites = vec![];
 
     let mut locked = store.lock().await;
+
+    for room in client.invited_rooms() {
+        if let Some(alias) = room.canonical_alias() {
+            locked
+                .application
+                .names
+                .insert(alias.to_string(), room.room_id().to_owned());
+        }
+
+        // pre-compute name
+        if let Err(err) = room.sync_members().await {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room members: {err}");
+        }
+        if let Err(err) = room.display_name().await {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
+        };
+
+        invites.push(room.room_id().to_owned());
+    }
+
     for room in client.joined_rooms() {
         if let Some(alias) = room.canonical_alias() {
             locked
@@ -214,7 +234,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
         // only create `RoomInfo` for chats
 
         if locked.application.rooms.get(room.room_id()).is_none() {
-            let info = match RoomInfo::new(&room, Arc::clone(store), &mut locked).await {
+            let info = match RoomInfo::new(&room, Arc::clone(store)).await {
                 Ok(info) => info,
                 Err(err) => {
                     tracing::warn!(room_id = ?room.room_id(), "cannot create room info: {err}");
@@ -240,6 +260,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     locked.application.sync_info.spaces = spaces;
     locked.application.sync_info.rooms = rooms;
     locked.application.sync_info.dms = dms;
+    locked.application.sync_info.invites = invites;
 }
 
 async fn refresh_rooms_forever(client: &Client, store: &AsyncProgramStore) {
@@ -309,9 +330,10 @@ pub enum WorkerTask {
     Init(AsyncProgramStore, ClientReply<()>),
     Login(LoginStyle, ClientReply<IambResult<EditInfo>>),
     Logout(String, ClientReply<IambResult<EditInfo>>),
-    GetInviter(MatrixRoom, ClientReply<IambResult<Option<RoomMember>>>),
+    GetInviter(MatrixRoom, ClientReply<Result<Invite, matrix_sdk::Error>>),
     GetMessages(MatrixRoom, Option<OwnedEventId>, ClientReply<MessagesResult>),
-    JoinRoom(String, ClientReply<IambResult<OwnedRoomId>>),
+    JoinRoom(String, ClientReply<IambResult<MatrixRoom>>),
+    CreateRoomInfo(MatrixRoom, ClientReply<Result<RoomInfo, matrix_sdk_ui::timeline::Error>>),
     Members(OwnedRoomId, ClientReply<IambResult<Vec<RoomMember>>>),
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
     TypingNotice(OwnedRoomId),
@@ -351,6 +373,12 @@ impl Debug for WorkerTask {
             WorkerTask::JoinRoom(s, _) => {
                 f.debug_tuple("WorkerTask::JoinRoom")
                     .field(s)
+                    .field(&format_args!("_"))
+                    .finish()
+            },
+            WorkerTask::CreateRoomInfo(room, _) => {
+                f.debug_tuple("WorkerTask::CreateRoomInfo")
+                    .field(room)
                     .field(&format_args!("_"))
                     .finish()
             },
@@ -477,7 +505,7 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn get_inviter(&self, invite: MatrixRoom) -> IambResult<Option<RoomMember>> {
+    pub fn get_inviter(&self, invite: MatrixRoom) -> Result<Invite, matrix_sdk::Error> {
         let (reply, response) = oneshot();
 
         self.tx.send(WorkerTask::GetInviter(invite, reply)).unwrap();
@@ -493,10 +521,21 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn join_room(&self, name: String) -> IambResult<OwnedRoomId> {
+    pub fn join_room(&self, name: String) -> IambResult<MatrixRoom> {
         let (reply, response) = oneshot();
 
         self.tx.send(WorkerTask::JoinRoom(name, reply)).unwrap();
+
+        return response.recv();
+    }
+
+    pub fn create_room_info(
+        &self,
+        room: MatrixRoom,
+    ) -> Result<RoomInfo, matrix_sdk_ui::timeline::Error> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::CreateRoomInfo(room, reply)).unwrap();
 
         return response.recv();
     }
@@ -607,9 +646,13 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.join_room(room_id).await);
             },
+            WorkerTask::CreateRoomInfo(room, reply) => {
+                assert!(self.initialized);
+                reply.send(RoomInfo::new(&room, Arc::clone(self.store.as_ref().unwrap())).await);
+            },
             WorkerTask::GetInviter(invited, reply) => {
                 assert!(self.initialized);
-                reply.send(self.get_inviter(invited).await);
+                reply.send(invited.invite_details().await);
             },
             WorkerTask::GetMessages(room, thread, reply) => {
                 assert!(self.initialized);
@@ -922,14 +965,14 @@ impl ClientWorker {
         Ok(Some(InfoMessage::from("Successfully logged out")))
     }
 
-    async fn direct_message(&mut self, user: OwnedUserId) -> IambResult<OwnedRoomId> {
+    async fn direct_message(&mut self, user: OwnedUserId) -> IambResult<MatrixRoom> {
         for room in self.client.rooms() {
             if !is_direct(&room).await {
                 continue;
             }
 
             if room.get_member(user.as_ref()).await.map_err(IambError::from)?.is_some() {
-                return Ok(room.room_id().to_owned());
+                return Ok(room);
             }
         }
 
@@ -948,12 +991,6 @@ impl ClientWorker {
         })
     }
 
-    async fn get_inviter(&mut self, invited: MatrixRoom) -> IambResult<Option<RoomMember>> {
-        let details = invited.invite_details().await.map_err(IambError::from)?;
-
-        Ok(details.inviter)
-    }
-
     async fn get_messages(
         &mut self,
         room: MatrixRoom,
@@ -963,10 +1000,10 @@ impl ClientWorker {
         Messages::new(&room, thread, store).await
     }
 
-    async fn join_room(&mut self, name: String) -> IambResult<OwnedRoomId> {
-        if let Ok(alias_id) = OwnedRoomOrAliasId::from_str(name.as_str()) {
+    async fn join_room(&mut self, name: String) -> IambResult<MatrixRoom> {
+        let room = if let Ok(alias_id) = OwnedRoomOrAliasId::from_str(name.as_str()) {
             match self.client.join_room_by_id_or_alias(&alias_id, &[]).await {
-                Ok(resp) => Ok(resp.room_id().to_owned()),
+                Ok(resp) => resp,
                 Err(e) => {
                     let msg = e.to_string();
                     let err = UIError::Failure(msg);
@@ -975,13 +1012,20 @@ impl ClientWorker {
                 },
             }
         } else if let Ok(user) = OwnedUserId::try_from(name.as_str()) {
-            self.direct_message(user).await
+            self.direct_message(user).await?
         } else {
             let msg = format!("{:?} is not a valid room or user name", name.as_str());
             let err = UIError::Failure(msg);
 
             return Err(err);
-        }
+        };
+
+        // pre-compute name
+        if let Err(err) = room.display_name().await {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
+        };
+
+        Ok(room)
     }
 
     async fn members(&mut self, room_id: OwnedRoomId) -> IambResult<Vec<RoomMember>> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -16,6 +16,7 @@ use matrix_sdk::room::Invite;
 use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;
 use matrix_sdk::ruma::events::fully_read::FullyReadEventContent;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
+use matrix_sdk::ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent};
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::OwnedEventId;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
@@ -767,6 +768,22 @@ impl ClientWorker {
                     async move {
                         let mut locked = store.lock().await;
                         locked.application.presences.insert(ev.sender, ev.content.presence);
+                    }
+                });
+
+        let _ =
+            self.client
+                .add_event_handler(|ev: OriginalSyncRoomMessageEvent, client: Client| {
+                    async move {
+                        if let MessageType::VerificationRequest(_) = ev.content.msgtype {
+                            if let Some(request) = client
+                                .encryption()
+                                .get_verification_request(&ev.sender, &ev.event_id)
+                                .await
+                            {
+                                request.accept().await.expect("Failed to accept request");
+                            }
+                        }
                     }
                 });
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2,6 +2,7 @@
 //!
 //! The worker thread handles asynchronous work, and can receive messages from the main thread that
 //! block on a reply from the async worker.
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
@@ -13,6 +14,8 @@ use std::time::Duration;
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
 use matrix_sdk::ruma::events::room::MediaSource;
+use matrix_sdk::ruma::OwnedEventId;
+use matrix_sdk_ui::timeline::TimelineEventItemId;
 use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex, Semaphore};
@@ -46,7 +49,6 @@ use matrix_sdk::{
             },
             presence::PresenceEvent,
             room::encryption::RoomEncryptionEventContent,
-            tag::Tags,
             typing::SyncTypingEvent,
             AnyInitialStateEvent,
             EmptyStateKey,
@@ -72,6 +74,8 @@ use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::RoomInfo;
 use crate::config::ImagePreviewSize;
+use crate::message::html::StyleTree;
+use crate::message::Messages;
 use crate::notifications::register_notifications;
 use crate::preview::load_image;
 use crate::{
@@ -251,7 +255,7 @@ async fn load_older_forever(_client: &Client, _store: &AsyncProgramStore) {
 
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     // TODO: process invited rooms
-    // TODO: load initial messages
+    // TODO: load members
 
     let mut spaces = vec![];
     let mut rooms = vec![];
@@ -373,14 +377,15 @@ fn oneshot<T>() -> (ClientReply<T>, ClientResponse<T>) {
     return (reply, response);
 }
 
-pub type FetchedRoom = (MatrixRoom, RoomDisplayName, Option<Tags>);
+pub type MessagesResult =
+    Result<(Messages, HashMap<TimelineEventItemId, StyleTree>), matrix_sdk_ui::timeline::Error>;
 
 pub enum WorkerTask {
     Init(AsyncProgramStore, ClientReply<()>),
     Login(LoginStyle, ClientReply<IambResult<EditInfo>>),
     Logout(String, ClientReply<IambResult<EditInfo>>),
     GetInviter(MatrixRoom, ClientReply<IambResult<Option<RoomMember>>>),
-    GetRoom(OwnedRoomId, ClientReply<IambResult<FetchedRoom>>),
+    GetMessages(MatrixRoom, Option<OwnedEventId>, ClientReply<MessagesResult>),
     JoinRoom(String, ClientReply<IambResult<OwnedRoomId>>),
     Members(OwnedRoomId, ClientReply<IambResult<Vec<RoomMember>>>),
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
@@ -411,9 +416,10 @@ impl Debug for WorkerTask {
             WorkerTask::GetInviter(invite, _) => {
                 f.debug_tuple("WorkerTask::GetInviter").field(invite).finish()
             },
-            WorkerTask::GetRoom(room_id, _) => {
-                f.debug_tuple("WorkerTask::GetRoom")
-                    .field(room_id)
+            WorkerTask::GetMessages(room, thread, _) => {
+                f.debug_tuple("WorkerTask::GetMessages")
+                    .field(&room.room_id())
+                    .field(thread)
                     .field(&format_args!("_"))
                     .finish()
             },
@@ -554,10 +560,10 @@ impl Requester {
         return response.recv();
     }
 
-    pub fn get_room(&self, room_id: OwnedRoomId) -> IambResult<FetchedRoom> {
+    pub fn get_messages(&self, room: MatrixRoom, thread: Option<OwnedEventId>) -> MessagesResult {
         let (reply, response) = oneshot();
 
-        self.tx.send(WorkerTask::GetRoom(room_id, reply)).unwrap();
+        self.tx.send(WorkerTask::GetMessages(room, thread, reply)).unwrap();
 
         return response.recv();
     }
@@ -680,9 +686,9 @@ impl ClientWorker {
                 assert!(self.initialized);
                 reply.send(self.get_inviter(invited).await);
             },
-            WorkerTask::GetRoom(room_id, reply) => {
+            WorkerTask::GetMessages(room, thread, reply) => {
                 assert!(self.initialized);
-                reply.send(self.get_room(room_id).await);
+                reply.send(self.get_messages(room, thread).await);
             },
             WorkerTask::Login(style, reply) => {
                 assert!(self.initialized);
@@ -1003,15 +1009,13 @@ impl ClientWorker {
         Ok(details.inviter)
     }
 
-    async fn get_room(&mut self, room_id: OwnedRoomId) -> IambResult<FetchedRoom> {
-        if let Some(room) = self.client.get_room(&room_id) {
-            let name = room.cached_display_name().ok_or_else(|| IambError::UnknownRoom(room_id))?;
-            let tags = room.tags().await.map_err(IambError::from)?;
-
-            Ok((room, name, tags))
-        } else {
-            Err(IambError::UnknownRoom(room_id).into())
-        }
+    async fn get_messages(
+        &mut self,
+        room: MatrixRoom,
+        thread: Option<OwnedEventId>,
+    ) -> MessagesResult {
+        let store = self.store.clone().unwrap();
+        Messages::new(&room, thread, store).await
     }
 
     async fn join_room(&mut self, name: String) -> IambResult<OwnedRoomId> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -251,53 +251,44 @@ async fn load_older_forever(client: &Client, store: &AsyncProgramStore) {
     }
 }
 
-async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
-    let mut names = vec![];
-
-    let mut spaces = vec![];
-    let mut rooms = vec![];
-    let mut dms = vec![];
-
-    for room in client.invited_rooms().into_iter() {
-        let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
-        let tags = room.tags().await.unwrap_or_default();
-
-        names.push((room.room_id().to_owned(), name));
-
-        if is_direct(&room).await {
-            dms.push(Arc::new((room, tags)));
-        } else if room.is_space() {
-            spaces.push(Arc::new((room, tags)));
-        } else {
-            rooms.push(Arc::new((room, tags)));
-        }
-    }
-
-    for room in client.joined_rooms().into_iter() {
-        let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
-        let tags = room.tags().await.unwrap_or_default();
-
-        names.push((room.room_id().to_owned(), name));
-
-        if is_direct(&room).await {
-            dms.push(Arc::new((room, tags)));
-        } else if room.is_space() {
-            spaces.push(Arc::new((room, tags)));
-        } else {
-            rooms.push(Arc::new((room, tags)));
-        }
-    }
-
-    let mut locked = store.lock().await;
-    locked.application.sync_info.spaces = spaces;
-    locked.application.sync_info.rooms = rooms;
-    locked.application.sync_info.dms = dms;
-
-    for (room_id, name) in names {
-        locked.application.rooms.get_or_default(room_id).name = name.into();
-    }
-
-    // TODO: load initial messages
+async fn refresh_rooms(_client: &Client, _store: &AsyncProgramStore) {
+    todo!()
+    // let mut names = vec![];
+    //
+    // let mut spaces = vec![];
+    // let mut rooms = vec![];
+    // let mut dms = vec![];
+    //
+    // // TODO: process invited rooms
+    //
+    // for room in client.joined_rooms().into_iter() {
+    //     let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
+    //     let tags = room.tags().await.unwrap_or_default();
+    //
+    //     names.push((room.room_id().to_owned(), name));
+    //
+    //     if is_direct(&room).await {
+    //         dms.push(Arc::new((room, tags)));
+    //     } else if room.is_space() {
+    //         spaces.push(Arc::new((room, tags)));
+    //     } else {
+    //         rooms.push(Arc::new((room, tags)));
+    //     }
+    // }
+    //
+    // let mut locked = store.lock().await;
+    // locked.application.sync_info.spaces = spaces;
+    // locked.application.sync_info.rooms = rooms;
+    // locked.application.sync_info.dms = dms;
+    //
+    // for (room_id, name) in names {
+    //     locked.application.rooms.get_or_default(room_id).name = name.into();
+    //     // if let Some(alias) = room.canonical_alias() {
+    //     //     locked.application.names.insert(alias.to_string(), room_id);
+    //     // }
+    // }
+    //
+    // // TODO: load initial messages
 }
 
 async fn refresh_rooms_forever(client: &Client, store: &AsyncProgramStore) {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -178,7 +178,6 @@ pub async fn create_room(
 
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     // TODO: process invited rooms
-    // TODO: log errors
 
     let mut spaces = vec![];
     let mut rooms = vec![];
@@ -194,8 +193,12 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
         }
 
         // pre-compute name
-        let _ = room.sync_members().await;
-        let _ = room.display_name().await;
+        if let Err(err) = room.sync_members().await {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room members: {err}");
+        }
+        if let Err(err) = room.display_name().await {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
+        };
 
         if room.is_space() {
             spaces.push(room.room_id().to_owned());
@@ -214,7 +217,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
             let info = match RoomInfo::new(&room, Arc::clone(store), &mut locked).await {
                 Ok(info) => info,
                 Err(err) => {
-                    tracing::warn!("cannot create room info: {err}");
+                    tracing::warn!(room_id = ?room.room_id(), "cannot create room info: {err}");
                     continue;
                 },
             };
@@ -229,7 +232,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
         match room.tags().await {
             Ok(tags) => info.tags = tags,
             Err(err) => {
-                tracing::warn!("unable to compute room tags: {err}");
+                tracing::warn!(room_id = ?room.room_id(), "cannot to load room tags: {err}");
             },
         }
     }
@@ -884,7 +887,9 @@ impl ClientWorker {
 
                 let settings = SyncSettings::new().filter(filter.into());
 
-                let _ = client.sync(settings).await;
+                if let Err(err) = client.sync(settings).await {
+                    tracing::warn!("sync error: {err}");
+                };
             }
         })
         .into();
@@ -1001,7 +1006,9 @@ impl ClientWorker {
 
     async fn typing_notice(&mut self, room_id: OwnedRoomId) {
         if let Some(room) = self.client.get_room(room_id.as_ref()) {
-            let _ = room.typing_notice(true).await;
+            if let Err(err) = room.typing_notice(true).await {
+                tracing::warn!("cannot send typing notice: {err}");
+            };
         }
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -45,13 +45,12 @@ use matrix_sdk::{
                 VerificationMethod,
             },
             presence::PresenceEvent,
-            room::{encryption::RoomEncryptionEventContent, name::RoomNameEventContent},
+            room::encryption::RoomEncryptionEventContent,
             tag::Tags,
             typing::SyncTypingEvent,
             AnyInitialStateEvent,
             EmptyStateKey,
             InitialStateEvent,
-            SyncStateEvent,
         },
         room::RoomType,
         serde::Raw,
@@ -71,6 +70,7 @@ use matrix_sdk::{
 use modalkit::errors::UIError;
 use modalkit::prelude::{EditInfo, InfoMessage};
 
+use crate::base::RoomInfo;
 use crate::config::ImagePreviewSize;
 use crate::notifications::register_notifications;
 use crate::preview::load_image;
@@ -251,44 +251,68 @@ async fn load_older_forever(client: &Client, store: &AsyncProgramStore) {
     }
 }
 
-async fn refresh_rooms(_client: &Client, _store: &AsyncProgramStore) {
-    todo!()
-    // let mut names = vec![];
-    //
-    // let mut spaces = vec![];
-    // let mut rooms = vec![];
-    // let mut dms = vec![];
-    //
-    // // TODO: process invited rooms
-    //
-    // for room in client.joined_rooms().into_iter() {
-    //     let name = room.cached_display_name().unwrap_or(RoomDisplayName::Empty).to_string();
-    //     let tags = room.tags().await.unwrap_or_default();
-    //
-    //     names.push((room.room_id().to_owned(), name));
-    //
-    //     if is_direct(&room).await {
-    //         dms.push(Arc::new((room, tags)));
-    //     } else if room.is_space() {
-    //         spaces.push(Arc::new((room, tags)));
-    //     } else {
-    //         rooms.push(Arc::new((room, tags)));
-    //     }
-    // }
-    //
-    // let mut locked = store.lock().await;
-    // locked.application.sync_info.spaces = spaces;
-    // locked.application.sync_info.rooms = rooms;
-    // locked.application.sync_info.dms = dms;
-    //
-    // for (room_id, name) in names {
-    //     locked.application.rooms.get_or_default(room_id).name = name.into();
-    //     // if let Some(alias) = room.canonical_alias() {
-    //     //     locked.application.names.insert(alias.to_string(), room_id);
-    //     // }
-    // }
-    //
-    // // TODO: load initial messages
+async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
+    // TODO: process invited rooms
+    // TODO: load initial messages
+
+    let mut spaces = vec![];
+    let mut rooms = vec![];
+    let mut dms = vec![];
+
+    let mut locked = store.lock().await;
+    for room in client.joined_rooms() {
+        if let Some(alias) = room.canonical_alias() {
+            locked
+                .application
+                .names
+                .insert(alias.to_string(), room.room_id().to_owned());
+        }
+
+        // pre-compute name for spaces
+        let name = room.display_name().await.unwrap_or(RoomDisplayName::Empty).to_string();
+
+        if room.is_space() {
+            spaces.push(room.room_id().to_owned());
+            continue;
+        }
+
+        if is_direct(&room).await {
+            dms.push(room.room_id().to_owned());
+        } else {
+            rooms.push(room.room_id().to_owned());
+        }
+
+        // only create `RoomInfo` for chats
+
+        if locked.application.rooms.get(room.room_id()).is_none() {
+            let info = match RoomInfo::new(&room, Arc::clone(store)).await {
+                Ok(info) => info,
+                Err(err) => {
+                    tracing::warn!("cannot create room info: {err}");
+                    continue;
+                },
+            };
+            locked.application.rooms.insert(room.room_id().to_owned(), info);
+        }
+        let info = locked
+            .application
+            .rooms
+            .get_mut(room.room_id())
+            .expect("value should have been inserted");
+
+        info.name = name;
+
+        match room.tags().await {
+            Ok(tags) => info.tags = tags,
+            Err(err) => {
+                tracing::warn!("unable to compute room tags: {err}");
+            },
+        }
+    }
+
+    locked.application.sync_info.spaces = spaces;
+    locked.application.sync_info.rooms = rooms;
+    locked.application.sync_info.dms = dms;
 }
 
 async fn refresh_rooms_forever(client: &Client, store: &AsyncProgramStore) {
@@ -732,22 +756,6 @@ impl ClientWorker {
                         locked.application.presences.insert(ev.sender, ev.content.presence);
                     }
                 });
-
-        let _ = self.client.add_event_handler(
-            |ev: SyncStateEvent<RoomNameEventContent>,
-             room: MatrixRoom,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    if let SyncStateEvent::Original(ev) = ev {
-                        let room_id = room.room_id().to_owned();
-                        let room_name = Some(ev.content.name);
-                        let mut locked = store.lock().await;
-                        let info = locked.application.rooms.get_or_default(room_id.clone());
-                        info.name = room_name;
-                    }
-                }
-            },
-        );
 
         let _ = self.client.add_event_handler(
             |ev: OriginalSyncKeyVerificationStartEvent,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -241,13 +241,13 @@ fn members_insert(
     // else ???
 }
 
-async fn load_older_forever(client: &Client, store: &AsyncProgramStore) {
+async fn load_older_forever(_client: &Client, _store: &AsyncProgramStore) {
     // Load any pending older messages or members every 2 seconds.
     let mut interval = tokio::time::interval(Duration::from_secs(2));
 
     loop {
         interval.tick().await;
-        load_older(client, store).await;
+        // load_older(client, store).await;
     }
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -15,7 +15,7 @@ use gethostname::gethostname;
 use matrix_sdk::ruma::events::room::MediaSource;
 use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::error;
 use url::Url;
@@ -96,8 +96,6 @@ const DEFAULT_ENCRYPTION_SETTINGS: EncryptionSettings = EncryptionSettings {
 
 const IAMB_DEVICE_NAME: &str = "iamb";
 const IAMB_USER_AGENT: &str = "iamb";
-#[allow(unused)]
-const MIN_MSG_LOAD: u32 = 50;
 
 fn initial_devname() -> String {
     format!("{} on {}", IAMB_DEVICE_NAME, gethostname().to_string_lossy())
@@ -520,6 +518,7 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
 pub struct Requester {
     pub client: Client,
     pub tx: UnboundedSender<WorkerTask>,
+    pub store: Weak<Mutex<ProgramStore>>,
 }
 
 impl Requester {
@@ -646,7 +645,7 @@ impl ClientWorker {
             worker.work(rx).await;
         });
 
-        return Requester { client, tx };
+        return Requester { client, tx, store: Weak::new() };
     }
 
     async fn work(&mut self, mut rx: UnboundedReceiver<WorkerTask>) {
@@ -728,6 +727,7 @@ impl ClientWorker {
     }
 
     async fn init(&mut self, store: AsyncProgramStore) {
+        store.lock().await.application.worker.store = Arc::downgrade(&store);
         self.client.add_event_handler_context(store.clone());
 
         let _ = self.client.add_event_handler(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2,14 +2,13 @@
 //!
 //! The worker thread handles asynchronous work, and can receive messages from the main thread that
 //! block on a reply from the async worker.
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use gethostname::gethostname;
@@ -18,18 +17,17 @@ use ratatui_image::picker::Picker;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
-use tracing::{error, warn};
+use tracing::error;
 use url::Url;
 
 use matrix_sdk::{
     authentication::matrix::MatrixSession,
     config::{RequestConfig, SyncSettings},
-    deserialized_responses::DisplayName,
     encryption::verification::{SasVerification, Verification},
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_handler::Ctx,
     reqwest,
-    room::{Messages, MessagesOptions, Room as MatrixRoom, RoomMember},
+    room::{Room as MatrixRoom, RoomMember},
     ruma::{
         api::client::{
             filter::{FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter},
@@ -47,37 +45,21 @@ use matrix_sdk::{
                 VerificationMethod,
             },
             presence::PresenceEvent,
-            reaction::ReactionEventContent,
-            receipt::ReceiptType,
-            receipt::{ReceiptEventContent, ReceiptThread},
-            room::{
-                encryption::RoomEncryptionEventContent,
-                member::OriginalSyncRoomMemberEvent,
-                message::{MessageType, RoomMessageEventContent},
-                name::RoomNameEventContent,
-                redaction::OriginalSyncRoomRedactionEvent,
-            },
+            room::{encryption::RoomEncryptionEventContent, name::RoomNameEventContent},
             tag::Tags,
             typing::SyncTypingEvent,
             AnyInitialStateEvent,
-            AnyMessageLikeEvent,
-            AnyTimelineEvent,
             EmptyStateKey,
             InitialStateEvent,
-            SyncEphemeralRoomEvent,
-            SyncMessageLikeEvent,
             SyncStateEvent,
         },
         room::RoomType,
         serde::Raw,
         EventEncryptionAlgorithm,
-        EventId,
-        OwnedEventId,
         OwnedRoomId,
         OwnedRoomOrAliasId,
         OwnedUserId,
         RoomId,
-        RoomVersionId,
     },
     Client,
     ClientBuildError,
@@ -89,7 +71,6 @@ use matrix_sdk::{
 use modalkit::errors::UIError;
 use modalkit::prelude::{EditInfo, InfoMessage};
 
-use crate::base::MessageNeed;
 use crate::config::ImagePreviewSize;
 use crate::notifications::register_notifications;
 use crate::preview::load_image;
@@ -102,8 +83,6 @@ use crate::{
         IambError,
         IambResult,
         ProgramStore,
-        RoomFetchStatus,
-        RoomInfo,
         VerifyAction,
     },
     ApplicationSettings,
@@ -117,9 +96,8 @@ const DEFAULT_ENCRYPTION_SETTINGS: EncryptionSettings = EncryptionSettings {
 
 const IAMB_DEVICE_NAME: &str = "iamb";
 const IAMB_USER_AGENT: &str = "iamb";
+#[allow(unused)]
 const MIN_MSG_LOAD: u32 = 50;
-
-type MessageFetchResult = IambResult<(Option<String>, Vec<(AnyTimelineEvent, Vec<OwnedUserId>)>)>;
 
 fn initial_devname() -> String {
     format!("{} on {}", IAMB_DEVICE_NAME, gethostname().to_string_lossy())
@@ -200,189 +178,20 @@ pub async fn create_room(
     return Ok(resp.room_id().to_owned());
 }
 
-async fn update_event_receipts(info: &mut RoomInfo, room: &MatrixRoom, event_id: &EventId) {
-    let receipts = match room
-        .load_event_receipts(ReceiptType::Read, ReceiptThread::Main, event_id)
-        .await
-    {
-        Ok(receipts) => receipts,
-        Err(e) => {
-            tracing::warn!(?event_id, "failed to get event receipts: {e}");
-            return;
-        },
-    };
-
-    for (user_id, _) in receipts {
-        info.set_receipt(ReceiptThread::Main, user_id, event_id.to_owned());
-    }
-}
-
-#[derive(Debug)]
-enum Plan {
-    Messages(OwnedRoomId, Option<String>, Vec<MessageNeed>),
-    Members(OwnedRoomId),
-}
-
-async fn load_plans(store: &AsyncProgramStore) -> Vec<Plan> {
-    let mut locked = store.lock().await;
-    let ChatStore { need_load, rooms, .. } = &mut locked.application;
-    let mut plan = Vec::with_capacity(need_load.rooms() * 2);
-
-    for (room_id, need) in std::mem::take(need_load).into_iter() {
-        if let Some(message_need) = need.messages {
-            let info = rooms.get_or_default(room_id.clone());
-
-            if !info.recently_fetched() && !info.fetching {
-                info.fetch_last = Instant::now().into();
-                info.fetching = true;
-
-                let fetch_id = match &info.fetch_id {
-                    RoomFetchStatus::Done => continue,
-                    RoomFetchStatus::HaveMore(fetch_id) => Some(fetch_id.clone()),
-                    RoomFetchStatus::NotStarted => None,
-                };
-
-                plan.push(Plan::Messages(room_id.to_owned(), fetch_id, message_need));
-            }
-        }
-        if need.members {
-            plan.push(Plan::Members(room_id.to_owned()));
-        }
-    }
-
-    return plan;
-}
-
-async fn run_plan(client: &Client, store: &AsyncProgramStore, plan: Plan, permits: &Semaphore) {
+async fn run_plan(
+    client: &Client,
+    store: &AsyncProgramStore,
+    room_id: OwnedRoomId,
+    permits: &Semaphore,
+) {
     let permit = permits.acquire().await;
-    match plan {
-        Plan::Messages(room_id, fetch_id, message_need) => {
-            let limit = MIN_MSG_LOAD;
-            let client = client.clone();
-
-            let res = load_older_one(&client, &room_id, fetch_id, limit).await;
-            let mut locked = store.lock().await;
-            load_insert(room_id, res, locked.deref_mut(), message_need);
-        },
-        Plan::Members(room_id) => {
-            let res = members_load(client, &room_id).await;
-            let mut locked = store.lock().await;
-            members_insert(room_id, res, locked.deref_mut());
-        },
-    }
+    let res = members_load(client, &room_id).await;
+    let mut locked = store.lock().await;
+    members_insert(room_id, res, locked.deref_mut());
     drop(permit);
 }
 
-async fn load_older_one(
-    client: &Client,
-    room_id: &RoomId,
-    fetch_id: Option<String>,
-    limit: u32,
-) -> MessageFetchResult {
-    if let Some(room) = client.get_room(room_id) {
-        // Update cached encryption state. This is a noop if the state is already cached.
-        let _ = room.request_encryption_state().await;
-
-        let mut opts = match &fetch_id {
-            Some(id) => MessagesOptions::backward().from(id.as_str()),
-            None => MessagesOptions::backward(),
-        };
-        opts.limit = limit.into();
-
-        let Messages { end, chunk, .. } = room.messages(opts).await.map_err(IambError::from)?;
-
-        let mut msgs = vec![];
-
-        for ev in chunk.into_iter() {
-            let Ok(msg) = ev.into_raw().deserialize() else {
-                continue;
-            };
-
-            let event_id = msg.event_id();
-            let receipts = match room
-                .load_event_receipts(ReceiptType::Read, ReceiptThread::Main, event_id)
-                .await
-            {
-                Ok(receipts) => receipts.into_iter().map(|(u, _)| u).collect(),
-                Err(e) => {
-                    tracing::warn!(?event_id, "failed to get event receipts: {e}");
-                    vec![]
-                },
-            };
-
-            let msg = msg.into_full_event(room_id.to_owned());
-            msgs.push((msg, receipts));
-        }
-
-        Ok((end, msgs))
-    } else {
-        Err(IambError::UnknownRoom(room_id.to_owned()).into())
-    }
-}
-
-fn load_insert(
-    room_id: OwnedRoomId,
-    res: MessageFetchResult,
-    locked: &mut ProgramStore,
-    message_needs: Vec<MessageNeed>,
-) {
-    let ChatStore { presences, rooms, previews, settings, worker, .. } = &mut locked.application;
-    let info = rooms.get_or_default(room_id.clone());
-    info.fetching = false;
-
-    match res {
-        Ok((fetch_id, msgs)) => {
-            for (msg, receipts) in msgs.into_iter() {
-                let sender = msg.sender().to_owned();
-                let _ = presences.get_or_default(sender);
-
-                for user_id in receipts {
-                    info.set_receipt(ReceiptThread::Main, user_id, msg.event_id().to_owned());
-                }
-
-                match msg {
-                    AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomEncrypted(_)) => {
-                        todo!()
-                    },
-                    AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(msg)) => {
-                        info.insert_with_preview(msg, settings, previews, worker);
-                    },
-                    AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Reaction(ev)) => {
-                        info.insert_reaction(ev);
-                    },
-                    AnyTimelineEvent::MessageLike(_) => {
-                        continue;
-                    },
-                    AnyTimelineEvent::State(_) => {
-                        todo!()
-                    },
-                }
-            }
-
-            info.fetch_id = fetch_id.map_or(RoomFetchStatus::Done, RoomFetchStatus::HaveMore);
-
-            // check if more are needed
-            let needs: Vec<_> = message_needs
-                .into_iter()
-                .filter(|need| !info.keys.contains_key(&need.event_id) && need.ttl > 0)
-                .map(|mut need| {
-                    need.ttl -= 1;
-                    need
-                })
-                .collect();
-            if !needs.is_empty() {
-                locked.application.need_load.need_messages_all(room_id, needs);
-            }
-        },
-        Err(e) => {
-            warn!(room_id = room_id.as_str(), err = e.to_string(), "Failed to load older messages");
-
-            // Wait and try again.
-            locked.application.need_load.need_messages_all(room_id, message_needs);
-        },
-    }
-}
-
+#[allow(unused)]
 async fn load_older(client: &Client, store: &AsyncProgramStore) -> usize {
     // This is an arbitrary limit on how much work we do in parallel to avoid
     // spawning too many tasks at startup and overwhelming the client. We
@@ -391,7 +200,7 @@ async fn load_older(client: &Client, store: &AsyncProgramStore) -> usize {
     const LIMIT: usize = 15;
 
     // Plans are run in parallel. Any room *may* have several plans.
-    let plans = load_plans(store).await;
+    let plans: Vec<OwnedRoomId> = todo!();
     let permits = Semaphore::new(LIMIT);
 
     plans
@@ -487,6 +296,8 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     for (room_id, name) in names {
         locked.application.rooms.get_or_default(room_id).name = name.into();
     }
+
+    // TODO: load initial messages
 }
 
 async fn refresh_rooms_forever(client: &Client, store: &AsyncProgramStore) {
@@ -495,57 +306,6 @@ async fn refresh_rooms_forever(client: &Client, store: &AsyncProgramStore) {
     loop {
         refresh_rooms(client, store).await;
         interval.tick().await;
-    }
-}
-
-async fn send_receipts_forever(client: &Client, store: &AsyncProgramStore) {
-    let mut interval = tokio::time::interval(Duration::from_secs(2));
-    let mut sent: HashMap<OwnedRoomId, HashMap<ReceiptThread, OwnedEventId>> = Default::default();
-
-    loop {
-        interval.tick().await;
-
-        let mut locked = store.lock().await;
-        let ChatStore { settings, open_notifications, rooms, .. } = &mut locked.application;
-        let user_id = &settings.profile.user_id;
-
-        let mut updates = Vec::new();
-        for room in client.joined_rooms() {
-            let room_id = room.room_id();
-            let Some(info) = rooms.get(room_id) else {
-                continue;
-            };
-
-            let changed = info.receipts(user_id).filter_map(|(thread, new_receipt)| {
-                let old_receipt = sent.get(room_id).and_then(|ts| ts.get(thread));
-                let changed = Some(new_receipt) != old_receipt;
-                if changed {
-                    open_notifications.remove(room_id);
-                }
-                changed.then(|| (room_id.to_owned(), thread.to_owned(), new_receipt.to_owned()))
-            });
-
-            updates.extend(changed);
-        }
-        drop(locked);
-
-        for (room_id, thread, new_receipt) in updates {
-            use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;
-
-            let Some(room) = client.get_room(&room_id) else {
-                continue;
-            };
-
-            match room
-                .send_single_receipt(ReceiptType::Read, thread.to_owned(), new_receipt.clone())
-                .await
-            {
-                Ok(()) => {
-                    sent.entry(room_id).or_default().insert(thread, new_receipt);
-                },
-                Err(e) => tracing::warn!(?room_id, "Failed to set read receipt: {e}"),
-            }
-        }
     }
 }
 
@@ -566,20 +326,6 @@ pub async fn do_first_sync(client: &Client, store: &AsyncProgramStore) -> Result
 
     // Populate sync_info with our initial set of rooms/dms/spaces.
     refresh_rooms(client, store).await;
-
-    // Insert Need::Messages to fetch accurate recent timestamps in the background.
-    let mut locked = store.lock().await;
-    let ChatStore { sync_info, need_load, .. } = &mut locked.application;
-
-    for room in sync_info.rooms.iter() {
-        let room_id = room.as_ref().0.room_id().to_owned();
-        need_load.need_messages(room_id);
-    }
-
-    for room in sync_info.dms.iter() {
-        let room_id = room.as_ref().0.room_id().to_owned();
-        need_load.need_messages(room_id);
-    }
 
     Ok(())
 }
@@ -1013,141 +759,6 @@ impl ClientWorker {
         );
 
         let _ = self.client.add_event_handler(
-            |ev: SyncMessageLikeEvent<RoomMessageEventContent>,
-             room: MatrixRoom,
-             client: Client,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    let room_id = room.room_id();
-
-                    if let Some(msg) = ev.as_original() {
-                        if let MessageType::VerificationRequest(_) = msg.content.msgtype {
-                            if let Some(request) = client
-                                .encryption()
-                                .get_verification_request(ev.sender(), ev.event_id())
-                                .await
-                            {
-                                request.accept().await.expect("Failed to accept request");
-                            }
-                        }
-                    }
-
-                    let mut locked = store.lock().await;
-
-                    let sender = ev.sender().to_owned();
-                    let _ = locked.application.presences.get_or_default(sender);
-
-                    let ChatStore { rooms, previews, settings, worker, .. } =
-                        &mut locked.application;
-                    let info = rooms.get_or_default(room_id.to_owned());
-
-                    update_event_receipts(info, &room, ev.event_id()).await;
-
-                    let full_ev = ev.into_full_event(room_id.to_owned());
-                    info.insert_with_preview(full_ev, settings, previews, worker);
-                }
-            },
-        );
-
-        let _ = self.client.add_event_handler(
-            |ev: SyncMessageLikeEvent<ReactionEventContent>,
-             room: MatrixRoom,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    let room_id = room.room_id();
-
-                    let mut locked = store.lock().await;
-
-                    let sender = ev.sender().to_owned();
-                    let _ = locked.application.presences.get_or_default(sender);
-
-                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
-                    update_event_receipts(info, &room, ev.event_id()).await;
-                    info.insert_reaction(ev.into_full_event(room_id.to_owned()));
-                }
-            },
-        );
-
-        let _ = self.client.add_event_handler(
-            |ev: SyncEphemeralRoomEvent<ReceiptEventContent>,
-             room: MatrixRoom,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    let room_id = room.room_id();
-
-                    let mut locked = store.lock().await;
-
-                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
-                    for (event_id, receipts) in ev.content.0.into_iter() {
-                        let Some(receipts) = receipts.get(&ReceiptType::Read) else {
-                            continue;
-                        };
-                        for (user_id, rcpt) in receipts.iter() {
-                            info.set_receipt(
-                                rcpt.thread.clone(),
-                                user_id.to_owned(),
-                                event_id.clone(),
-                            );
-                        }
-                    }
-                }
-            },
-        );
-
-        let _ = self.client.add_event_handler(
-            |ev: OriginalSyncRoomRedactionEvent,
-             room: MatrixRoom,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    let room_id = room.room_id();
-                    let room_info = room.clone_info();
-                    let rules = &room_info
-                        .room_version()
-                        .and_then(RoomVersionId::rules)
-                        .unwrap_or(RoomVersionId::V1.rules().unwrap())
-                        .redaction;
-
-                    let mut locked = store.lock().await;
-                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
-                    info.redact(ev, rules);
-                }
-            },
-        );
-
-        let _ = self.client.add_event_handler(
-            |ev: OriginalSyncRoomMemberEvent,
-             room: MatrixRoom,
-             client: Client,
-             store: Ctx<AsyncProgramStore>| {
-                async move {
-                    let room_id = room.room_id();
-                    let user_id = ev.state_key;
-
-                    let ambiguous_name = DisplayName::new(
-                        ev.content.displayname.as_deref().unwrap_or_else(|| user_id.as_str()),
-                    );
-                    let ambiguous = client
-                        .state_store()
-                        .get_users_with_display_name(room_id, &ambiguous_name)
-                        .await
-                        .map(|users| users.len() > 1)
-                        .unwrap_or_default();
-
-                    let mut locked = store.lock().await;
-                    let info = locked.application.rooms.get_or_default(room_id.to_owned());
-
-                    if ambiguous {
-                        info.display_names.remove(&user_id);
-                    } else if let Some(display) = ev.content.displayname {
-                        info.display_names.insert(user_id, display);
-                    } else {
-                        info.display_names.remove(&user_id);
-                    }
-                }
-            },
-        );
-
-        let _ = self.client.add_event_handler(
             |ev: OriginalSyncKeyVerificationStartEvent,
              client: Client,
              store: Ctx<AsyncProgramStore>| {
@@ -1272,10 +883,9 @@ impl ClientWorker {
                 }
 
                 let load = load_older_forever(&client, &store);
-                let rcpt = send_receipts_forever(&client, &store);
                 let room = refresh_rooms_forever(&client, &store);
                 let notifications = register_notifications(&client, &settings, &store);
-                let ((), (), (), ()) = tokio::join!(load, rcpt, room, notifications);
+                let ((), (), ()) = tokio::join!(load, room, notifications);
             }
         })
         .into();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,6 +13,9 @@ use std::time::Duration;
 
 use gethostname::gethostname;
 use matrix_sdk::room::Invite;
+use matrix_sdk::ruma::api::client::receipt::create_receipt::v3::ReceiptType;
+use matrix_sdk::ruma::events::fully_read::FullyReadEventContent;
+use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::OwnedEventId;
 use matrix_sdk_ui::timeline::TimelineEventItemId;
@@ -241,6 +244,35 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
                     continue;
                 },
             };
+
+            match room.account_data_static::<FullyReadEventContent>().await {
+                Ok(Some(_)) => (),
+                Ok(None) => {
+                    // initialize with normal read marker
+                    if let Some((event_id, _)) = info
+                        .get_thread(None)
+                        .unwrap()
+                        .timeline()
+                        .latest_user_read_receipt(client.user_id().unwrap())
+                        .await
+                    {
+                        if let Err(err) = room
+                            .send_single_receipt(
+                                ReceiptType::FullyRead,
+                                ReceiptThread::Unthreaded,
+                                event_id,
+                            )
+                            .await
+                        {
+                            tracing::warn!(room_id = ?room.room_id(), "cannot set default fully_read marker: {err}");
+                        }
+                    }
+                },
+                Err(err) => {
+                    tracing::warn!(room_id = ?room.room_id(), "failed to load fully_read marker: {err}");
+                },
+            };
+
             locked.application.rooms.insert(room.room_id().to_owned(), info);
         }
         let info = locked

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -180,6 +180,31 @@ pub async fn create_room(
     return Ok(resp);
 }
 
+async fn refresh_matrix_room(room: &MatrixRoom, store: &mut ProgramStore) {
+    if let Some(alias) = room.canonical_alias() {
+        store
+            .application
+            .names
+            .insert(alias.to_string(), room.room_id().to_owned());
+    }
+
+    match room.members(RoomMemberships::ACTIVE).await {
+        Ok(members) => {
+            for member in members {
+                store.application.presences.get_or_default(member.user_id().to_owned());
+            }
+        },
+        Err(err) => {
+            tracing::warn!(room_id = ?room.room_id(), "cannot load room members: {err}");
+        },
+    }
+
+    // pre-compute name
+    if let Err(err) = room.display_name().await {
+        tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
+    };
+}
+
 async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     let mut spaces = vec![];
     let mut rooms = vec![];
@@ -189,39 +214,12 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
     let mut locked = store.lock().await;
 
     for room in client.invited_rooms() {
-        if let Some(alias) = room.canonical_alias() {
-            locked
-                .application
-                .names
-                .insert(alias.to_string(), room.room_id().to_owned());
-        }
-
-        // pre-compute name
-        if let Err(err) = room.sync_members().await {
-            tracing::warn!(room_id = ?room.room_id(), "cannot load room members: {err}");
-        }
-        if let Err(err) = room.display_name().await {
-            tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
-        };
-
+        refresh_matrix_room(&room, &mut locked).await;
         invites.push(room.room_id().to_owned());
     }
 
     for room in client.joined_rooms() {
-        if let Some(alias) = room.canonical_alias() {
-            locked
-                .application
-                .names
-                .insert(alias.to_string(), room.room_id().to_owned());
-        }
-
-        // pre-compute name
-        if let Err(err) = room.sync_members().await {
-            tracing::warn!(room_id = ?room.room_id(), "cannot load room members: {err}");
-        }
-        if let Err(err) = room.display_name().await {
-            tracing::warn!(room_id = ?room.room_id(), "cannot load room name: {err}");
-        };
+        refresh_matrix_room(&room, &mut locked).await;
 
         if room.is_space() {
             spaces.push(room.room_id().to_owned());

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -211,7 +211,7 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore) {
         // only create `RoomInfo` for chats
 
         if locked.application.rooms.get(room.room_id()).is_none() {
-            let info = match RoomInfo::new(&room, Arc::clone(store)).await {
+            let info = match RoomInfo::new(&room, Arc::clone(store), &mut locked).await {
                 Ok(info) => info,
                 Err(err) => {
                     tracing::warn!("cannot create room info: {err}");


### PR DESCRIPTION
Use [`matrix-sdk-ui`](https://docs.rs/matrix-sdk-ui/latest/matrix_sdk_ui/) for internal statekeeping.
This will reduce inconsistencies with other clients by respecting the spec better (e.g. message order by homerserver order instead of origin server timestamp or which messages should get a read receipt). 

Things this PR provides/does:
- update `modalkit` to newest git
- update `matrix-sdk` from `0.14.0` to `0.16.0`
- make sending nonblocking
- implement `:invites` list
- show replied to message for replies to old messages that are not loaded
- show and update the fully_read marker

Future Possibilities (that are way easier with `matrix-sdk-ui`):
- support polls
- show the raw json for an event (in combination with #566)
- differentiate in ui between unread messages, notifications and highlights (maybe with #472)
- show a [shield state](https://docs.rs/matrix-sdk-common/0.16.0/matrix_sdk_common/deserialized_responses/enum.ShieldState.html) for problematic messages
- going directly to the message context on `:replied` instead of paginating backwards until we hit it

includes #464
provides #445, #516, #579
fixes #588