### PR TITLE
Fix build on rustc `1.94.0`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 //!
 //! Most rendering logic lives under the [windows] module, but [Matrix messages][message] have
 //! their own module.
+#![recursion_limit = "256"]
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::result_large_err)]


### PR DESCRIPTION
Due to changes in how the compiler desugars `async` blocks, the default recursion limit was reached.

This is a workaround until upstream provides a more permanent solution.

fixes #598