### PR TITLE
Add VimBindings::without_nxo_space_motion() for space-prefixed key chords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,8 +1492,6 @@ dependencies = [
 [[package]]
 name = "editor-types"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e99679670f67825fcd24a23cb4eb655a0f92c82bd4d1c1a1357c0cd71e87"
 dependencies = [
  "bitflags 2.10.0",
  "editor-types-macros",
@@ -1504,8 +1502,6 @@ dependencies = [
 [[package]]
 name = "editor-types-macros"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42680de76cf91f231abd90cc623750d39077f7d2fadb7962325fb082871f4c66"
 dependencies = [
  "editor-types-parser",
  "nom 7.1.3",
@@ -1517,8 +1513,6 @@ dependencies = [
 [[package]]
 name = "editor-types-parser"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac4b91fe830fbbe0a60c37ba0264b6e9ffc70e3664c028234dac59e79299ad4"
 dependencies = [
  "nom 7.1.3",
  "thiserror 1.0.69",
@@ -2871,8 +2865,6 @@ dependencies = [
 [[package]]
 name = "keybindings"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a726307ed87e05155c31329676130e6a237e62dda80211f7e1ed811e47630f"
 dependencies = [
  "textwrap",
  "unicode-segmentation",
@@ -3503,9 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbb03c35f23ec7d13f7870049803cd8829f5e60b69d38fa98f5e7876de9f34e"
+version = "0.0.25"
 dependencies = [
  "anymap2",
  "arboard",
@@ -3526,9 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "modalkit-ratatui"
-version = "0.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9b01555837e6d34c67ba887aee1d3d83e4622c42cbad0da1d90de00230d2aa"
+version = "0.0.25"
 dependencies = [
  "crossterm",
  "intervaltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,15 +79,20 @@ features = ["zbus", "serde"]
 optional = true
 
 [dependencies.modalkit]
-version = "0.0.24"
+version = "0.0.25"
 default-features = false
 #git = "https://github.com/ulyssa/modalkit"
 #rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 
 [dependencies.modalkit-ratatui]
-version = "0.0.24"
+version = "0.0.25"
 #git = "https://github.com/ulyssa/modalkit"
 #rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
+
+# Remove this patch once modalkit 0.0.25 is published to crates.io.
+[patch.crates-io]
+modalkit = { path = "../modalkit/crates/modalkit" }
+modalkit-ratatui = { path = "../modalkit/crates/modalkit-ratatui" }
 
 [dependencies.matrix-sdk]
 version = "0.14.0"

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@ user_id = "@user:matrix.org"
 url = "https://matrix.org"
 
 [settings]
+# leader_space_chords = true
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
 log_level = "warn"

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -176,6 +176,22 @@ Defines whether or not the message body is colored like the username.
 .It Sy normal_after_send
 Defines whether to reset input to Normal mode after sending a message.
 
+.It Sy leader_space_chords
+Defaults to
+.Sy false .
+When set to
+.Sy true ,
+the default Vim binding for a lone space key in Normal, Visual, and Operator-pending mode
+.Pq moving one column to the right
+is disabled so that space can be the first key of a multi-key chord defined under
+.Sx "CUSTOM KEYBINDINGS"
+.Pq e.g. LazyVim-style
+.Sy <Space>
+followed by another key.
+When this is enabled, use
+.Sy l
+or another mapping if you still want to move right with a single keypress.
+
 .It Sy notifications
 When this subsection is present, you can enable and configure push notifications.
 See

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,6 +581,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub leader_space_chords: bool,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -609,6 +610,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub leader_space_chords: Option<bool>,
 }
 
 impl Tunables {
@@ -643,6 +645,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            leader_space_chords: self.leader_space_chords.or(other.leader_space_chords),
         }
     }
 
@@ -673,6 +676,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            leader_space_chords: self.leader_space_chords.unwrap_or(false),
         }
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -22,12 +22,15 @@ fn once(key: &TerminalKey) -> (EdgeRepeat, EdgeEvent<TerminalKey, CommonKeyClass
 }
 
 /// Initialize the default keybinding state.
-pub fn setup_keybindings() -> Keybindings {
+pub fn setup_keybindings(leader_space_chords: bool) -> Keybindings {
     let mut ism = Keybindings::empty();
 
-    let vim = VimBindings::default()
+    let mut vim = VimBindings::default()
         .submit_on_enter()
         .cursor_open(MATRIX_ID_WORD.clone());
+    if leader_space_chords {
+        vim = vim.without_nxo_space_motion();
+    }
 
     vim.setup(&mut ism);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,8 @@ impl Application {
         let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend)?;
 
-        let mut bindings = crate::keybindings::setup_keybindings();
+        let mut bindings =
+            crate::keybindings::setup_keybindings(settings.tunables.leader_space_chords);
         settings.setup(&mut bindings);
         let bindings = KeyManager::new(bindings);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,6 +202,7 @@ pub fn mock_tunables() -> TunableValues {
         image_preview: None,
         user_gutter_width: 30,
         tabstop: 4,
+        leader_space_chords: false,
     }
 }
 


### PR DESCRIPTION
### Summary

Adds an opt-in `VimBindings` builder method that removes the default Normal/Visual/Operator-pending binding for a **lone space** (move one column right). That single-key binding prevents applications from registering multi-key sequences whose first key is space (e.g. leader-style chords implemented via config macros). 

### Motivation

Consumers such as [iamb](https://github.com/ulyssa/iamb) map user-defined key sequences after installing default Vim bindings. When space is already a complete `Step`, the input machine never enters a “wait for next key” state for `<Space>` followed by another key, so prefix chords starting with space cannot work.

Removing only this one mapping (there is a single `" "` entry in `default_keys()` today) frees `<Space>` as a chord prefix at the cost of losing the default space-as-motion behavior in NXO modes.

This allows lazyvim style leader navigation in iamb (when coupled with the changes in [modalkit PR](https://github.com/ulyssa/modalkit/pull/193)), as an alternative to the clunkier vanilla vim ":command" format.

### Changes

- `VimBindings::without_nxo_space_motion()` — filters `mappings` to drop the `" "` row.
- Unit test `without_nxo_space_motion_removes_space_mapping`.
- Crate version bump to **0.0.25** (workspace + `modalkit` + `modalkit-ratatui` as applicable).

### API

```rust
let vim = VimBindings::default()
    .submit_on_enter()
    .without_nxo_space_motion();
    
### Breaking Changes
None for default VimBindings::default(); the new behavior is strictly opt-in.