### PR TITLE
Bump MSRV to 1.92

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Install Rust (1.83 w/ clippy)
-      uses: dtolnay/rust-toolchain@1.83
+    - name: Install Rust (1.92 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.92
       with:
           components: clippy
     - name: Install Rust (nightly w/ rustfmt)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = [".github", "CONTRIBUTING.md"]
 keywords = ["matrix", "chat", "tui", "vim"]
 categories = ["command-line-utilities"]
-rust-version = "1.88"
+rust-version = "1.92"
 build = "build.rs"
 
 [features]

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         rustToolchain = fenix.packages.${system}.fromToolchainFile {
           file = ./rust-toolchain.toml;
           # When the file changes, this hash must be updated.
-          sha256 = "sha256-Qxt8XAuaUR2OMdKbN4u8dBJOhSHxS+uS06Wl9+flVEk=";
+          sha256 = "sha256-sqSWJDUxc+zaz1nBWMAJKTAGBuGWP25GCftIOlCEAtA=";
         };
 
         # Nightly toolchain for rustfmt (pinned to current flake lock)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.92"
 components = [ "clippy" ]


### PR DESCRIPTION
Updates the MSRV to help unblock future dependency updates.