### PR TITLE
Add `input_prompt` configuration option for overriding message bar prompt

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,7 @@ url = "https://matrix.org"
 [settings]
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
+# input_prompt = "❯ "  # Overrides the input-area prompt. Unset = default 🔒/🔓/> based on encryption state.
 log_level = "warn"
 message_shortcode_display = false
 open_command = ["my-open", "--file"]

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,8 +10,8 @@ default_markup = "html"
 default_room = "#iamb-users:0x.badd.cafe"
 default_split = "vertical"
 external_edit_file_suffix = ".md"
-# input_prompt = "❯ "  # Overrides the input-area prompt. Unset = default 🔒/🔓/> based on encryption state.
 ignorecase = false
+input_prompt = "❯ "
 log_level = "warn"
 members_split = "vertical"
 message_shortcode_display = false

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -166,6 +166,8 @@ Subsection for configuring image previews. See
 for more details.
 .It Sy ignorecase
 Defines whether searches ignore case. Defaults to false.
+.It Sy input_prompt
+Override the default message bar prompt.
 .It Sy log_level
 Specifies the lowest log level that should be shown.
 Possible values are:

--- a/src/config.rs
+++ b/src/config.rs
@@ -540,6 +540,7 @@ pub struct TunableValues {
     pub user_gutter_width: usize,
     pub external_edit_file_suffix: String,
     pub tabstop: usize,
+    pub input_prompt: Option<String>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -569,6 +570,7 @@ pub struct Tunables {
     pub user_gutter_width: Option<usize>,
     pub external_edit_file_suffix: Option<String>,
     pub tabstop: Option<usize>,
+    pub input_prompt: Option<String>,
 }
 
 impl Tunables {
@@ -604,6 +606,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .or(other.external_edit_file_suffix),
             tabstop: self.tabstop.or(other.tabstop),
+            input_prompt: self.input_prompt.or(other.input_prompt),
         }
     }
 
@@ -635,6 +638,7 @@ impl Tunables {
                 .external_edit_file_suffix
                 .unwrap_or_else(|| ".md".to_string()),
             tabstop: self.tabstop.unwrap_or(4),
+            input_prompt: self.input_prompt,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -170,6 +170,7 @@ pub fn mock_tunables() -> TunableValues {
         ignorecase: false,
         default_room: None,
         encryption: Encryption::default().values(),
+        input_prompt: None,
         log_level: "warn".into(),
         max_log_files: 7,
         message_shortcode_display: false,

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -9,7 +9,6 @@ use edit::edit_with_builder as external_edit;
 use edit::Builder;
 use matrix_sdk::EncryptionState;
 use modalkit::editing::store::RegisterError;
-use ratatui::style::{Color, Style};
 use std::process::Command;
 use tokio;
 use url::Url;
@@ -41,6 +40,7 @@ use matrix_sdk::{
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
+    style::{Color, Style},
     text::{Line, Span},
     widgets::{Paragraph, StatefulWidget, Widget},
 };
@@ -992,15 +992,27 @@ impl StatefulWidget for Chat<'_> {
             Paragraph::new(desc_spans).render(descarea, buf);
         }
 
-        let prompt = match (self.focused, state.room().encryption_state()) {
-            (false, _) => Span::raw("  "),
-            (_, EncryptionState::Encrypted) => {
-                Span::styled("\u{1F512}\u{FE0E} ", Style::new().fg(Color::LightGreen))
-            },
-            (_, EncryptionState::NotEncrypted) => {
-                Span::styled("\u{1F513}\u{FE0E} ", Style::new().fg(Color::Red))
-            },
-            (_, EncryptionState::Unknown) => Span::styled("> ", Style::new().fg(Color::Red)),
+        let prompt = if !self.focused {
+            Span::raw("  ")
+        } else if let Some(custom) = self
+            .store
+            .application
+            .settings
+            .tunables
+            .input_prompt
+            .as_deref()
+        {
+            Span::raw(custom)
+        } else {
+            match state.room().encryption_state() {
+                EncryptionState::Encrypted => {
+                    Span::styled("\u{1F512}\u{FE0E} ", Style::new().fg(Color::LightGreen))
+                },
+                EncryptionState::NotEncrypted => {
+                    Span::styled("\u{1F513}\u{FE0E} ", Style::new().fg(Color::Red))
+                },
+                EncryptionState::Unknown => Span::styled("> ", Style::new().fg(Color::Red)),
+            }
         };
 
         let tbox = TextBox::new().prompt(prompt);


### PR DESCRIPTION
when running in tmux, the default 🔒/🔓 encryption indicators didnt work properly for me and displayed a comma then a closing parenthesis. i just added the ability to override the input prompt.


SUMMARY BELOW IS AI GENERATED

## Summary

Adds an optional `input_prompt` string under `[settings]` that overrides the default lock/unlock emoji prompt in the input area.

- **Unset (default):** preserves existing behaviour — 🔒 green for encrypted, 🔓 red for unencrypted, `> ` red for unknown encryption state.
- **Set:** the provided string replaces the prompt for all three states.

## Example

```toml
[settings]
input_prompt = "❯ "
```

## Motivation

When running iamb inside tmux, the default emoji prompt can produce stray characters in the input line that only `Ctrl+L` clears. `tmux capture-pane` on the affected region shows a clean logical buffer — the artifact lives at the terminal display layer, caused by disagreement between ratatui's `unicode-width`, tmux's internal width tables, and the outer terminal's rendering of the lock glyph + `U+FE0E` variation selector. Not configurable at either end.

An ASCII override sidesteps the width mismatch while leaving the emoji prompt intact for users who aren't affected.

## Test plan

- [x] `cargo install --path . --locked` builds clean on rust 1.92
- [x] Default config: emoji prompt + colors render as before
- [x] With `input_prompt = "❯ "` in `[settings]`: single ASCII prompt renders, tmux artifacts disappear
- [x] `config.example.toml` updated with a commented example