### PR TITLE
Support configuring when read marker updates are triggered

### DIFF
--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -229,6 +229,25 @@ Defines whether or not reactions should be shown.
 Defines whether or not reactions should be shown as their respective shortcode.
 .It Sy read_receipt_send
 Defines whether or not public read confirmations are sent.
+.It Sy read_receipt_trigger
+Defines under what conditions threads and rooms are marked read.
+Possible values are:
+.Bl -tag -width Ds
+.It Sy focused
+The room or thread must be focused and scrolled to the last message.
+This is the default value.
+.It Sy visible
+The room or thread must be on screen and scrolled to the last message.
+.It Sy scrollback
+Some portion of the scrollback for the room or thread must be on screen, but
+the room does not need to be scrolled to the last message.
+.It Sy message
+A message must be sent to the room before marking it read.
+.It Sy disabled
+Rooms and threads do not get their read markers updated, and the room
+will remain marked unread until manually cleared or another device updates
+the read marker.
+.El
 .It Sy read_receipt_display
 Defines whether or not read confirmations are displayed.
 .It Sy request_timeout

--- a/src/base.rs
+++ b/src/base.rs
@@ -93,13 +93,12 @@ use modalkit::{
     prelude::{CommandType, WordStyle},
 };
 
-use crate::config::ImagePreviewProtocolValues;
-use crate::notifications::NotificationHandle;
-use crate::preview::{source_from_event, PreviewManager};
 use crate::{
+    config::{ApplicationSettings, ImagePreviewProtocolValues},
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
+    notifications::NotificationHandle,
+    preview::{source_from_event, PreviewManager},
     worker::Requester,
-    ApplicationSettings,
 };
 
 /// The set of characters used in different Matrix IDs.

--- a/src/config.rs
+++ b/src/config.rs
@@ -350,6 +350,42 @@ where
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[repr(u8)]
+pub enum ReadReceiptTrigger {
+    /// Update read receipts for a room when a window for it is focused, and it is scrolled to the
+    /// last message.
+    #[default]
+    Focused,
+    /// Update read receipts for a room when a window for it is visible, and it is scrolled to the
+    /// last message.
+    Visible,
+    /// Update read receipts for a room whenever some portion of its scrollback is rendered.
+    Scrollback,
+    /// Update read receipts for a room once the user sends a message to it.
+    Message,
+    /// Never update read receipts.
+    Disabled,
+}
+
+impl ReadReceiptTrigger {
+    /// Whether to update read receipts when a room is being rendered.
+    pub fn on_render(&self, last_visible: bool, room_focused: bool) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::Scrollback => true,
+            Self::Focused => last_visible && room_focused,
+            Self::Visible => last_visible,
+            Self::Message => false,
+        }
+    }
+
+    pub fn on_message(&self) -> bool {
+        matches!(self, Self::Message)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
 pub enum EncryptionIndicator {
     /// Always indicate the room's encryption status.
     #[default]
@@ -763,6 +799,7 @@ pub struct TunableValues {
     pub reaction_display: bool,
     pub reaction_shortcode_display: bool,
     pub read_receipt_send: bool,
+    pub read_receipt_trigger: ReadReceiptTrigger,
     pub read_receipt_display: bool,
     pub request_timeout: u64,
     pub sort: SortValues,
@@ -812,6 +849,7 @@ pub struct Tunables {
     pub reaction_display: Option<bool>,
     pub reaction_shortcode_display: Option<bool>,
     pub read_receipt_send: Option<bool>,
+    pub read_receipt_trigger: Option<ReadReceiptTrigger>,
     pub read_receipt_display: Option<bool>,
     pub request_timeout: Option<u64>,
     pub state_event_display: Option<bool>,
@@ -855,6 +893,7 @@ impl Tunables {
                 .reaction_shortcode_display
                 .or(other.reaction_shortcode_display),
             read_receipt_send: self.read_receipt_send.or(other.read_receipt_send),
+            read_receipt_trigger: self.read_receipt_trigger.or(other.read_receipt_trigger),
             read_receipt_display: self.read_receipt_display.or(other.read_receipt_display),
             request_timeout: self.request_timeout.or(other.request_timeout),
             state_event_display: self.state_event_display.or(other.state_event_display),
@@ -892,6 +931,7 @@ impl Tunables {
             reaction_display: self.reaction_display.unwrap_or(true),
             reaction_shortcode_display: self.reaction_shortcode_display.unwrap_or(false),
             read_receipt_send: self.read_receipt_send.unwrap_or(true),
+            read_receipt_trigger: self.read_receipt_trigger.unwrap_or_default(),
             read_receipt_display: self.read_receipt_display.unwrap_or(true),
             request_timeout: self.request_timeout.unwrap_or(DEFAULT_REQ_TIMEOUT),
             state_event_display: self.state_event_display.unwrap_or(true),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -176,6 +176,7 @@ pub fn mock_tunables() -> TunableValues {
         reaction_display: true,
         reaction_shortcode_display: false,
         read_receipt_send: true,
+        read_receipt_trigger: Default::default(),
         read_receipt_display: true,
         request_timeout: 120,
         sort: SortOverrides::default().values(),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -564,6 +564,8 @@ impl ChatState {
         _: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
+        let settings = &store.application.settings;
+        let tunables = &settings.tunables;
         let room = self.get_joined(&store.application.worker)?;
         let info = store.application.rooms.get_or_default(self.id().to_owned());
 
@@ -691,6 +693,12 @@ impl ChatState {
 
         // Jump to the end of the scrollback to show the message.
         self.scrollback.goto_latest();
+
+        if tunables.read_receipt_trigger.on_message() {
+            if let Some(thread) = self.scrollback.get_thread(info) {
+                info.fully_read(settings.profile.user_id.clone(), thread.1.clone());
+            }
+        }
 
         Ok(None)
     }

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1459,8 +1459,12 @@ impl StatefulWidget for Scrollback<'_> {
             }
         }
 
-        if self.room_focused && state.cursor.timestamp.is_none() {
-            // If the cursor is at the last message, then update the read marker.
+        // Check if we should update the user's read receipt for this room after this render:
+        if settings
+            .tunables
+            .read_receipt_trigger
+            .on_render(state.cursor.timestamp.is_none(), self.room_focused)
+        {
             info.fully_read(settings.profile.user_id.clone(), thread.1.clone());
         }
 


### PR DESCRIPTION
This resolves #484 by adding a new `settings.read_receipt_trigger` option that can be set to different values to control just how in-focus the most recent message needs to be. Possible values are:

- `focused`, the default and the current behaviour: the room must be scrolled to the most recent message, and the window must be focused.
- `visible`, a slightly more relaxed condition like asked for in #484, which only requires that the room is scrolled to the most recent message and is on-screen.
- `scrollback`, an even more relaxed condition, which only requires that some portion of the scrollback is visible.
- `message`, which delays updating until the user actually sends a message. (i.e., don't consider rooms read until a response has been sent.)
- `disabled`, which disables any automatic updates to the markers, and requires using either `:unreads clear` or `:room unread clear` to clear read markers.