### PR TITLE
Add support for SOCKS and HTTPS proxying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2378,7 @@ dependencies = [
  "futures",
  "gethostname",
  "html5ever",
+ "http-serde",
  "humansize",
  "image",
  "lazy_static 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ feruca = "0.11"
 futures = "0.3"
 gethostname = "1.1"
 html5ever = "0.39.0"
+http-serde = "2.1.1"
 humansize = "2.0.0"
 image = "0.25.6"
 libc = "0.2"
@@ -89,7 +90,7 @@ version = "0.0.25"
 [dependencies.matrix-sdk]
 version = "0.18.0"
 default-features = false
-features = ["e2e-encryption", "sqlite", "sso-login"]
+features = ["e2e-encryption", "socks", "sqlite", "sso-login"]
 
 [dependencies.matrix-sdk-crypto]
 version = "0.18.0"

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,6 +30,11 @@ indicator_location = "title|prompt"
 protocol.type = "sixel"
 size = { "width" = 66, "height" = 10 }
 
+[settings.proxy]
+url = "" # An empty string disables any proxying
+auth = "Bearer abcd1234"
+headers.X-Proxy-Config = "foobar"
+
 [settings.sort]
 rooms = ["favorite", "lowpriority", "unread", "name"]
 members = ["power", "id"]

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -309,12 +309,17 @@ The behaviour of
 .Nm
 is affected by the following environment variables.
 .Bl -tag -width Ds
+.It Sy "ALL_PROXY, HTTP_PROXY, HTTPS_PROXY"
+Sets the proxy server to use.
+These names also work in lowercase.
+Example:
+.Dq export ALL_PROXY=socks5://localhost:9050 .
 .It Sy "RUST_LOG"
 Overwrites the value set by the
 .Sy log_level
 config value.
 The syntax is defined at
-.Lk https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
+.Lk https://docs.rs/tracing_subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html
 
 .Sh EXAMPLES
 .Ss Example 1: Starting with a specific profile

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -218,6 +218,11 @@ for more details.
 Defines a custom  command and its arguments to run when opening downloads instead of the default.
 (For example,
 .Sy ["my-open",\ "--file"] . )
+.Sy proxy
+When this subsection is present, you can configure how requests are proxied to the homeserver.
+See
+.Sx PROXYING
+for more details.
 .It Sy reaction_display
 Defines whether or not reactions should be shown.
 .It Sy reaction_shortcode_display
@@ -376,6 +381,34 @@ enabled = true
 sound_hint = "message-new-instant" # Linux
 sound_hint = "IM"                  # Windows
 .Ed
+.Sh "PROXYING"
+The
+.Sy settings.proxy
+subsection allows configuring proxying for requests to the homeserver.
+.Pp
+Fields available within this subsection are:
+.Bl -tag -width Ds
+.It Sy url
+Either a
+.Sy socks5://IP:PORT
+URL for a SOCKS server to proxy request through,
+or a
+.Sy http[s]://[USER:PASS@]HOST[:PORT]/
+URL to do HTTP(S) proxying through.
+Setting this to the empty string will explicitly disable proxying, and any environment variables will be ignored.
+.It Sy auth
+A value to send in a
+.Sy Proxy-Authorization
+header if your HTTP(S) proxy requires it,
+such as for doing Bearer authentication with a token.
+.It Sy headers
+A subsection for specifying additional headers and values to include in requests sent to the proxy.
+For example, custom HTTPS proxy server software may require specifying a
+.Sy User-Agent
+or a custom header like
+.Sy X-Proxy-Token
+in order to be allowed to send request through it.
+.El
 .Sh "SORTING LISTS"
 The
 .Sy settings.sort

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,9 +9,11 @@ use std::hash::{Hash, Hasher};
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::str::FromStr;
 
 use clap::Parser;
 use matrix_sdk::authentication::matrix::MatrixSession;
+use matrix_sdk::reqwest::header::{HeaderMap, HeaderValue};
 use matrix_sdk::ruma::{OwnedDeviceId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UserId};
 use matrix_sdk::EncryptionState;
 use ratatui::style::{Color, Modifier as StyleModifier, Style};
@@ -123,6 +125,20 @@ fn validate_profile_names(names: &BTreeMap<String, ProfileConfig>) {
     }
 }
 
+fn deserialize_from_str_opt<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Display,
+{
+    <Option<&'de str>>::deserialize(deserializer)?
+        .map(|s| {
+            let t = T::from_str(s);
+            t.map_err(|e| D::Error::custom(format!("failed to parse string: {e}")))
+        })
+        .transpose()
+}
+
 const VERSION: &str = match option_env!("VERGEN_GIT_SHA") {
     None => env!("CARGO_PKG_VERSION"),
     Some(_) => concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")"),
@@ -154,6 +170,26 @@ pub enum ConfigError {
     InvalidJSON(#[from] serde_json::Error),
 }
 
+macro_rules! deserialize_str_with_visitor {
+    ($t: ident, $v: ident) => {
+        impl<'de> Deserialize<'de> for $t {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_str($v)
+            }
+        }
+    };
+}
+
+deserialize_str_with_visitor!(Keys, KeysVisitor);
+deserialize_str_with_visitor!(VimModes, VimModesVisitor);
+deserialize_str_with_visitor!(UserColor, UserColorVisitor);
+deserialize_str_with_visitor!(EncryptionIndicatorLocation, EncryptionIndicatorLocationVisitor);
+deserialize_str_with_visitor!(NotifyVia, NotifyViaVisitor);
+deserialize_str_with_visitor!(ProxyUrl, ProxyUrlVisitor);
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Keys(pub Vec<TerminalKey>, pub String);
 pub struct KeysVisitor;
@@ -173,15 +209,6 @@ impl Visitor<'_> for KeysVisitor {
             Ok(keys) => Ok(Keys(keys, value.to_string())),
             Err(e) => Err(E::custom(format!("Could not parse key sequence: {e}"))),
         }
-    }
-}
-
-impl<'de> Deserialize<'de> for Keys {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(KeysVisitor)
     }
 }
 
@@ -220,15 +247,6 @@ impl Visitor<'_> for VimModesVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for VimModes {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(VimModesVisitor)
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UserColor(pub Color);
 pub struct UserColorVisitor;
@@ -264,15 +282,6 @@ impl Visitor<'_> for UserColorVisitor {
             "white" => Ok(UserColor(Color::White)),
             _ => Err(E::custom("Could not parse color")),
         }
-    }
-}
-
-impl<'de> Deserialize<'de> for UserColor {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(UserColorVisitor)
     }
 }
 
@@ -392,15 +401,6 @@ impl Visitor<'_> for EncryptionIndicatorLocationVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for EncryptionIndicatorLocation {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(EncryptionIndicatorLocationVisitor)
-    }
-}
-
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum UserDisplayStyle {
@@ -485,15 +485,6 @@ impl Visitor<'_> for NotifyViaVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for NotifyVia {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(NotifyViaVisitor)
-    }
-}
-
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Encryption {
     indicator: Option<EncryptionIndicator>,
@@ -564,6 +555,69 @@ impl EncryptionValues {
     }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum ProxyUrl {
+    Disabled,
+    Endpoint(Url),
+    #[default]
+    System,
+}
+
+pub struct ProxyUrlVisitor;
+
+impl Visitor<'_> for ProxyUrlVisitor {
+    type Value = ProxyUrl;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a valid proxy URL (e.g. \"socks5://localhost:9050\")")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: SerdeError,
+    {
+        if value.is_empty() {
+            return Ok(ProxyUrl::Disabled);
+        }
+
+        match Url::from_str(value) {
+            Ok(uri) => Ok(ProxyUrl::Endpoint(uri)),
+            Err(e) => Err(E::custom(format!("could not parse {value:?}: {e}"))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct Proxy {
+    /// How and where to proxy the client's requests to the homeserver.
+    url: Option<ProxyUrl>,
+
+    /// An optional value to include in the `Proxy-Authorization` header.
+    #[serde(default, deserialize_with = "deserialize_from_str_opt")]
+    auth: Option<HeaderValue>,
+
+    /// Optional headers to include in requests sent to the proxy.
+    #[serde(default, with = "http_serde::header_map")]
+    headers: HeaderMap,
+}
+
+impl Proxy {
+    pub fn values(self) -> ProxyValues {
+        ProxyValues {
+            url: self.url.unwrap_or_default(),
+            auth: self.auth,
+            headers: self.headers,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProxyValues {
+    pub url: ProxyUrl,
+    pub auth: Option<HeaderValue>,
+    pub headers: HeaderMap,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 pub struct Mouse {
     #[serde(default)]
@@ -589,7 +643,7 @@ pub struct ImagePreviewValues {
     pub protocol: Option<ImagePreviewProtocolValues>,
 }
 
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct ImagePreview {
     pub lazy_load: Option<bool>,
     pub size: Option<ImagePreviewSize>,
@@ -618,7 +672,7 @@ impl Default for ImagePreviewSize {
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ImagePreviewProtocolValues {
     pub r#type: Option<ProtocolType>,
     pub font_size: Option<(u16, u16)>,
@@ -633,7 +687,7 @@ pub struct SortValues {
     pub members: Vec<SortColumn<SortFieldUser>>,
 }
 
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct SortOverrides {
     pub chats: Option<Vec<SortColumn<SortFieldRoom>>>,
     pub dms: Option<Vec<SortColumn<SortFieldRoom>>>,
@@ -696,6 +750,8 @@ pub struct TerminalValues {
     pub enable_title: bool,
 }
 
+/// The configuration settings to run with, after merging the
+/// per-profile overrides on top of the global settings.
 #[derive(Clone)]
 pub struct TunableValues {
     pub encryption: EncryptionValues,
@@ -703,6 +759,7 @@ pub struct TunableValues {
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
     pub normal_after_send: bool,
+    pub proxy: ProxyValues,
     pub reaction_display: bool,
     pub reaction_shortcode_display: bool,
     pub read_receipt_send: bool,
@@ -728,11 +785,14 @@ pub struct TunableValues {
     pub ssl_verify: bool,
 }
 
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct Tunables {
     /// Subsection for overriding encryption-related settings.
     #[serde(default)]
     pub encryption: Encryption,
+
+    /// Subsection for configuring an HTTP(S) proxy.
+    pub proxy: Option<Proxy>,
 
     /// Subsection for overriding sort orders in UI lists.
     #[serde(default)]
@@ -779,6 +839,11 @@ impl Tunables {
             terminal: Terminal::merge(self.terminal, other.terminal),
             users: merge_maps(self.users, other.users),
 
+            // Proxy configuration sub-field do *not* get merged, so that a
+            // per-profile override won't inherit auth or headers from the
+            // global settings.
+            proxy: self.proxy.or(other.proxy),
+
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -815,8 +880,10 @@ impl Tunables {
     fn values(self) -> TunableValues {
         TunableValues {
             encryption: self.encryption.values(),
+            proxy: self.proxy.unwrap_or_default().values(),
             sort: self.sort.values(),
             terminal: self.terminal.values(),
+            users: self.users.unwrap_or_default(),
 
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
@@ -830,7 +897,6 @@ impl Tunables {
             state_event_display: self.state_event_display.unwrap_or(true),
             typing_notice_send: self.typing_notice_send.unwrap_or(true),
             typing_notice_display: self.typing_notice_display.unwrap_or(true),
-            users: self.users.unwrap_or_default(),
             username_display: self.username_display.unwrap_or_default(),
             message_user_color: self.message_user_color.unwrap_or(false),
             default_room: self.default_room,
@@ -1422,6 +1488,82 @@ mod tests {
         ]);
         assert_eq!(res.sort.rooms, Vec::from(DEFAULT_ROOM_SORT));
         assert_eq!(res.sort.dms, Vec::from(DEFAULT_ROOM_SORT));
+    }
+
+    #[test]
+    fn test_parse_tunables_proxy_invalid() {
+        let res =
+            serde_json::from_str::<Tunables>(r#"{"proxy": {"url": "localhost"}}"#).unwrap_err();
+
+        // Should result in a validation error:
+        assert_eq!(res.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    fn test_parse_tunables_proxy_empty() {
+        let res: Tunables = serde_json::from_str(r#"{"proxy": {"url": ""}}"#).unwrap();
+        let proxy = res.proxy.unwrap();
+        assert_eq!(proxy.url.unwrap(), ProxyUrl::Disabled);
+    }
+
+    #[test]
+    fn test_parse_tunables_proxy_socks5() {
+        let res: Tunables =
+            serde_json::from_str(r#"{"proxy": {"url": "socks5://localhost:1080"}}"#).unwrap();
+        let proxy = res.proxy.unwrap();
+        let ProxyUrl::Endpoint(url) = proxy.url.unwrap() else {
+            panic!("should parse ProxyUrl::Endpoint")
+        };
+
+        assert_eq!(url.scheme(), "socks5");
+        assert_eq!(url.host_str().unwrap(), "localhost");
+        assert_eq!(url.port().unwrap(), 1080);
+        assert_eq!(url.authority(), "localhost:1080");
+    }
+
+    #[test]
+    fn test_parse_tunables_proxy_https() {
+        let res: Tunables = serde_json::from_str(
+            r#"{"proxy": {"url": "https://localhost:8080","auth": "Bearer abcd1234","headers":{"User-Agent": "iamb"}}}"#
+        ).unwrap();
+        let proxy = res.proxy.unwrap();
+        let ProxyUrl::Endpoint(url) = proxy.url.unwrap() else {
+            panic!("should parse ProxyUrl::Endpoint")
+        };
+
+        // Verify URL fields:
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str().unwrap(), "localhost");
+        assert_eq!(url.port().unwrap(), 8080);
+        assert_eq!(url.authority(), "localhost:8080");
+
+        // Verify our `Proxy-Authorization` value:
+        assert_eq!(proxy.auth.unwrap(), "Bearer abcd1234");
+
+        // Verify our custom header is present:
+        assert_eq!(proxy.headers.len(), 1);
+        assert_eq!(proxy.headers.get("user-agent").unwrap(), "iamb");
+    }
+
+    #[test]
+    fn test_parse_tunables_proxy_merge() {
+        let global: Tunables = serde_json::from_str(
+            r#"{"proxy": {"url": "https://localhost:8080","auth": "Bearer abcd1234","headers":{"User-Agent": "iamb"}}}"#
+        ).unwrap();
+        let profile: Tunables =
+            serde_json::from_str(r#"{"proxy": {"url": "socks5://localhost:1080"}}"#).unwrap();
+
+        // The configuration merge should select the entirety of the profile proxy config,
+        // and not merge subfields, to ensure that things like `auth` and `headers` are
+        // not ever sent to a `url` they were meant for.
+        let merged = profile.merge(global).values();
+        let ProxyUrl::Endpoint(url) = merged.proxy.url else {
+            panic!("should parse ProxyUrl::Endpoint")
+        };
+        assert_eq!(url.scheme(), "socks5");
+        assert_eq!(url.authority(), "localhost:1080");
+        assert_eq!(merged.proxy.auth, None);
+        assert_eq!(merged.proxy.headers.is_empty(), true);
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,22 +23,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use crate::message::MessageTimeStamp;
 use crate::{
     base::{ChatStore, EventLocation, ProgramStore, RoomInfo},
-    config::{
-        user_color,
-        user_style_from_color,
-        ApplicationSettings,
-        DirectoryValues,
-        Encryption,
-        Notifications,
-        NotifyVia,
-        ProfileConfig,
-        SortOverrides,
-        Terminal,
-        TunableValues,
-        UserColor,
-        UserDisplayStyle,
-        UserDisplayTunables,
-    },
+    config::*,
     message::{Message, MessageEvent, MessageKey, Messages},
     worker::Requester,
 };
@@ -187,6 +172,7 @@ pub fn mock_tunables() -> TunableValues {
         max_log_files: 7,
         message_shortcode_display: false,
         normal_after_send: true,
+        proxy: Proxy::default().values(),
         reaction_display: true,
         reaction_shortcode_display: false,
         read_receipt_send: true,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -95,7 +95,7 @@ use modalkit::errors::UIError;
 use modalkit::prelude::{EditInfo, InfoMessage};
 
 use crate::base::{EchoLocation, MessageNeed};
-use crate::config::ImagePreviewSize;
+use crate::config::{ImagePreviewSize, ProxyUrl};
 use crate::message::{Message, MessageEvent, MessageId, MessageKey};
 use crate::notifications::register_notifications;
 use crate::preview::load_image;
@@ -808,15 +808,41 @@ async fn create_client_inner(
     let req_timeout = Duration::from_secs(settings.tunables.request_timeout);
 
     // Set up the HTTP client.
-    let http = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .user_agent(IAMB_USER_AGENT)
         .timeout(req_timeout)
         .pool_idle_timeout(Duration::from_secs(60))
         .pool_max_idle_per_host(10)
         .tcp_keepalive(Duration::from_secs(10))
-        .danger_accept_invalid_certs(!settings.tunables.ssl_verify)
-        .build()
-        .unwrap();
+        .danger_accept_invalid_certs(!settings.tunables.ssl_verify);
+
+    // Configure the HTTP client to use any provided proxy settings:
+    let proxy_config = &settings.tunables.proxy;
+
+    match &proxy_config.url {
+        ProxyUrl::Disabled => builder = builder.no_proxy(),
+        ProxyUrl::Endpoint(url) => {
+            let mut proxy =
+                reqwest::Proxy::all(url.clone()).map_err(matrix_sdk::HttpError::Reqwest)?;
+
+            if !proxy_config.headers.is_empty() {
+                proxy = proxy.headers(proxy_config.headers.clone());
+            }
+
+            if let Some(auth) = proxy_config.auth.clone() {
+                proxy = proxy.custom_http_auth(auth);
+            }
+
+            builder = builder.proxy(proxy)
+        },
+        ProxyUrl::System => {
+            // `reqwest` will use the *_PROXY environment variables from the
+            // system by default (through `hyper_util::client::proxy`), so do
+            // nothing and let it just figure things out for us.
+        },
+    }
+
+    let http = builder.build().map_err(matrix_sdk::HttpError::Reqwest)?;
 
     let req_config = RequestConfig::new().timeout(req_timeout).max_retry_time(req_timeout);
 


### PR DESCRIPTION
This is based on the proposed changes for supporting proxying in #576 and #575, but with some additions and tests:

* Use a `[settings.proxy]` subsection, but do not merge fields inside of it so that profile overrides cannot accidentally inherit values for other proxy servers from a global config.
* Expose the `Proxy-Authorization` and other header settings for `Proxy` to support more complex HTTPS proxy configurations
* Do URL validation during configuration parsing, so that we don't crash after calling `Proxy::all`
* Enable the `socks` feature on `matrix-sdk` instead

This keeps the "empty string disables any proxying" behaviour, and keeps things [using the system configuration](https://docs.rs/hyper-util/0.1.20/hyper_util/client/proxy/matcher/struct.Matcher.html#method.from_system) by default when no URL is provided. I took a look, and specifically this means:

* Checking the `{ALL,HTTPS,HTTP,NO}_PROXY` environment variables first
* If the environment variables are unset on macOS, then check the system configuration's dynamic store to see if it has proxy settings.
* If the environment variables are unset on Windows, then check the system registry for `Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings` and look for configured proxy settings