### PR TITLE
Add `"server"` field for sorting room lists

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -418,7 +418,7 @@ Defaults to
 .Sy ["power",\ "id"] .
 .El
 .Pp
-The available values are:
+The available values for sorting rooms are:
 .Bl -tag -width Ds
 .It Sy favorite
 Put favorite rooms before other rooms.
@@ -430,6 +430,10 @@ Sort rooms by alphabetically ascending room name.
 Sort rooms by alphabetically ascending canonical room alias.
 .It Sy id
 Sort rooms by alphabetically ascending Matrix room identifier.
+.It Sy server
+Sort rooms by alphabetically ascending server name from the room alias.
+This will fall back to the server from the room identifier if there is
+no canonical alias for the room.
 .It Sy unread
 Put unread rooms before other rooms.
 .It Sy recent

--- a/src/base.rs
+++ b/src/base.rs
@@ -256,6 +256,13 @@ pub enum SortFieldRoom {
     /// Sort rooms by their Matrix room identifier.
     RoomId,
 
+    /// Sort rooms by the server portion of their canonical room alias.
+    ///
+    /// If the room has no canonical alias, and the room identifier uses the version 1 syntax
+    /// for formatting the MXID, then this will fall back to using the server portion of the
+    /// identifier (aka, the "namespace").
+    Server,
+
     /// Sort rooms by whether they have unread messages.
     Unread,
 
@@ -328,6 +335,7 @@ impl Visitor<'_> for SortRoomVisitor {
             "name" => SortFieldRoom::Name,
             "alias" => SortFieldRoom::Alias,
             "id" => SortFieldRoom::RoomId,
+            "server" => SortFieldRoom::Server,
             "invite" => SortFieldRoom::Invite,
             _ => {
                 let msg = format!("Unknown sort field: {value:?}");

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -203,6 +203,17 @@ fn room_cmp<T: RoomLikeItem>(
         SortFieldRoom::Name => collator.collate(a.name(), b.name()),
         SortFieldRoom::Alias => some_cmp(a.alias(), b.alias(), Ord::cmp),
         SortFieldRoom::RoomId => a.room_id().cmp(b.room_id()),
+        SortFieldRoom::Server => {
+            let a = a
+                .alias()
+                .map(RoomAliasId::server_name)
+                .or_else(|| a.room_id().server_name());
+            let b = b
+                .alias()
+                .map(RoomAliasId::server_name)
+                .or_else(|| b.room_id().server_name());
+            some_cmp(a, b, Ord::cmp)
+        },
         SortFieldRoom::Unread => {
             // Sort true (unread) before false (read)
             b.is_unread().cmp(&a.is_unread())
@@ -1917,5 +1928,81 @@ mod tests {
         ];
         rooms.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
         assert_eq!(rooms, vec![&room1, &room2, &room3]);
+    }
+
+    #[test]
+    fn sort_room_servers() {
+        let mut collator = Collator::default();
+        let collator = &mut collator;
+        let server1 = server_name!("a.com");
+        let server3 = server_name!("c.com");
+
+        // No alias, fallback to namespace of V1 room ID:
+        let room1 = TestRoomItem {
+            room_id: RoomId::new_v1(server3).to_owned(),
+            tags: vec![],
+            alias: None,
+            name: "Room E",
+            unread: UnreadInfo::default(),
+            invite: false,
+        };
+
+        // Alias and V1 room ID agree:
+        let room2 = TestRoomItem {
+            room_id: RoomId::new_v1(server1).to_owned(),
+            tags: vec![],
+            alias: Some(room_alias_id!("#name:a.com").to_owned()),
+            name: "Room D",
+            unread: UnreadInfo::default(),
+            invite: false,
+        };
+
+        // Alias, V2 room id:
+        let room3 = TestRoomItem {
+            room_id: RoomId::new_v2("refhash").unwrap().to_owned(),
+            tags: vec![],
+            alias: Some(room_alias_id!("#alias:b.com").to_owned()),
+            name: "Room C",
+            unread: UnreadInfo::default(),
+            invite: true,
+        };
+
+        // Alias and V2 room ID disagree, alias is used:
+        let room4 = TestRoomItem {
+            room_id: RoomId::new_v1(server3).to_owned(),
+            tags: vec![],
+            alias: Some(room_alias_id!("#alias:a.com").to_owned()),
+            name: "Room B",
+            unread: UnreadInfo::default(),
+            invite: true,
+        };
+
+        // No alias and V2 room ID:
+        let room5 = TestRoomItem {
+            room_id: RoomId::new_v2("refhash").unwrap().to_owned(),
+            tags: vec![],
+            alias: None,
+            name: "Room A",
+            unread: UnreadInfo::default(),
+            invite: true,
+        };
+
+        // Sort servers first ascending, name tie breaks:
+        let mut rooms = vec![&room1, &room2, &room3, &room4, &room5];
+        let fields = &[
+            SortColumn(SortFieldRoom::Server, SortOrder::Ascending),
+            SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
+        ];
+        rooms.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+        assert_eq!(rooms, vec![&room4, &room2, &room3, &room1, &room5]);
+
+        // Sort servers first descending, name tie breaks:
+        let mut rooms = vec![&room1, &room2, &room3, &room4, &room5];
+        let fields = &[
+            SortColumn(SortFieldRoom::Server, SortOrder::Descending),
+            SortColumn(SortFieldRoom::Name, SortOrder::Ascending),
+        ];
+        rooms.sort_by(|a, b| room_fields_cmp(a, b, fields, collator));
+        assert_eq!(rooms, vec![&room5, &room1, &room3, &room4, &room2]);
     }
 }


### PR DESCRIPTION
It's possible to sort `:members` by the server portion of the user identifier, but it isn't possible to do the same with lists of rooms. This adds a new `"servers"` field that can be used to sort lists of rooms, which will use the server portion of the room's canonical alias, or fall back to the namespace of the room identifier if it's using the V1 format. 

This addresses part of #570. 