### PR TITLE
Fix mdoc(7) warnings in docs/iamb.5

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -124,15 +124,12 @@ These options are configured as an object under the
 key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
-
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
-
 .It Sy default_room
 The room to show by default instead of the
 .Sy :welcome
 window.
-
 .It Sy image_preview
 Enable image previews and configure it.
 An empty object will enable the feature with default settings, omitting it will disable the feature.
@@ -169,57 +166,44 @@ Possible values are:
 .Dq Sy error .
 Also supports the syntax defined by
 .Lk https://docs.rs/tracing_subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
-
 .It Sy max_log_files
 Specifies how many daily log files should be saved.
 Set this to
 .Sy 0
 to disable automatically deleting log files.
-Defaults to 
+Defaults to
 .Sy 7 .
-
 .It Sy mouse
 Enable mouse support
 See
 .Sx MOUSE
 for more details.
-
 .It Sy message_shortcode_display
 Defines whether or not Emoji characters in messages should be replaced by their
 respective shortcodes.
-
 .It Sy message_user_color
 Defines whether or not the message body is colored like the username.
-
 .It Sy normal_after_send
 Defines whether to reset input to Normal mode after sending a message.
-
 .It Sy notifications
 When this subsection is present, you can enable and configure push notifications.
 See
 .Sx NOTIFICATIONS
 for more details.
-
 .It Sy open_command
 Defines a custom  command and its arguments to run when opening downloads instead of the default.
 (For example,
 .Sy ["my-open",\ "--file"] . )
-
 .It Sy reaction_display
 Defines whether or not reactions should be shown.
-
 .It Sy reaction_shortcode_display
 Defines whether or not reactions should be shown as their respective shortcode.
-
 .It Sy read_receipt_send
 Defines whether or not read confirmations are sent.
-
 .It Sy read_receipt_display
 Defines whether or not read confirmations are displayed.
-
 .It Sy request_timeout
 Defines the maximum time per request in seconds.
-
 .It Sy sort
 Configures how to sort the lists shown in windows like
 .Sy :rooms
@@ -228,22 +212,17 @@ or
 See
 .Sx "SORTING LISTS"
 for more details.
-
 .It Sy state_event_display
 Defines whether the state events like joined or left are shown.
-
 .It Sy typing_notice_send
 Defines whether or not the typing state is sent.
-
 .It Sy typing_notice_display
 Defines whether or not the typing state is displayed.
-
 .It Sy user
 Overrides values for the specified user.
 See
 .Sx "USER OVERRIDES"
 for details on the format.
-
 .It Sy username_display
 Defines how usernames are shown for message senders.
 Possible values are
@@ -251,17 +230,14 @@ Possible values are
 .Dq Sy localpart ,
 or
 .Dq Sy displayname .
-
 .It Sy user_gutter_width
 Specify the width of the column where usernames are displayed in a room.
 Usernames that are too long are truncated.
 Defaults to 30.
-
 .It Sy tabstop
 Number of spaces that a <Tab> counts for.
 Defaults to 4.
 .El
-
 .Ss Example 1: Avoid showing Emojis (useful for terminals w/o support)
 .Bd -literal -offset indent
 [settings]
@@ -269,20 +245,17 @@ username = "username"
 message_shortcode_display = true
 reaction_shortcode_display = true
 .Ed
-
 .Ss Example 2: Increase request timeout to 2 minutes for a slow homeserver
 .Bd -literal -offset indent
 [settings]
 request_timeout = 120
 .Ed
-
 .Sh MOUSE
-
 The
 .Sy settings.mouse
 subsection allows enabling mouse support.
 Currently the only difference is that scrolling moves the window view instead of changing the selection.
-
+.Pp
 The available fields in this subsection are:
 .Bl -tag -width Ds
 .It Sy enabled
@@ -291,13 +264,12 @@ Defaults to
 Setting this field to
 .Sy true
 enables mouse support.
-
+.El
 .Sh NOTIFICATIONS
-
 The
 .Sy settings.notifications
 subsection allows configuring how notifications for new messages behave.
-
+.Pp
 The available fields in this subsection are:
 .Bl -tag -width Ds
 .It Sy enabled
@@ -306,7 +278,6 @@ Defaults to
 Setting this field to
 .Sy true
 enables notifications.
-
 .It Sy via
 Defaults to
 .Dq Sy desktop
@@ -316,18 +287,15 @@ Setting this field to
 will use the terminal bell instead.
 Both can be used via
 .Dq Sy desktop|bell .
-
 .It Sy show_message
 controls whether to show the message in the desktop notification, and defaults to
 .Sy true .
 Messages are truncated beyond a small length.
 The notification rules are stored server side, loaded once at startup, and are currently not configurable in iamb.
 In other words, you can simply change the rules with another client.
-
 .It Sy sound_hint
 Controls the notification sound name that is passed as a hint to the notification daemon.
 .El
-
 .Ss Example 1: Enable notifications with default options
 .Bd -literal -offset indent
 [settings.notifications]
@@ -347,13 +315,11 @@ enabled = true
 sound_hint = "message-new-instant" # Linux
 sound_hint = "IM"                  # Windows
 .Ed
-
 .Sh "SORTING LISTS"
-
 The
 .Sy settings.sort
 subsection allows configuring how different windows have their contents sorted.
-
+.Pp
 Fields available within this subsection are:
 .Bl -tag -width Ds
 .It Sy rooms
@@ -390,7 +356,7 @@ window.
 Defaults to
 .Sy ["power",\ "id"] .
 .El
-
+.Pp
 The available values are:
 .Bl -tag -width Ds
 .It Sy favorite
@@ -410,31 +376,25 @@ Sort rooms by most recent message timestamp.
 .It Sy invite
 Put invites before other rooms.
 .El
-.El
-
+.Pp
 Add a
 .Dq Sy ~
 in front of any value to flip the order.
-
 .Ss Example 1: Group room members by their server first and descending localpart second
 .Bd -literal -offset indent
 [settings.sort]
 members = ["server", "~localpart"]
 .Ed
-
 .Sh "USER OVERRIDES"
-
 The
 .Sy settings.users
 subsections allows overriding how specific senders are displayed.
 Overrides are mapped onto Matrix User IDs such as
 .Sy @user:matrix.org ,
 and are typically written as inline tables containing the following keys:
-
 .Bl -tag -width Ds
 .It Sy name
 Change the display name of the user.
-
 .It Sy color
 Change the color the user is shown as.
 Possible values are:
@@ -457,20 +417,16 @@ Possible values are:
 and
 .Dq Sy yellow .
 .El
-
 .Ss Example 1: Override how @ada:example.com appears in chat
 .Bd -literal -offset indent
 [settings.users]
 "@ada:example.com" = { name = "Ada Lovelace", color = "light-red" }
 .Ed
-
 .Sh STARTUP LAYOUT
-
 The
 .Sy layout
 section allows configuring the initial set of tabs and windows to show when
 starting the client.
-
 .Bl -tag -width Ds
 .It Sy style
 Specifies what window layout to load when starting.
@@ -484,7 +440,6 @@ if set), or
 .Dq Sy config
 to open the layout described under
 .Sy tabs .
-
 .It Sy tabs
 If
 .Sy style
@@ -497,7 +452,6 @@ key specifying a username, room identifier or room alias to show, or a
 .Sy split
 key specifying an array of window objects.
 .El
-
 .Ss Example 1: Show a single room every startup
 .Bd -literal -offset indent
 [settings]
@@ -523,67 +477,54 @@ split = [
     { "window" = "#iamb-dev:0x.badd.cafe" }
 ]
 .Ed
-
 .Sh "CUSTOM KEYBINDINGS"
-
 The
 .Sy macros
 subsections allow configuring custom keybindings.
 Available subsections are:
-
 .Bl -tag -width Ds
 .It Sy insert , Sy i
 Map the key sequences in this section in
 .Sy Insert
 mode.
-
 .It Sy normal , Sy n
 Map the key sequences in this section in
 .Sy Normal
 mode.
-
 .It Sy visual , Sy v
 Map the key sequences in this section in
 .Sy Visual
 mode.
-
 .It Sy select
 Map the key sequences in this section in
 .Sy Select
 mode.
-
 .It Sy command , Sy c
 Map the key sequences in this section in
 .Sy Visual
 mode.
-
 .It Sy operator-pending
 Map the key sequences in this section in
 .Sy "Operator Pending"
 mode.
 .El
-
+.Pp
 Multiple modes can be given together by separating their names with
 .Dq Sy | .
-
 .Ss Example 1: Use "jj" to exit Insert mode
 .Bd -literal -offset indent
 [macros.insert]
 "jj" = "<Esc>"
 .Ed
-
 .Ss Example 2: Use "V" for switching between message bar and room history
 .Bd -literal -offset indent
 [macros."normal|visual"]
 "V" = "<C-W>m"
 .Ed
-
 .Sh DIRECTORIES
-
 Specifies the directories to save data in.
 Configured as an object under the key
 .Sy dirs .
-
 .Bl -tag -width Ds
 .It Sy cache
 Specifies where to store assets and temporary data in.
@@ -594,22 +535,18 @@ and
 will also go in here by default.)
 Defaults to
 .Ev $XDG_CACHE_HOME/iamb .
-
 .It Sy data
 Specifies where to store persistent data in, such as E2EE room keys.
 Defaults to
 .Ev $XDG_DATA_HOME/iamb .
-
 .It Sy downloads
 Specifies where to store downloaded files.
 Defaults to
 .Ev $XDG_DOWNLOAD_DIR .
-
 .It Sy image_previews
 Specifies where to store automatically downloaded image previews.
 Defaults to
 .Ev ${cache}/image_preview_downloads .
-
 .It Sy logs
 Specifies where to store log files.
 Defaults to


### PR DESCRIPTION
## Summary

- Remove blank lines inside `.Bl`/`.El` list blocks (between `.It` entries) — bare blank lines are invalid in mdoc and produce "Empty input line" warnings
- Add the missing `.El` to close the `.Bl -tag -width Ds` list in the MOUSE section, which was left open and caused downstream structural problems
- Remove the extraneous `.El` calls that had been added to compensate for the missing one in later sections (SORTING LISTS)
- Remove blank lines outside list blocks (between `.Sh`/`.Ss` headings and content, between prose paragraphs) that also triggered "Empty input line" warnings; paragraph breaks are represented with `.Pp` where needed

Running `man ./docs/iamb.5 2>&1 | grep -c "mdoc warning"` returns 0 after this change (down from 76).

## Test plan

- [x] Run `man ./docs/iamb.5 2>&1 | grep -c "mdoc warning"` and confirm the output is `0`
- [x] Run `man ./docs/iamb.5` and verify the rendered output looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)