### PR TITLE
Add configurable cursor shape via `settings.terminal.cursor_shape`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@ user_id = "@user:matrix.org"
 url = "https://matrix.org"
 
 [settings]
+cursor_shape = "default"
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
 log_level = "warn"

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,7 +6,6 @@ password_file = "/path/to/password"
 url = "https://matrix.org"
 
 [settings]
-cursor_shape = "default"
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
 log_level = "warn"
@@ -35,6 +34,7 @@ rooms = ["favorite", "lowpriority", "unread", "name"]
 members = ["power", "id"]
 
 [settings.terminal]
+cursor_shape = "default"
 enable_extended_keys = false
 enable_title = true
 

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -128,6 +128,16 @@ key and can be overridden as described in
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 
+.It Sy cursor_shape
+Control the terminal cursor shape used by iamb.
+Possible values are:
+.Dq Sy default ,
+.Dq Sy block ,
+.Dq Sy line , and
+.Dq Sy underline .
+Defaults to
+.Dq Sy default .
+
 .It Sy default_room
 The room to show by default instead of the
 .Sy :welcome

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,15 +126,6 @@ These options are configured as an object under the
 key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
-.It Sy cursor_shape
-Control the terminal cursor shape used by iamb.
-Possible values are:
-.Dq Sy default ,
-.Dq Sy block ,
-.Dq Sy line , and
-.Dq Sy underline .
-Defaults to
-.Dq Sy default .
 .It Sy encryption
 Configuration subsection for specific settings related to room encryption.
 See
@@ -447,6 +438,15 @@ interacts with your terminal.
 .Pp
 The available fields in this subsection are:
 .Bl -tag -width Ds
+.It Sy cursor_shape
+Control the terminal cursor shape used by iamb.
+Possible values are:
+.Dq Sy default ,
+.Dq Sy block ,
+.Dq Sy line , and
+.Dq Sy underline .
+Defaults to
+.Dq Sy default .
 .It Sy enable_extended_keys
 Defines whether to explicitly enable or disable requesting extended keypresses from your terminal.
 By default, when unset,

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,6 +558,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
+    pub cursor_shape: CursorShape,
     pub log_level: Level,
     pub message_shortcode_display: bool,
     pub normal_after_send: bool,
@@ -585,6 +586,7 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
+    pub cursor_shape: Option<CursorShape>,
     pub log_level: Option<LogLevel>,
     pub message_shortcode_display: Option<bool>,
     pub normal_after_send: Option<bool>,
@@ -614,6 +616,7 @@ pub struct Tunables {
 impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
+            cursor_shape: self.cursor_shape.or(other.cursor_shape),
             log_level: self.log_level.or(other.log_level),
             message_shortcode_display: self
                 .message_shortcode_display
@@ -648,6 +651,7 @@ impl Tunables {
 
     fn values(self) -> TunableValues {
         TunableValues {
+            cursor_shape: self.cursor_shape.unwrap_or_default(),
             log_level: self.log_level.map(Level::from).unwrap_or(Level::INFO),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),
@@ -675,6 +679,16 @@ impl Tunables {
             tabstop: self.tabstop.unwrap_or(4),
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CursorShape {
+    #[default]
+    Default,
+    Block,
+    Line,
+    Underline,
 }
 
 #[derive(Clone)]
@@ -1343,6 +1357,16 @@ mod tests {
         );
         assert!(serde_json::from_str::<NotifyVia>(r#""other""#).is_err());
         assert!(serde_json::from_str::<NotifyVia>(r#""""#).is_err());
+    }
+
+    #[test]
+    fn test_parse_cursor_shape() {
+        assert_eq!(CursorShape::Default, CursorShape::default());
+        assert_eq!(CursorShape::Default, serde_json::from_str(r#""default""#).unwrap());
+        assert_eq!(CursorShape::Block, serde_json::from_str(r#""block""#).unwrap());
+        assert_eq!(CursorShape::Line, serde_json::from_str(r#""line""#).unwrap());
+        assert_eq!(CursorShape::Underline, serde_json::from_str(r#""underline""#).unwrap());
+        assert!(serde_json::from_str::<CursorShape>(r#""beam""#).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -655,6 +655,7 @@ impl SortOverrides {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Terminal {
+    pub cursor_shape: Option<CursorShape>,
     pub enable_extended_keys: Option<bool>,
     pub enable_title: Option<bool>,
 }
@@ -662,6 +663,7 @@ pub struct Terminal {
 impl Terminal {
     fn merge(profile: Self, global: Self) -> Self {
         Self {
+            cursor_shape: profile.cursor_shape.or(global.cursor_shape),
             enable_extended_keys: profile.enable_extended_keys.or(global.enable_extended_keys),
             enable_title: profile.enable_title.or(global.enable_title),
         }
@@ -669,6 +671,7 @@ impl Terminal {
 
     pub fn values(self) -> TerminalValues {
         TerminalValues {
+            cursor_shape: self.cursor_shape.unwrap_or_default(),
             enable_extended_keys: self.enable_extended_keys,
             enable_title: self.enable_title.unwrap_or(DEFAULT_ENABLE_TITLE),
         }
@@ -677,13 +680,13 @@ impl Terminal {
 
 #[derive(Clone, Debug)]
 pub struct TerminalValues {
+    pub cursor_shape: CursorShape,
     pub enable_extended_keys: Option<bool>,
     pub enable_title: bool,
 }
 
 #[derive(Clone)]
 pub struct TunableValues {
-    pub cursor_shape: CursorShape,
     pub encryption: EncryptionValues,
     pub log_level: String,
     pub max_log_files: usize,
@@ -730,7 +733,6 @@ pub struct Tunables {
     /// Subsection for overriding how specific Matrix users are rendered.
     pub users: Option<UserOverrides>,
 
-    pub cursor_shape: Option<CursorShape>,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -764,7 +766,6 @@ impl Tunables {
             terminal: Terminal::merge(self.terminal, other.terminal),
             users: merge_maps(self.users, other.users),
 
-            cursor_shape: self.cursor_shape.or(other.cursor_shape),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -803,7 +804,6 @@ impl Tunables {
             sort: self.sort.values(),
             terminal: self.terminal.values(),
 
-            cursor_shape: self.cursor_shape.unwrap_or_default(),
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
@@ -835,13 +835,25 @@ impl Tunables {
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
 pub enum CursorShape {
     #[default]
     Default,
     Block,
     Line,
     Underline,
+}
+
+impl From<CursorShape> for modalkit::crossterm::cursor::SetCursorStyle {
+    fn from(shape: CursorShape) -> Self {
+        match shape {
+            CursorShape::Default => Self::DefaultUserShape,
+            CursorShape::Block => Self::SteadyBlock,
+            CursorShape::Line => Self::SteadyBar,
+            CursorShape::Underline => Self::SteadyUnderScore,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ use tracing_subscriber::FmtSubscriber;
 
 use modalkit::crossterm::{
     self,
-    cursor::Show as CursorShow,
+    cursor::{SetCursorStyle, Show as CursorShow},
     event::{
         poll,
         read,
@@ -99,7 +99,7 @@ use crate::{
         ProgramContext,
         ProgramStore,
     },
-    config::{ApplicationSettings, Iamb},
+    config::{ApplicationSettings, CursorShape, Iamb},
     windows::IambWindow,
     worker::{create_room, ClientWorker, LoginStyle, Requester},
 };
@@ -976,6 +976,12 @@ async fn login_normal(
 /// Set up the terminal for drawing the TUI, and getting additional info.
 fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std::io::Result<()> {
     let title = format!("iamb ({})", settings.profile.user_id.as_str());
+    let cursor_style = match settings.tunables.cursor_shape {
+        CursorShape::Default => SetCursorStyle::DefaultUserShape,
+        CursorShape::Block => SetCursorStyle::SteadyBlock,
+        CursorShape::Line => SetCursorStyle::SteadyBar,
+        CursorShape::Underline => SetCursorStyle::SteadyUnderScore,
+    };
 
     // Enable raw mode and enter the alternate screen.
     crossterm::terminal::enable_raw_mode()?;
@@ -993,7 +999,13 @@ fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std:
         crossterm::execute!(stdout(), EnableMouseCapture)?;
     }
 
-    crossterm::execute!(stdout(), EnableBracketedPaste, EnableFocusChange, SetTitle(title))
+    crossterm::execute!(
+        stdout(),
+        EnableBracketedPaste,
+        EnableFocusChange,
+        SetTitle(title),
+        cursor_style
+    )
 }
 
 // Do our best to reverse what we did in setup_tty() when we exit or crash.
@@ -1010,6 +1022,7 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
         stdout(),
         DisableBracketedPaste,
         DisableFocusChange,
+        SetCursorStyle::DefaultUserShape,
         LeaveAlternateScreen,
         CursorShow,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ use crate::{
         ProgramContext,
         ProgramStore,
     },
-    config::{ApplicationSettings, CursorShape, Iamb},
+    config::{ApplicationSettings, Iamb},
     windows::IambWindow,
     worker::{create_room, ClientWorker, LoginStyle, Requester},
 };
@@ -985,13 +985,6 @@ async fn login_normal(
 
 /// Set up the terminal for drawing the TUI, and getting additional info.
 fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std::io::Result<()> {
-    let cursor_style = match settings.tunables.cursor_shape {
-        CursorShape::Default => SetCursorStyle::DefaultUserShape,
-        CursorShape::Block => SetCursorStyle::SteadyBlock,
-        CursorShape::Line => SetCursorStyle::SteadyBar,
-        CursorShape::Underline => SetCursorStyle::SteadyUnderScore,
-    };
-
     // Enable raw mode and enter the alternate screen.
     crossterm::terminal::enable_raw_mode()?;
     crossterm::execute!(stdout(), EnterAlternateScreen)?;
@@ -1013,12 +1006,9 @@ fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std:
         crossterm::execute!(stdout(), SetTitle(title))?;
     }
 
-    crossterm::execute!(
-        stdout(),
-        EnableBracketedPaste,
-        EnableFocusChange,
-        cursor_style
-    )
+    let cursor_shape = SetCursorStyle::from(settings.tunables.terminal.cursor_shape);
+
+    crossterm::execute!(stdout(), EnableBracketedPaste, EnableFocusChange, cursor_shape)
 }
 
 // Do our best to reverse what we did in setup_tty() when we exit or crash.


### PR DESCRIPTION
### Summary

Add a new `settings.cursor_shape` option to configure the terminal cursor shape used by iamb.

Supported values:
- `default`
- `block`
- `line`
- `underline`

### Changes

- add `CursorShape` config enum with serde parsing
- add `cursor_shape` to `Tunables` / `TunableValues` (including merge + default handling)
- apply selected shape in TTY setup using `crossterm::cursor::SetCursorStyle`
- restore terminal cursor style to default on exit
- document the new setting in `docs/iamb.5`
- add `cursor_shape = \"default\"` to `config.example.toml`
- add unit test coverage for parsing (`test_parse_cursor_shape`)

### Motivation

Closes a long-standing request to support non-block cursors and allows users to match their terminal/editor preferences.

Closes #197