### PR TITLE
Fix: Rename `location` to `indicator_location` in example config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -24,7 +24,7 @@ username_display = "username"
 
 [settings.encryption]
 indicator = "only-encrypted"
-location = "title|prompt"
+indicator_location = "title|prompt"
 
 [settings.image_preview]
 protocol.type = "sixel"


### PR DESCRIPTION
Both the code and docs reflect that it should be indicator_location

- https://github.com/ulyssa/iamb/blob/e5f91f7e4c3a38fde98c03b4bf7ff0134eb86abc/src/config.rs#L508 
- https://github.com/ulyssa/iamb/blob/e5f91f7e4c3a38fde98c03b4bf7ff0134eb86abc/docs/iamb.5#L283