### PR TITLE
Improve logging rotation and change default level to `WARN`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6011,10 +6020,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ thiserror = "^1.0.37"
 toml = "^0.8.12"
 tracing = "~0.1.36"
 tracing-appender = "~0.2.2"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 unicode-segmentation = "^1.7"
 unicode-width = "0.1.10"
 url = {version = "^2.2.2", features = ["serde"]}

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -295,6 +295,18 @@ Produces no effect in
 but will display aliens from Space Invaders in Matrix clients that support doing so.
 .El
 
+.Sh "ENVIRONMENT"
+The behaviour of
+.Nm
+is affected by the following environment variables.
+.Bl -tag -width Ds
+.It Sy "RUST_LOG"
+Overwrites the value set by the
+.Sy log_level
+config value.
+The syntax is defined at
+.Lk https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
+
 .Sh EXAMPLES
 .Ss Example 1: Starting with a specific profile
 To start with a profile named

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -166,6 +166,14 @@ Possible values are:
 .Dq Sy warn , and
 .Dq Sy error .
 
+.It Sy max_log_files
+Specifies how many daily log files should be saved.
+Set this to
+.Sy 0
+to disable automatically deleting log files.
+Defaults to 
+.Sy 7 .
+
 .It Sy message_shortcode_display
 Defines whether or not Emoji characters in messages should be replaced by their
 respective shortcodes.

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -163,8 +163,11 @@ Possible values are:
 .Dq Sy trace ,
 .Dq Sy debug ,
 .Dq Sy info ,
-.Dq Sy warn , and
+.Dq Sy warn
+(the default), and
 .Dq Sy error .
+Also supports the syntax defined by
+.Lk https://docs.rs/tracing_subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
 
 .It Sy max_log_files
 Specifies how many daily log files should be saved.

--- a/src/config.rs
+++ b/src/config.rs
@@ -648,7 +648,7 @@ impl Tunables {
 
     fn values(self) -> TunableValues {
         TunableValues {
-            log_level: self.log_level.map(Level::from).unwrap_or(Level::INFO),
+            log_level: self.log_level.map(Level::from).unwrap_or(Level::WARN),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),
             reaction_display: self.reaction_display.unwrap_or(true),

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,6 @@ use ratatui::style::{Color, Modifier as StyleModifier, Style};
 use ratatui::text::Span;
 use ratatui_image::picker::ProtocolType;
 use serde::{de::Error as SerdeError, de::Visitor, Deserialize, Deserializer, Serialize};
-use tracing::Level;
 use url::Url;
 
 use modalkit::{env::vim::VimMode, key::TerminalKey, keybindings::InputKey};
@@ -221,47 +220,6 @@ impl<'de> Deserialize<'de> for VimModes {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_str(VimModesVisitor)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LogLevel(pub Level);
-pub struct LogLevelVisitor;
-
-impl From<LogLevel> for Level {
-    fn from(level: LogLevel) -> Level {
-        level.0
-    }
-}
-
-impl Visitor<'_> for LogLevelVisitor {
-    type Value = LogLevel;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a valid log level (e.g. \"warn\" or \"debug\")")
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: SerdeError,
-    {
-        match value {
-            "info" => Ok(LogLevel(Level::INFO)),
-            "debug" => Ok(LogLevel(Level::DEBUG)),
-            "warn" => Ok(LogLevel(Level::WARN)),
-            "error" => Ok(LogLevel(Level::ERROR)),
-            "trace" => Ok(LogLevel(Level::TRACE)),
-            _ => Err(E::custom("Could not parse log level")),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for LogLevel {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(LogLevelVisitor)
     }
 }
 
@@ -558,7 +516,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
-    pub log_level: Level,
+    pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
     pub normal_after_send: bool,
@@ -586,7 +544,7 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
-    pub log_level: Option<LogLevel>,
+    pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
     pub normal_after_send: Option<bool>,
@@ -651,7 +609,7 @@ impl Tunables {
 
     fn values(self) -> TunableValues {
         TunableValues {
-            log_level: self.log_level.map(Level::from).unwrap_or(Level::WARN),
+            log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),

--- a/src/config.rs
+++ b/src/config.rs
@@ -559,6 +559,7 @@ impl SortOverrides {
 #[derive(Clone)]
 pub struct TunableValues {
     pub log_level: Level,
+    pub max_log_files: usize,
     pub message_shortcode_display: bool,
     pub normal_after_send: bool,
     pub reaction_display: bool,
@@ -586,6 +587,7 @@ pub struct TunableValues {
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
     pub log_level: Option<LogLevel>,
+    pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
     pub normal_after_send: Option<bool>,
     pub reaction_display: Option<bool>,
@@ -615,6 +617,7 @@ impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
             log_level: self.log_level.or(other.log_level),
+            max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
                 .message_shortcode_display
                 .or(other.message_shortcode_display),
@@ -649,6 +652,7 @@ impl Tunables {
     fn values(self) -> TunableValues {
         TunableValues {
             log_level: self.log_level.map(Level::from).unwrap_or(Level::WARN),
+            max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),
             reaction_display: self.reaction_display.unwrap_or(true),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1091,7 +1091,7 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
         .filename_prefix(log_prefix)
         .max_log_files(max_log_files)
         .build(log_dir)
-        .unwrap();
+        .expect("can build appending tracing logger");
     let (appender, guard) = tracing_appender::non_blocking(appender);
 
     let filter = if let Ok(dirs) = std::env::var(EnvFilter::DEFAULT_ENV) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1084,7 +1084,7 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
 fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocking::WorkerGuard {
     let log_prefix = format!("iamb-log-{}", settings.profile_name);
     let log_dir = settings.dirs.logs.as_path();
-    let max_log_files = 7;
+    let max_log_files = settings.tunables.max_log_files;
 
     let appender = tracing_appender::rolling::Builder::new()
         .rotation(tracing_appender::rolling::Rotation::DAILY)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1085,6 +1085,7 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
     let log_prefix = format!("iamb-log-{}", settings.profile_name);
     let log_dir = settings.dirs.logs.as_path();
     let max_log_files = settings.tunables.max_log_files;
+    let log_level = settings.tunables.log_level;
 
     let appender = tracing_appender::rolling::Builder::new()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -1094,10 +1095,16 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
         .unwrap();
     let (appender, guard) = tracing_appender::non_blocking(appender);
 
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(log_level.into())
+        .from_env()
+        .unwrap();
+
     let subscriber = FmtSubscriber::builder()
         .with_writer(appender)
-        .with_max_level(settings.tunables.log_level)
+        .with_env_filter(filter)
         .finish();
+
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     guard

--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,6 +1081,28 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     Ok(())
 }
 
+fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocking::WorkerGuard {
+    let log_prefix = format!("iamb-log-{}", settings.profile_name);
+    let log_dir = settings.dirs.logs.as_path();
+    let max_log_files = 7;
+
+    let appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix(log_prefix)
+        .max_log_files(max_log_files)
+        .build(log_dir)
+        .unwrap();
+    let (appender, guard) = tracing_appender::non_blocking(appender);
+
+    let subscriber = FmtSubscriber::builder()
+        .with_writer(appender)
+        .with_max_level(settings.tunables.log_level)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    guard
+}
+
 fn main() -> IambResult<()> {
     // Parse command-line flags.
     let iamb = Iamb::parse();
@@ -1094,18 +1116,7 @@ fn main() -> IambResult<()> {
         libc::umask(0o077);
     };
 
-    // Set up the tracing subscriber so we can log client messages.
-    let log_prefix = format!("iamb-log-{}", settings.profile_name);
-    let log_dir = settings.dirs.logs.as_path();
-
-    let appender = tracing_appender::rolling::daily(log_dir, log_prefix);
-    let (appender, guard) = tracing_appender::non_blocking(appender);
-
-    let subscriber = FmtSubscriber::builder()
-        .with_writer(appender)
-        .with_max_level(settings.tunables.log_level)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    let guard = setup_logging(&settings);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ use modalkit::keybindings::InputBindings;
 use rand::{distributions::Alphanumeric, Rng};
 use temp_dir::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
-use tracing_subscriber::FmtSubscriber;
+use tracing::Level;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use modalkit::crossterm::{
     self,
@@ -1085,7 +1086,7 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
     let log_prefix = format!("iamb-log-{}", settings.profile_name);
     let log_dir = settings.dirs.logs.as_path();
     let max_log_files = settings.tunables.max_log_files;
-    let log_level = settings.tunables.log_level;
+    let log_level = &settings.tunables.log_level;
 
     let appender = tracing_appender::rolling::Builder::new()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -1095,10 +1096,19 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
         .unwrap();
     let (appender, guard) = tracing_appender::non_blocking(appender);
 
-    let filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(log_level.into())
-        .from_env()
-        .unwrap();
+    let filter = if let Ok(dirs) = std::env::var(EnvFilter::DEFAULT_ENV) {
+        EnvFilter::builder()
+            .with_default_directive(Level::WARN.into())
+            .parse(dirs)
+            .map_err(|err| format!("Unable to parse {}: {err}", EnvFilter::DEFAULT_ENV))
+            .unwrap_or_else(print_exit)
+    } else {
+        EnvFilter::builder()
+            .with_default_directive(Level::WARN.into())
+            .parse(log_level)
+            .map_err(|err| format!("Unable to parse `log_level`: {err}"))
+            .unwrap_or_else(print_exit)
+    };
 
     let subscriber = FmtSubscriber::builder()
         .with_writer(appender)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,6 @@ use matrix_sdk::ruma::{
 use lazy_static::lazy_static;
 use ratatui::style::{Color, Style};
 use tokio::sync::mpsc::unbounded_channel;
-use tracing::Level;
 use url::Url;
 
 use crate::{
@@ -170,7 +169,7 @@ pub fn mock_dirs() -> DirectoryValues {
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
         default_room: None,
-        log_level: Level::WARN,
+        log_level: "warn".into(),
         max_log_files: 7,
         message_shortcode_display: false,
         normal_after_send: true,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -170,7 +170,7 @@ pub fn mock_dirs() -> DirectoryValues {
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
         default_room: None,
-        log_level: Level::INFO,
+        log_level: Level::WARN,
         message_shortcode_display: false,
         normal_after_send: true,
         reaction_display: true,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,6 +171,7 @@ pub fn mock_tunables() -> TunableValues {
     TunableValues {
         default_room: None,
         log_level: Level::WARN,
+        max_log_files: 7,
         message_shortcode_display: false,
         normal_after_send: true,
         reaction_display: true,


### PR DESCRIPTION
Feel free to only use some of these commits.

Changes:
- set the default `log_level` to `warn` (the matrix-skd `info` logs are very verbose)
- delete log files after 7 files have been created (configured via `max_log_files`)
- support target specific log levels using [`EnvFilter`](https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html)
  - log configuration taken from `RUST_LOG` environment variable (ecosystem default location)
  - parse `log_level` setting as `EnvFilter` (backwards compatible, overwritten by `RUST_LOG`)

fixes #368