### PR TITLE
Store event cache in `~/.cache/iamb`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -866,6 +866,7 @@ pub struct ApplicationSettings {
     pub session_json_old: PathBuf,
     pub sled_dir: PathBuf,
     pub sqlite_dir: PathBuf,
+    pub sqlite_cache_dir: PathBuf,
     pub profile_name: String,
     pub profile: ProfileConfig,
     pub tunables: TunableValues,
@@ -999,12 +1000,16 @@ impl ApplicationSettings {
         let mut layout_json = cache_dir.clone();
         layout_json.push("layout.json");
 
+        let mut sqlite_cache_dir = cache_dir;
+        sqlite_cache_dir.push("sqlite");
+
         let settings = ApplicationSettings {
             sled_dir,
             layout_json,
             session_json,
             session_json_old,
             sqlite_dir,
+            sqlite_cache_dir,
             profile_name,
             profile,
             tunables,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -212,6 +212,7 @@ pub fn mock_settings() -> ApplicationSettings {
         session_json_old: PathBuf::new(),
         sled_dir: PathBuf::new(),
         sqlite_dir: PathBuf::new(),
+        sqlite_cache_dir: PathBuf::new(),
 
         profile_name: "test".into(),
         profile: ProfileConfig {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -725,7 +725,11 @@ async fn create_client_inner(
     // Set up the Matrix client for the selected profile.
     let builder = Client::builder()
         .http_client(http)
-        .sqlite_store(settings.sqlite_dir.as_path(), None)
+        .sqlite_store_with_cache_path(
+            settings.sqlite_dir.as_path(),
+            settings.sqlite_cache_dir.as_path(),
+            None,
+        )
         .request_config(req_config)
         .with_encryption_settings(DEFAULT_ENCRYPTION_SETTINGS);
 


### PR DESCRIPTION
This separates the event cache from the state store and makes it easier to delete the cache without accidentally deleting all room keys.