### PR TITLE
Support running room commands in `:members` window and room lists

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -78,6 +78,7 @@ use crate::base::{
     SpaceAction,
     UnreadInfo,
 };
+use crate::windows::room::room_command;
 
 use self::{room::RoomState, welcome::WelcomeState};
 use crate::message::MessageTimeStamp;
@@ -386,8 +387,22 @@ impl IambWindow {
         ctx: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
-        if let IambWindow::Room(w) = self {
-            w.room_command(act, ctx, store).await
+        let id = match self {
+            IambWindow::Room(state) => Some(state.id()),
+            IambWindow::MemberList(_, room_id, _) => Some(&**room_id),
+
+            IambWindow::DirectList(state) => state.get().map(|state| state.room_id()),
+            IambWindow::RoomList(state) => state.get().map(|state| state.room_id()),
+            IambWindow::SpaceList(state) => state.get().map(|state| state.room_id()),
+            IambWindow::ChatList(state) | IambWindow::UnreadList(state) => {
+                state.get().map(|state| state.room_id())
+            },
+
+            _ => None,
+        };
+
+        if let Some(id) = id {
+            room_command(id, act, ctx, store).await
         } else {
             return Err(IambError::NoSelectedRoomOrSpace.into());
         }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -109,6 +109,405 @@ fn hist_visibility_mode(name: impl Into<String>) -> IambResult<HistoryVisibility
     Ok(mode)
 }
 
+pub async fn room_command(
+    id: &RoomId,
+    act: RoomAction,
+    ctx: ProgramContext,
+    store: &mut ProgramStore,
+) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
+    match act {
+        RoomAction::InviteAccept => {
+            if let Some(room) = store.application.worker.client.get_room(id) {
+                room.join().await.map_err(IambError::from)?;
+                Ok(vec![])
+            } else {
+                Err(IambError::NotInvited.into())
+            }
+        },
+        RoomAction::InviteReject => {
+            if let Some(room) = store.application.worker.client.get_room(id) {
+                room.leave().await.map_err(IambError::from)?;
+
+                Ok(vec![])
+            } else {
+                Err(IambError::NotInvited.into())
+            }
+        },
+        RoomAction::InviteSend(user) => {
+            if let Some(room) = store.application.worker.client.get_room(id) {
+                room.invite_user_by_id(user.as_ref()).await.map_err(IambError::from)?;
+
+                Ok(vec![])
+            } else {
+                Err(IambError::NotJoined.into())
+            }
+        },
+        RoomAction::Leave(skip_confirm) => {
+            if let Some(room) = store.application.worker.client.get_room(id) {
+                if skip_confirm {
+                    room.leave().await.map_err(IambError::from)?;
+
+                    Ok(vec![])
+                } else {
+                    let msg = "Do you really want to leave this room?";
+                    let leave = IambAction::Room(RoomAction::Leave(true));
+                    let prompt = PromptYesNo::new(msg, vec![Action::from(leave)]);
+                    let prompt = Box::new(prompt);
+
+                    Err(UIError::NeedConfirm(prompt))
+                }
+            } else {
+                Err(IambError::NotJoined.into())
+            }
+        },
+        RoomAction::MemberUpdate(mua, user, reason, skip_confirm) => {
+            let Some(room) = store.application.worker.client.get_room(id) else {
+                return Err(IambError::NotJoined.into());
+            };
+
+            let Ok(user_id) = OwnedUserId::try_from(user.as_str()) else {
+                let err = IambError::InvalidUserId(user);
+
+                return Err(err.into());
+            };
+
+            if !skip_confirm {
+                let msg = format!("Do you really want to {mua} {user} from this room?");
+                let act = RoomAction::MemberUpdate(mua, user, reason, true);
+                let act = IambAction::from(act);
+                let prompt = PromptYesNo::new(msg, vec![Action::from(act)]);
+                let prompt = Box::new(prompt);
+
+                return Err(UIError::NeedConfirm(prompt));
+            }
+
+            match mua {
+                MemberUpdateAction::Ban => {
+                    room.ban_user(&user_id, reason.as_deref()).await.map_err(IambError::from)?;
+                },
+                MemberUpdateAction::Unban => {
+                    room.unban_user(&user_id, reason.as_deref())
+                        .await
+                        .map_err(IambError::from)?;
+                },
+                MemberUpdateAction::Kick => {
+                    room.kick_user(&user_id, reason.as_deref())
+                        .await
+                        .map_err(IambError::from)?;
+                },
+            }
+
+            Ok(vec![])
+        },
+        RoomAction::Members(mut cmd) => {
+            let width = Count::Exact(30);
+            let act = cmd
+                .default_axis(Axis::Vertical)
+                .default_relation(MoveDir1D::Next)
+                .window(OpenTarget::Application(IambId::MemberList(id.to_owned())), width.into());
+
+            Ok(vec![(act, cmd.context.clone())])
+        },
+        RoomAction::SetDirect(is_direct) => {
+            let room = store
+                .application
+                .get_joined_room(id)
+                .ok_or(UIError::Application(IambError::NotJoined))?;
+
+            room.set_is_direct(is_direct).await.map_err(IambError::from)?;
+
+            Ok(vec![])
+        },
+        RoomAction::Set(field, value) => {
+            let room = store
+                .application
+                .get_joined_room(id)
+                .ok_or(UIError::Application(IambError::NotJoined))?;
+
+            match field {
+                RoomField::History => {
+                    let visibility = hist_visibility_mode(value)?;
+                    let ev = RoomHistoryVisibilityEventContent::new(visibility);
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Name => {
+                    let ev = RoomNameEventContent::new(value);
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Tag(tag) => {
+                    let mut info = TagInfo::new();
+                    info.order = Some(1.0);
+
+                    let _ = room.set_tag(tag, info).await.map_err(IambError::from)?;
+                },
+                RoomField::Topic => {
+                    let ev = RoomTopicEventContent::new(value);
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::NotificationMode => {
+                    let mode = notification_mode(value)?;
+                    let client = &store.application.worker.client;
+                    let notifications = client.notification_settings().await;
+
+                    notifications
+                        .set_room_notification_mode(id, mode)
+                        .await
+                        .map_err(IambError::from)?;
+                },
+                RoomField::CanonicalAlias => {
+                    let client = &mut store.application.worker.client;
+
+                    let Ok(orai) = OwnedRoomAliasId::try_from(value.as_str()) else {
+                        let err = IambError::InvalidRoomAlias(value);
+
+                        return Err(err.into());
+                    };
+
+                    let mut alt_aliases = room.alt_aliases().into_iter().collect::<HashSet<_>>();
+                    let canonical_old = room.canonical_alias();
+
+                    // If the room's alias is already that, ignore it
+                    if canonical_old.as_ref() == Some(&orai) {
+                        let msg = format!("The canonical room alias is already {orai}");
+
+                        return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
+                    }
+
+                    // Try creating the room alias on the server.
+                    if let Err(e) = client.create_room_alias(&orai, room.room_id()).await {
+                        if let Some(ClientApiErrorKind::Unknown) = e.client_api_error_kind() {
+                            // Ignore when it already exists.
+                        } else {
+                            return Err(IambError::from(e).into());
+                        }
+                    }
+
+                    // Demote the previous one to an alt alias.
+                    alt_aliases.extend(canonical_old);
+
+                    // At this point the room alias definitely exists, and we can update the
+                    // state event.
+                    let mut ev = RoomCanonicalAliasEventContent::new();
+                    ev.alias = Some(orai);
+                    ev.alt_aliases = alt_aliases.into_iter().collect();
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Alias(alias) => {
+                    let client = &mut store.application.worker.client;
+
+                    let Ok(orai) = OwnedRoomAliasId::try_from(alias.as_str()) else {
+                        let err = IambError::InvalidRoomAlias(alias);
+
+                        return Err(err.into());
+                    };
+
+                    let mut alt_aliases = room.alt_aliases().into_iter().collect::<HashSet<_>>();
+                    let canonical = room.canonical_alias();
+
+                    if alt_aliases.contains(&orai) || canonical.as_ref() == Some(&orai) {
+                        let msg = format!("The alias {orai} already maps to this room");
+
+                        return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
+                    } else {
+                        alt_aliases.insert(orai.clone());
+                    }
+
+                    // If the room alias does not exist on the server, create it
+                    if let Err(e) = client.create_room_alias(&orai, room.room_id()).await {
+                        if let Some(ClientApiErrorKind::Unknown) = e.client_api_error_kind() {
+                            // Ignore when it already exists.
+                        } else {
+                            return Err(IambError::from(e).into());
+                        }
+                    }
+
+                    // And add it to the aliases in the state event.
+                    let mut ev = RoomCanonicalAliasEventContent::new();
+                    ev.alias = canonical;
+                    ev.alt_aliases = alt_aliases.into_iter().collect();
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Aliases => {
+                    // This never happens, aliases is only used for showing
+                },
+                RoomField::Id => {
+                    // This never happens, id is only used for showing
+                },
+            }
+
+            Ok(vec![])
+        },
+        RoomAction::Unset(field) => {
+            let room = store
+                .application
+                .get_joined_room(id)
+                .ok_or(UIError::Application(IambError::NotJoined))?;
+
+            match field {
+                RoomField::History => {
+                    let visibility = HistoryVisibility::Joined;
+                    let ev = RoomHistoryVisibilityEventContent::new(visibility);
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Name => {
+                    let ev = RoomNameEventContent::new("".into());
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::Tag(tag) => {
+                    let _ = room.remove_tag(tag).await.map_err(IambError::from)?;
+                },
+                RoomField::Topic => {
+                    let ev = RoomTopicEventContent::new("".into());
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+                },
+                RoomField::NotificationMode => {
+                    let client = &store.application.worker.client;
+                    let notifications = client.notification_settings().await;
+
+                    notifications
+                        .delete_user_defined_room_rules(id)
+                        .await
+                        .map_err(IambError::from)?;
+                },
+                RoomField::CanonicalAlias => {
+                    let Some(alias_to_destroy) = room.canonical_alias() else {
+                        let msg = "This room has no canonical alias to unset";
+
+                        return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
+                    };
+
+                    // Remove the canonical alias from the state event.
+                    let mut ev = RoomCanonicalAliasEventContent::new();
+                    ev.alias = None;
+                    ev.alt_aliases = room.alt_aliases();
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+
+                    // And then unmap it on the server.
+                    store
+                        .application
+                        .worker
+                        .client
+                        .remove_room_alias(&alias_to_destroy)
+                        .await
+                        .map_err(IambError::from)?;
+                },
+                RoomField::Alias(alias) => {
+                    let Ok(orai) = OwnedRoomAliasId::try_from(alias.as_str()) else {
+                        let err = IambError::InvalidRoomAlias(alias);
+
+                        return Err(err.into());
+                    };
+
+                    let alt_aliases = room.alt_aliases();
+                    let canonical = room.canonical_alias();
+
+                    if !alt_aliases.contains(&orai) && canonical.as_ref() != Some(&orai) {
+                        let msg = format!("The alias {orai:?} isn't mapped to this room");
+
+                        return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
+                    }
+
+                    // Remove the alias from the state event if it's in it.
+                    let mut ev = RoomCanonicalAliasEventContent::new();
+                    ev.alias = canonical.filter(|canon| canon != &orai);
+                    ev.alt_aliases = alt_aliases;
+                    ev.alt_aliases.retain(|in_orai| in_orai != &orai);
+                    let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
+
+                    // And then unmap it on the server.
+                    store
+                        .application
+                        .worker
+                        .client
+                        .remove_room_alias(&orai)
+                        .await
+                        .map_err(IambError::from)?;
+                },
+                RoomField::Aliases => {
+                    // This will not happen, you cannot unset all aliases
+                },
+                RoomField::Id => {
+                    // This never happens, id is only used for showing
+                },
+            }
+
+            Ok(vec![])
+        },
+        RoomAction::Show(field) => {
+            let room = store
+                .application
+                .get_joined_room(id)
+                .ok_or(UIError::Application(IambError::NotJoined))?;
+
+            let msg = match field {
+                RoomField::History => {
+                    let visibility = room.history_visibility();
+                    let visibility = visibility.as_ref().map(|v| v.as_str());
+                    format!("Room history visibility: {}", visibility.unwrap_or("<unknown>"))
+                },
+                RoomField::Id => {
+                    let id = room.room_id();
+                    format!("Room identifier: {id}")
+                },
+                RoomField::Name => {
+                    match room.name() {
+                        None => "Room has no name".into(),
+                        Some(name) => format!("Room name: {name:?}"),
+                    }
+                },
+                RoomField::Topic => {
+                    match room.topic() {
+                        None => "Room has no topic".into(),
+                        Some(topic) => format!("Room topic: {topic:?}"),
+                    }
+                },
+                RoomField::NotificationMode => {
+                    let client = &store.application.worker.client;
+                    let notifications = client.notification_settings().await;
+                    let mode = notifications.get_user_defined_room_notification_mode(id).await;
+
+                    let level = match mode {
+                        Some(RoomNotificationMode::Mute) => "mute",
+                        Some(RoomNotificationMode::MentionsAndKeywordsOnly) => "keywords",
+                        Some(RoomNotificationMode::AllMessages) => "all",
+                        None => "default",
+                    };
+
+                    format!("Room notification level: {level:?}")
+                },
+                RoomField::Aliases => {
+                    let aliases = room
+                        .alt_aliases()
+                        .iter()
+                        .map(OwnedRoomAliasId::to_string)
+                        .collect::<Vec<String>>();
+
+                    if aliases.is_empty() {
+                        "No alternative aliases in room".into()
+                    } else {
+                        format!("Alternative aliases: {}.", aliases.join(", "))
+                    }
+                },
+                RoomField::CanonicalAlias => {
+                    match room.canonical_alias() {
+                        None => "No canonical alias for room".into(),
+                        Some(can) => format!("Canonical alias: {can}"),
+                    }
+                },
+                RoomField::Tag(_) => "Cannot currently show value for a tag".into(),
+                RoomField::Alias(_) => {
+                    "Cannot show a single alias; use `:room aliases show` instead.".into()
+                },
+            };
+
+            let msg = InfoMessage::Pager(msg);
+            let act = Action::ShowInfoMessage(msg);
+
+            Ok(vec![(act, ctx)])
+        },
+    }
+}
+
 /// State for a Matrix room or space.
 ///
 /// Since spaces function as special rooms within Matrix, we wrap their window state together, so
@@ -231,411 +630,6 @@ impl RoomState {
         match self {
             RoomState::Chat(chat) => chat.send_command(act, ctx, store).await,
             RoomState::Space(_) => Err(IambError::NoSelectedRoom.into()),
-        }
-    }
-
-    pub async fn room_command(
-        &mut self,
-        act: RoomAction,
-        ctx: ProgramContext,
-        store: &mut ProgramStore,
-    ) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
-        match act {
-            RoomAction::InviteAccept => {
-                if let Some(room) = store.application.worker.client.get_room(self.id()) {
-                    room.join().await.map_err(IambError::from)?;
-                    Ok(vec![])
-                } else {
-                    Err(IambError::NotInvited.into())
-                }
-            },
-            RoomAction::InviteReject => {
-                if let Some(room) = store.application.worker.client.get_room(self.id()) {
-                    room.leave().await.map_err(IambError::from)?;
-
-                    Ok(vec![])
-                } else {
-                    Err(IambError::NotInvited.into())
-                }
-            },
-            RoomAction::InviteSend(user) => {
-                if let Some(room) = store.application.worker.client.get_room(self.id()) {
-                    room.invite_user_by_id(user.as_ref()).await.map_err(IambError::from)?;
-
-                    Ok(vec![])
-                } else {
-                    Err(IambError::NotJoined.into())
-                }
-            },
-            RoomAction::Leave(skip_confirm) => {
-                if let Some(room) = store.application.worker.client.get_room(self.id()) {
-                    if skip_confirm {
-                        room.leave().await.map_err(IambError::from)?;
-
-                        Ok(vec![])
-                    } else {
-                        let msg = "Do you really want to leave this room?";
-                        let leave = IambAction::Room(RoomAction::Leave(true));
-                        let prompt = PromptYesNo::new(msg, vec![Action::from(leave)]);
-                        let prompt = Box::new(prompt);
-
-                        Err(UIError::NeedConfirm(prompt))
-                    }
-                } else {
-                    Err(IambError::NotJoined.into())
-                }
-            },
-            RoomAction::MemberUpdate(mua, user, reason, skip_confirm) => {
-                let Some(room) = store.application.worker.client.get_room(self.id()) else {
-                    return Err(IambError::NotJoined.into());
-                };
-
-                let Ok(user_id) = OwnedUserId::try_from(user.as_str()) else {
-                    let err = IambError::InvalidUserId(user);
-
-                    return Err(err.into());
-                };
-
-                if !skip_confirm {
-                    let msg = format!("Do you really want to {mua} {user} from this room?");
-                    let act = RoomAction::MemberUpdate(mua, user, reason, true);
-                    let act = IambAction::from(act);
-                    let prompt = PromptYesNo::new(msg, vec![Action::from(act)]);
-                    let prompt = Box::new(prompt);
-
-                    return Err(UIError::NeedConfirm(prompt));
-                }
-
-                match mua {
-                    MemberUpdateAction::Ban => {
-                        room.ban_user(&user_id, reason.as_deref())
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    MemberUpdateAction::Unban => {
-                        room.unban_user(&user_id, reason.as_deref())
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    MemberUpdateAction::Kick => {
-                        room.kick_user(&user_id, reason.as_deref())
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                }
-
-                Ok(vec![])
-            },
-            RoomAction::Members(mut cmd) => {
-                let width = Count::Exact(30);
-                let act =
-                    cmd.default_axis(Axis::Vertical).default_relation(MoveDir1D::Next).window(
-                        OpenTarget::Application(IambId::MemberList(self.id().to_owned())),
-                        width.into(),
-                    );
-
-                Ok(vec![(act, cmd.context.clone())])
-            },
-            RoomAction::SetDirect(is_direct) => {
-                let room = store
-                    .application
-                    .get_joined_room(self.id())
-                    .ok_or(UIError::Application(IambError::NotJoined))?;
-
-                room.set_is_direct(is_direct).await.map_err(IambError::from)?;
-
-                Ok(vec![])
-            },
-            RoomAction::Set(field, value) => {
-                let room = store
-                    .application
-                    .get_joined_room(self.id())
-                    .ok_or(UIError::Application(IambError::NotJoined))?;
-
-                match field {
-                    RoomField::History => {
-                        let visibility = hist_visibility_mode(value)?;
-                        let ev = RoomHistoryVisibilityEventContent::new(visibility);
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Name => {
-                        let ev = RoomNameEventContent::new(value);
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Tag(tag) => {
-                        let mut info = TagInfo::new();
-                        info.order = Some(1.0);
-
-                        let _ = room.set_tag(tag, info).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Topic => {
-                        let ev = RoomTopicEventContent::new(value);
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::NotificationMode => {
-                        let mode = notification_mode(value)?;
-                        let client = &store.application.worker.client;
-                        let notifications = client.notification_settings().await;
-
-                        notifications
-                            .set_room_notification_mode(self.id(), mode)
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    RoomField::CanonicalAlias => {
-                        let client = &mut store.application.worker.client;
-
-                        let Ok(orai) = OwnedRoomAliasId::try_from(value.as_str()) else {
-                            let err = IambError::InvalidRoomAlias(value);
-
-                            return Err(err.into());
-                        };
-
-                        let mut alt_aliases =
-                            room.alt_aliases().into_iter().collect::<HashSet<_>>();
-                        let canonical_old = room.canonical_alias();
-
-                        // If the room's alias is already that, ignore it
-                        if canonical_old.as_ref() == Some(&orai) {
-                            let msg = format!("The canonical room alias is already {orai}");
-
-                            return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
-                        }
-
-                        // Try creating the room alias on the server.
-                        if let Err(e) = client.create_room_alias(&orai, room.room_id()).await {
-                            if let Some(ClientApiErrorKind::Unknown) = e.client_api_error_kind() {
-                                // Ignore when it already exists.
-                            } else {
-                                return Err(IambError::from(e).into());
-                            }
-                        }
-
-                        // Demote the previous one to an alt alias.
-                        alt_aliases.extend(canonical_old);
-
-                        // At this point the room alias definitely exists, and we can update the
-                        // state event.
-                        let mut ev = RoomCanonicalAliasEventContent::new();
-                        ev.alias = Some(orai);
-                        ev.alt_aliases = alt_aliases.into_iter().collect();
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Alias(alias) => {
-                        let client = &mut store.application.worker.client;
-
-                        let Ok(orai) = OwnedRoomAliasId::try_from(alias.as_str()) else {
-                            let err = IambError::InvalidRoomAlias(alias);
-
-                            return Err(err.into());
-                        };
-
-                        let mut alt_aliases =
-                            room.alt_aliases().into_iter().collect::<HashSet<_>>();
-                        let canonical = room.canonical_alias();
-
-                        if alt_aliases.contains(&orai) || canonical.as_ref() == Some(&orai) {
-                            let msg = format!("The alias {orai} already maps to this room");
-
-                            return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
-                        } else {
-                            alt_aliases.insert(orai.clone());
-                        }
-
-                        // If the room alias does not exist on the server, create it
-                        if let Err(e) = client.create_room_alias(&orai, room.room_id()).await {
-                            if let Some(ClientApiErrorKind::Unknown) = e.client_api_error_kind() {
-                                // Ignore when it already exists.
-                            } else {
-                                return Err(IambError::from(e).into());
-                            }
-                        }
-
-                        // And add it to the aliases in the state event.
-                        let mut ev = RoomCanonicalAliasEventContent::new();
-                        ev.alias = canonical;
-                        ev.alt_aliases = alt_aliases.into_iter().collect();
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Aliases => {
-                        // This never happens, aliases is only used for showing
-                    },
-                    RoomField::Id => {
-                        // This never happens, id is only used for showing
-                    },
-                }
-
-                Ok(vec![])
-            },
-            RoomAction::Unset(field) => {
-                let room = store
-                    .application
-                    .get_joined_room(self.id())
-                    .ok_or(UIError::Application(IambError::NotJoined))?;
-
-                match field {
-                    RoomField::History => {
-                        let visibility = HistoryVisibility::Joined;
-                        let ev = RoomHistoryVisibilityEventContent::new(visibility);
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Name => {
-                        let ev = RoomNameEventContent::new("".into());
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Tag(tag) => {
-                        let _ = room.remove_tag(tag).await.map_err(IambError::from)?;
-                    },
-                    RoomField::Topic => {
-                        let ev = RoomTopicEventContent::new("".into());
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-                    },
-                    RoomField::NotificationMode => {
-                        let client = &store.application.worker.client;
-                        let notifications = client.notification_settings().await;
-
-                        notifications
-                            .delete_user_defined_room_rules(self.id())
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    RoomField::CanonicalAlias => {
-                        let Some(alias_to_destroy) = room.canonical_alias() else {
-                            let msg = "This room has no canonical alias to unset";
-
-                            return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
-                        };
-
-                        // Remove the canonical alias from the state event.
-                        let mut ev = RoomCanonicalAliasEventContent::new();
-                        ev.alias = None;
-                        ev.alt_aliases = room.alt_aliases();
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-
-                        // And then unmap it on the server.
-                        store
-                            .application
-                            .worker
-                            .client
-                            .remove_room_alias(&alias_to_destroy)
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    RoomField::Alias(alias) => {
-                        let Ok(orai) = OwnedRoomAliasId::try_from(alias.as_str()) else {
-                            let err = IambError::InvalidRoomAlias(alias);
-
-                            return Err(err.into());
-                        };
-
-                        let alt_aliases = room.alt_aliases();
-                        let canonical = room.canonical_alias();
-
-                        if !alt_aliases.contains(&orai) && canonical.as_ref() != Some(&orai) {
-                            let msg = format!("The alias {orai:?} isn't mapped to this room");
-
-                            return Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)]);
-                        }
-
-                        // Remove the alias from the state event if it's in it.
-                        let mut ev = RoomCanonicalAliasEventContent::new();
-                        ev.alias = canonical.filter(|canon| canon != &orai);
-                        ev.alt_aliases = alt_aliases;
-                        ev.alt_aliases.retain(|in_orai| in_orai != &orai);
-                        let _ = room.send_state_event(ev).await.map_err(IambError::from)?;
-
-                        // And then unmap it on the server.
-                        store
-                            .application
-                            .worker
-                            .client
-                            .remove_room_alias(&orai)
-                            .await
-                            .map_err(IambError::from)?;
-                    },
-                    RoomField::Aliases => {
-                        // This will not happen, you cannot unset all aliases
-                    },
-                    RoomField::Id => {
-                        // This never happens, id is only used for showing
-                    },
-                }
-
-                Ok(vec![])
-            },
-            RoomAction::Show(field) => {
-                let room = store
-                    .application
-                    .get_joined_room(self.id())
-                    .ok_or(UIError::Application(IambError::NotJoined))?;
-
-                let msg = match field {
-                    RoomField::History => {
-                        let visibility = room.history_visibility();
-                        let visibility = visibility.as_ref().map(|v| v.as_str());
-                        format!("Room history visibility: {}", visibility.unwrap_or("<unknown>"))
-                    },
-                    RoomField::Id => {
-                        let id = room.room_id();
-                        format!("Room identifier: {id}")
-                    },
-                    RoomField::Name => {
-                        match room.name() {
-                            None => "Room has no name".into(),
-                            Some(name) => format!("Room name: {name:?}"),
-                        }
-                    },
-                    RoomField::Topic => {
-                        match room.topic() {
-                            None => "Room has no topic".into(),
-                            Some(topic) => format!("Room topic: {topic:?}"),
-                        }
-                    },
-                    RoomField::NotificationMode => {
-                        let client = &store.application.worker.client;
-                        let notifications = client.notification_settings().await;
-                        let mode =
-                            notifications.get_user_defined_room_notification_mode(self.id()).await;
-
-                        let level = match mode {
-                            Some(RoomNotificationMode::Mute) => "mute",
-                            Some(RoomNotificationMode::MentionsAndKeywordsOnly) => "keywords",
-                            Some(RoomNotificationMode::AllMessages) => "all",
-                            None => "default",
-                        };
-
-                        format!("Room notification level: {level:?}")
-                    },
-                    RoomField::Aliases => {
-                        let aliases = room
-                            .alt_aliases()
-                            .iter()
-                            .map(OwnedRoomAliasId::to_string)
-                            .collect::<Vec<String>>();
-
-                        if aliases.is_empty() {
-                            "No alternative aliases in room".into()
-                        } else {
-                            format!("Alternative aliases: {}.", aliases.join(", "))
-                        }
-                    },
-                    RoomField::CanonicalAlias => {
-                        match room.canonical_alias() {
-                            None => "No canonical alias for room".into(),
-                            Some(can) => format!("Canonical alias: {can}"),
-                        }
-                    },
-                    RoomField::Tag(_) => "Cannot currently show value for a tag".into(),
-                    RoomField::Alias(_) => {
-                        "Cannot show a single alias; use `:room aliases show` instead.".into()
-                    },
-                };
-
-                let msg = InfoMessage::Pager(msg);
-                let act = Action::ShowInfoMessage(msg);
-
-                Ok(vec![(act, ctx)])
-            },
         }
     }
 


### PR DESCRIPTION
This change was written by @VAWVAW as part of #603, and allows running the different room commands in both the `:members` window and in the room lists. I'm splitting it out into its own PR to make sure that it gets called out as a separate item in the release notes PR list.