### PR TITLE
Add config option for case-insensitive search

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,9 +5,9 @@ user_id = "@user:matrix.org"
 url = "https://matrix.org"
 
 [settings]
-case_insensitive_search = false
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
+ignorecase = false
 log_level = "warn"
 message_shortcode_display = false
 open_command = ["my-open", "--file"]

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@ user_id = "@user:matrix.org"
 url = "https://matrix.org"
 
 [settings]
+case_insensitive_search = false
 default_room = "#iamb-users:0x.badd.cafe"
 external_edit_file_suffix = ".md"
 log_level = "warn"

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -125,6 +125,9 @@ key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
 
+.It Sy case_insensitive_search
+Defines whether searches ignore case. Defaults to false.
+
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -125,9 +125,6 @@ key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
 
-.It Sy case_insensitive_search
-Defines whether searches ignore case. Defaults to false.
-
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 
@@ -161,6 +158,9 @@ and
 An optional list of two numbers representing font width and height in pixels.
 .El
 .El
+.It Sy ignorecase
+Defines whether searches ignore case. Defaults to false.
+
 .It Sy log_level
 Specifies the lowest log level that should be shown.
 Possible values are:

--- a/src/config.rs
+++ b/src/config.rs
@@ -516,6 +516,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
+    pub case_insensitive_search: bool,
     pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
@@ -544,6 +545,7 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
+    pub case_insensitive_search: Option<bool>,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -574,6 +576,7 @@ pub struct Tunables {
 impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
+            case_insensitive_search: self.case_insensitive_search.or(other.case_insensitive_search),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -609,6 +612,7 @@ impl Tunables {
 
     fn values(self) -> TunableValues {
         TunableValues {
+            case_insensitive_search: self.case_insensitive_search.unwrap_or(false),
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),

--- a/src/config.rs
+++ b/src/config.rs
@@ -516,7 +516,7 @@ impl SortOverrides {
 
 #[derive(Clone)]
 pub struct TunableValues {
-    pub case_insensitive_search: bool,
+    pub ignorecase: bool,
     pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
@@ -545,7 +545,7 @@ pub struct TunableValues {
 
 #[derive(Clone, Default, Deserialize)]
 pub struct Tunables {
-    pub case_insensitive_search: Option<bool>,
+    pub ignorecase: Option<bool>,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -576,7 +576,7 @@ pub struct Tunables {
 impl Tunables {
     fn merge(self, other: Self) -> Self {
         Tunables {
-            case_insensitive_search: self.case_insensitive_search.or(other.case_insensitive_search),
+            ignorecase: self.ignorecase.or(other.ignorecase),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -612,7 +612,7 @@ impl Tunables {
 
     fn values(self) -> TunableValues {
         TunableValues {
-            case_insensitive_search: self.case_insensitive_search.unwrap_or(false),
+            ignorecase: self.ignorecase.unwrap_or(false),
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -170,6 +170,7 @@ pub fn mock_dirs() -> DirectoryValues {
 
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
+        case_insensitive_search: false,
         default_room: None,
         log_level: "warn".into(),
         max_log_files: 7,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -170,7 +170,7 @@ pub fn mock_dirs() -> DirectoryValues {
 
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
-        case_insensitive_search: false,
+        ignorecase: false,
         default_room: None,
         log_level: "warn".into(),
         max_log_files: 7,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! # Utility functions
 use std::borrow::Cow;
 
+use regex::{Regex, RegexBuilder};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -167,9 +168,27 @@ pub fn replace_emojis_in_line(line: &mut Line) {
     }
 }
 
+/// Compile a search pattern, optionally ignoring case.
+pub fn compile_search(pattern: &str, case_insensitive: bool) -> Result<Regex, regex::Error> {
+    RegexBuilder::new(pattern).case_insensitive(case_insensitive).build()
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    #[test]
+    fn test_compile_search_case_insensitive() {
+        let re = compile_search("chicken", true).unwrap();
+        assert!(re.is_match("CHICKEN"));
+        assert!(re.is_match("Chicken"));
+        assert!(re.is_match("chicken"));
+
+        let re = compile_search("chicken", false).unwrap();
+        assert!(!re.is_match("CHICKEN"));
+        assert!(!re.is_match("Chicken"));
+        assert!(re.is_match("chicken"));
+    }
 
     #[test]
     fn test_wrapped_lines_ascii() {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -541,8 +541,7 @@ impl WindowOps<IambInfo> for IambWindow {
 
                 if need_fetch {
                     if let Ok(mems) = store.application.worker.members(room_id.clone()) {
-                        let case_insensitive =
-                            store.application.settings.tunables.case_insensitive_search;
+                        let case_insensitive = store.application.settings.tunables.ignorecase;
                         let mut items = mems
                             .into_iter()
                             .map(|m| MemberItem::new(m, room_id.clone(), case_insensitive))
@@ -918,7 +917,7 @@ impl GenericChatItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+        let case_insensitive = store.application.settings.tunables.ignorecase;
 
         GenericChatItem {
             room_info,
@@ -1051,7 +1050,7 @@ impl RoomItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+        let case_insensitive = store.application.settings.tunables.ignorecase;
 
         RoomItem { room_info, name, alias, unread, case_insensitive }
     }
@@ -1167,7 +1166,7 @@ impl DirectItem {
         let unread = info.unreads(&store.application.settings);
         info.tags.clone_from(&room_info.deref().1);
 
-        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+        let case_insensitive = store.application.settings.tunables.ignorecase;
 
         DirectItem { room_info, name, alias, unread, case_insensitive }
     }
@@ -1287,7 +1286,7 @@ impl SpaceItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+        let case_insensitive = store.application.settings.tunables.ignorecase;
 
         SpaceItem { room_info, name, alias, case_insensitive }
     }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -541,9 +541,11 @@ impl WindowOps<IambInfo> for IambWindow {
 
                 if need_fetch {
                     if let Ok(mems) = store.application.worker.members(room_id.clone()) {
+                        let case_insensitive =
+                            store.application.settings.tunables.case_insensitive_search;
                         let mut items = mems
                             .into_iter()
-                            .map(|m| MemberItem::new(m, room_id.clone()))
+                            .map(|m| MemberItem::new(m, room_id.clone(), case_insensitive))
                             .collect::<Vec<_>>();
                         let fields = &store.application.settings.tunables.sort.members;
                         items.sort_by(|a, b| user_fields_cmp(a, b, fields));
@@ -879,6 +881,18 @@ impl Window<IambInfo> for IambWindow {
     }
 }
 
+// `needle` comes from modalkit already compiled case-sensitively, so recompile
+// it when the user wants case-insensitive search.
+fn matches_search(needle: &regex::Regex, case_insensitive: bool, haystacks: &[&str]) -> bool {
+    if case_insensitive {
+        if let Ok(re) = crate::util::compile_search(needle.as_str(), true) {
+            return haystacks.iter().any(|h| re.is_match(h));
+        }
+    }
+
+    haystacks.iter().any(|h| needle.is_match(h))
+}
+
 #[derive(Clone)]
 pub struct GenericChatItem {
     room_info: MatrixRoomInfo,
@@ -886,6 +900,7 @@ pub struct GenericChatItem {
     alias: Option<OwnedRoomAliasId>,
     unread: UnreadInfo,
     is_dm: bool,
+    case_insensitive: bool,
 }
 
 impl GenericChatItem {
@@ -903,7 +918,16 @@ impl GenericChatItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        GenericChatItem { room_info, name, alias, is_dm, unread }
+        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+
+        GenericChatItem {
+            room_info,
+            name,
+            alias,
+            is_dm,
+            unread,
+            case_insensitive,
+        }
     }
 
     #[inline]
@@ -986,6 +1010,10 @@ impl ListItem<IambInfo> for GenericChatItem {
     fn get_word(&self) -> Option<String> {
         self.room_id().to_string().into()
     }
+
+    fn matches(&self, needle: &regex::Regex) -> bool {
+        matches_search(needle, self.case_insensitive, &[self.name.as_str()])
+    }
 }
 
 impl Promptable<ProgramContext, ProgramStore, IambInfo> for GenericChatItem {
@@ -1005,6 +1033,7 @@ pub struct RoomItem {
     name: String,
     alias: Option<OwnedRoomAliasId>,
     unread: UnreadInfo,
+    case_insensitive: bool,
 }
 
 impl RoomItem {
@@ -1022,7 +1051,9 @@ impl RoomItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        RoomItem { room_info, name, alias, unread }
+        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+
+        RoomItem { room_info, name, alias, unread, case_insensitive }
     }
 
     #[inline]
@@ -1100,6 +1131,10 @@ impl ListItem<IambInfo> for RoomItem {
     fn get_word(&self) -> Option<String> {
         self.room_id().to_string().into()
     }
+
+    fn matches(&self, needle: &regex::Regex) -> bool {
+        matches_search(needle, self.case_insensitive, &[self.name.as_str()])
+    }
 }
 
 impl Promptable<ProgramContext, ProgramStore, IambInfo> for RoomItem {
@@ -1119,6 +1154,7 @@ pub struct DirectItem {
     name: String,
     alias: Option<OwnedRoomAliasId>,
     unread: UnreadInfo,
+    case_insensitive: bool,
 }
 
 impl DirectItem {
@@ -1131,7 +1167,9 @@ impl DirectItem {
         let unread = info.unreads(&store.application.settings);
         info.tags.clone_from(&room_info.deref().1);
 
-        DirectItem { room_info, name, alias, unread }
+        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+
+        DirectItem { room_info, name, alias, unread, case_insensitive }
     }
 
     #[inline]
@@ -1209,6 +1247,10 @@ impl ListItem<IambInfo> for DirectItem {
     fn get_word(&self) -> Option<String> {
         self.room_id().to_string().into()
     }
+
+    fn matches(&self, needle: &regex::Regex) -> bool {
+        matches_search(needle, self.case_insensitive, &[self.name.as_str()])
+    }
 }
 
 impl Promptable<ProgramContext, ProgramStore, IambInfo> for DirectItem {
@@ -1227,6 +1269,7 @@ pub struct SpaceItem {
     room_info: MatrixRoomInfo,
     name: String,
     alias: Option<OwnedRoomAliasId>,
+    case_insensitive: bool,
 }
 
 impl SpaceItem {
@@ -1244,7 +1287,9 @@ impl SpaceItem {
             store.application.names.insert(alias.to_string(), room_id.to_owned());
         }
 
-        SpaceItem { room_info, name, alias }
+        let case_insensitive = store.application.settings.tunables.case_insensitive_search;
+
+        SpaceItem { room_info, name, alias, case_insensitive }
     }
 
     #[inline]
@@ -1305,6 +1350,10 @@ impl ListItem<IambInfo> for SpaceItem {
 
     fn get_word(&self) -> Option<String> {
         self.room_id().to_string().into()
+    }
+
+    fn matches(&self, needle: &regex::Regex) -> bool {
+        matches_search(needle, self.case_insensitive, &[self.name.as_str()])
     }
 }
 
@@ -1525,11 +1574,12 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for VerifyItem {
 pub struct MemberItem {
     member: RoomMember,
     room_id: OwnedRoomId,
+    case_insensitive: bool,
 }
 
 impl MemberItem {
-    fn new(member: RoomMember, room_id: OwnedRoomId) -> Self {
-        Self { member, room_id }
+    fn new(member: RoomMember, room_id: OwnedRoomId, case_insensitive: bool) -> Self {
+        Self { member, room_id, case_insensitive }
     }
 }
 
@@ -1591,7 +1641,10 @@ impl ListItem<IambInfo> for MemberItem {
     }
 
     fn matches(&self, needle: &regex::Regex) -> bool {
-        needle.is_match(self.member.name()) || needle.is_match(self.member.user_id().as_str())
+        matches_search(needle, self.case_insensitive, &[
+            self.member.name(),
+            self.member.user_id().as_str(),
+        ])
     }
 }
 
@@ -1624,6 +1677,24 @@ impl Promptable<ProgramContext, ProgramStore, IambInfo> for MemberItem {
 mod tests {
     use super::*;
     use matrix_sdk::ruma::{room_alias_id, server_name};
+
+    #[test]
+    fn test_matches_search() {
+        let needle = regex::Regex::new("alice").unwrap();
+
+        // Case-sensitive (the default) only matches the exact case.
+        assert!(matches_search(&needle, false, &["alice in the room"]));
+        assert!(!matches_search(&needle, false, &["Alice in the room"]));
+
+        // Case-insensitive matches regardless of case.
+        assert!(matches_search(&needle, true, &["Alice in the room"]));
+        assert!(matches_search(&needle, true, &["ALICE"]));
+
+        // Any of the haystacks matching is enough (e.g. name or user id).
+        let needle = regex::Regex::new("bob").unwrap();
+        assert!(matches_search(&needle, true, &["Display Name", "@BOB:example.com"]));
+        assert!(!matches_search(&needle, false, &["Display Name", "@BOB:example.com"]));
+    }
 
     #[derive(Debug, Eq, PartialEq)]
     struct TestRoomItem {

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -690,7 +690,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let dir = flip.resolve(&dir);
 
                         let lsearch = store.registers.get_last_search().to_string();
-                        let ci = store.application.settings.tunables.case_insensitive_search;
+                        let ci = store.application.settings.tunables.ignorecase;
                         let needle = crate::util::compile_search(lsearch.as_ref(), ci)?;
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
@@ -767,7 +767,7 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let dir = flip.resolve(&dir);
 
                         let lsearch = store.registers.get_last_search().to_string();
-                        let ci = store.application.settings.tunables.case_insensitive_search;
+                        let ci = store.application.settings.tunables.ignorecase;
                         let needle = crate::util::compile_search(lsearch.as_ref(), ci)?;
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -690,7 +690,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let dir = flip.resolve(&dir);
 
                         let lsearch = store.registers.get_last_search().to_string();
-                        let needle = Regex::new(lsearch.as_ref())?;
+                        let ci = store.application.settings.tunables.case_insensitive_search;
+                        let needle = crate::util::compile_search(lsearch.as_ref(), ci)?;
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {
@@ -766,7 +767,8 @@ impl EditorActions<ProgramContext, ProgramStore, IambInfo> for ScrollbackState {
                         let dir = flip.resolve(&dir);
 
                         let lsearch = store.registers.get_last_search().to_string();
-                        let needle = Regex::new(lsearch.as_ref())?;
+                        let ci = store.application.settings.tunables.case_insensitive_search;
+                        let needle = crate::util::compile_search(lsearch.as_ref(), ci)?;
 
                         let (mc, needs_load) = self.find_message(key, dir, &needle, count, info);
                         if needs_load {


### PR DESCRIPTION
Adds a `case_insensitive_search` setting (default off) so searching rooms, DMs, spaces, members, and message scrollback ignores case without needing a `(?i)` prefix.