### PR TITLE
Show manually marked unread rooms in `:unreads`

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -869,6 +869,7 @@ impl EventLocation {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct UnreadInfo {
+    pub(crate) unread_mark: bool,
     pub(crate) unread_messages: u64,
     pub(crate) unread_notifications: u64,
     pub(crate) unread_mentions: u64,
@@ -877,7 +878,7 @@ pub struct UnreadInfo {
 
 impl UnreadInfo {
     pub fn is_unread(&self) -> bool {
-        self.unread_notifications > 0 || self.unread_mentions > 0
+        self.unread_mark || self.unread_notifications > 0 || self.unread_mentions > 0
     }
 
     pub fn has_mention(&self) -> bool {
@@ -1285,6 +1286,7 @@ impl RoomInfo {
             .find(|(_, msg)| !matches!(&msg.event, MessageEvent::State(..)));
 
         UnreadInfo {
+            unread_mark: room.is_marked_unread(),
             unread_messages: room.num_unread_messages(),
             unread_notifications: room.num_unread_notifications(),
             unread_mentions: room.num_unread_mentions(),

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -143,7 +143,7 @@ fn name_and_labels<'a>(
 
     if unread.unread_mentions > 0 {
         labels.push(vec![Span::styled("Unread Mention", style)]);
-    } else if unread.unread_notifications > 0 || unread.unread_messages > 0 {
+    } else if unread.is_unread() {
         labels.push(vec![Span::styled("Unread", style)]);
     }
 
@@ -1816,6 +1816,7 @@ mod tests {
             name: "Room 1",
             unread: UnreadInfo {
                 latest: None,
+                unread_mark: false,
                 unread_messages: 0,
                 unread_notifications: 0,
                 unread_mentions: 0,
@@ -1830,6 +1831,7 @@ mod tests {
             name: "Room 2",
             unread: UnreadInfo {
                 latest: Some(MessageTimeStamp::OriginServer(40u32.into())),
+                unread_mark: false,
                 unread_messages: 0,
                 unread_notifications: 0,
                 unread_mentions: 0,
@@ -1844,6 +1846,7 @@ mod tests {
             name: "Room 3",
             unread: UnreadInfo {
                 latest: Some(MessageTimeStamp::OriginServer(20u32.into())),
+                unread_mark: false,
                 unread_messages: 0,
                 unread_notifications: 0,
                 unread_mentions: 0,


### PR DESCRIPTION
Rooms manually marked unread using the `:room unread set` command added in #603 don't seem to get any of their associated unread counters incremented. Instead, the `is_marked_unread` method needs to be called to check for the explicity setting.