### PR TITLE
Add `default_markup` for configuring message parsing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,7 @@ password_file = "/path/to/password"
 url = "https://matrix.org"
 
 [settings]
+default_markup = "html"
 default_room = "#iamb-users:0x.badd.cafe"
 default_split = "vertical"
 external_edit_file_suffix = ".md"

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -126,11 +126,13 @@ These options are configured as an object under the
 key and can be overridden as described in
 .Sx PROFILES .
 .Bl -tag -width Ds
-.It Sy encryption
-Configuration subsection for specific settings related to room encryption.
-See
-.Sx ENCRYPTION
-for more details.
+.It Sy default_markup
+Controls how text in the message bar is interpreted by default.
+Possible values are
+.Dq Sy html ,
+.Dq Sy markdown
+(the default) and
+.Dq Sy plaintext .
 .It Sy default_room
 The room to show by default instead of the
 .Sy :welcome
@@ -145,6 +147,11 @@ Possible values are
 .Dq Sy horizontal
 (the default) and
 .Dq Sy vertical .
+.It Sy encryption
+Configuration subsection for specific settings related to room encryption.
+See
+.Sx ENCRYPTION
+for more details.
 .It Sy external_edit_file_suffix
 Suffix to append to temporary file names when using the :editor command. Defaults to .md.
 .It Sy image_preview

--- a/src/config.rs
+++ b/src/config.rs
@@ -803,6 +803,7 @@ pub struct TerminalValues {
 #[derive(Clone)]
 pub struct TunableValues {
     pub encryption: EncryptionValues,
+    pub default_markup: MarkupFormat,
     pub log_level: String,
     pub max_log_files: usize,
     pub message_shortcode_display: bool,
@@ -855,6 +856,7 @@ pub struct Tunables {
     /// Subsection for overriding how specific Matrix users are rendered.
     pub users: Option<UserOverrides>,
 
+    pub default_markup: Option<MarkupFormat>,
     pub log_level: Option<String>,
     pub max_log_files: Option<usize>,
     pub message_shortcode_display: Option<bool>,
@@ -896,6 +898,7 @@ impl Tunables {
             // global settings.
             proxy: self.proxy.or(other.proxy),
 
+            default_markup: self.default_markup.or(other.default_markup),
             log_level: self.log_level.or(other.log_level),
             max_log_files: self.max_log_files.or(other.max_log_files),
             message_shortcode_display: self
@@ -939,6 +942,7 @@ impl Tunables {
             terminal: self.terminal.values(),
             users: self.users.unwrap_or_default(),
 
+            default_markup: self.default_markup.unwrap_or_default(),
             log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
@@ -991,6 +995,16 @@ impl From<CursorShape> for modalkit::crossterm::cursor::SetCursorStyle {
             CursorShape::Underline => Self::SteadyUnderScore,
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
+pub enum MarkupFormat {
+    Html,
+    #[default]
+    Markdown,
+    Plaintext,
 }
 
 #[derive(Clone)]

--- a/src/message/compose.rs
+++ b/src/message/compose.rs
@@ -16,6 +16,8 @@ use matrix_sdk::ruma::events::room::message::{
     TextMessageEventContent,
 };
 
+use crate::config::MarkupFormat;
+
 #[derive(Clone, Debug, Default)]
 enum SlashCommand {
     /// Send an emote message.
@@ -102,6 +104,16 @@ impl SlashCommand {
     }
 }
 
+impl From<MarkupFormat> for SlashCommand {
+    fn from(markup: MarkupFormat) -> Self {
+        match markup {
+            MarkupFormat::Html => Self::Html,
+            MarkupFormat::Markdown => Self::Markdown,
+            MarkupFormat::Plaintext => Self::Plaintext,
+        }
+    }
+}
+
 fn parse_slash_command_inner(input: &str) -> IResult<&str, SlashCommand> {
     let (input, _) = space0(input)?;
     let (input, slash) = alt((
@@ -172,37 +184,35 @@ fn text_to_message_content(input: String) -> TextMessageEventContent {
     }
 }
 
-pub fn text_to_message(input: String) -> RoomMessageEventContent {
-    let msg = parse_slash_command(input.as_str())
-        .and_then(|(input, slash)| slash.to_message(input))
+pub fn text_to_message(input: String, default_markup: MarkupFormat) -> RoomMessageEventContent {
+    let (rest, slash) = parse_slash_command(input.as_str())
+        .unwrap_or_else(|_| (&input, SlashCommand::from(default_markup)));
+    let msg = slash
+        .to_message(rest)
         .unwrap_or_else(|_| MessageType::Text(text_to_message_content(input)));
 
     RoomMessageEventContent::new(msg)
 }
 
 /// Returns `None` if `input` contains a non-text slash command.
-pub fn text_to_text_message_event_content(input: String) -> Option<TextMessageEventContent> {
-    let cmd = parse_slash_command(&input);
+pub fn text_to_text_message_event_content(
+    input: String,
+    default_markup: MarkupFormat,
+) -> Option<TextMessageEventContent> {
+    let (body, cmd) = parse_slash_command(&input)
+        .unwrap_or_else(|_| (&input, SlashCommand::from(default_markup)));
 
     let content = match cmd {
-        Ok((body, SlashCommand::Html)) => TextMessageEventContent::html(body, body),
-        Ok((body, SlashCommand::Plaintext)) => TextMessageEventContent::plain(body),
-        Ok((body, SlashCommand::Markdown)) => {
+        SlashCommand::Html => TextMessageEventContent::html(body, body),
+        SlashCommand::Plaintext => TextMessageEventContent::plain(body),
+        SlashCommand::Markdown => {
             if let Some(html) = text_to_html(body) {
                 TextMessageEventContent::html(body, html)
             } else {
                 TextMessageEventContent::plain(body)
             }
         },
-        Ok(_) => return None,
-
-        _ => {
-            if let Some(html) = text_to_html(&input) {
-                TextMessageEventContent::html(input, html)
-            } else {
-                TextMessageEventContent::plain(input)
-            }
-        },
+        _ => return None,
     };
 
     Some(content)
@@ -348,59 +358,103 @@ pub mod tests {
 
     #[test]
     fn text_to_message_slash_commands() {
-        let MessageType::Text(content) = text_to_message("/html <b>bold</b>".into()).msgtype else {
+        let MessageType::Text(content) =
+            text_to_message("/html <b>bold</b>".into(), Default::default()).msgtype
+        else {
             panic!("Expected MessageType::Text");
         };
         assert_eq!(content.body, "<b>bold</b>");
         assert_eq!(content.formatted.unwrap().body, "<b>bold</b>");
 
-        let MessageType::Text(content) = text_to_message("/h <b>bold</b>".into()).msgtype else {
+        let MessageType::Text(content) =
+            text_to_message("/h <b>bold</b>".into(), Default::default()).msgtype
+        else {
             panic!("Expected MessageType::Text");
         };
         assert_eq!(content.body, "<b>bold</b>");
         assert_eq!(content.formatted.unwrap().body, "<b>bold</b>");
 
-        let MessageType::Text(content) = text_to_message("/plain <b>bold</b>".into()).msgtype
+        let MessageType::Text(content) =
+            text_to_message("/plain <b>bold</b>".into(), Default::default()).msgtype
         else {
             panic!("Expected MessageType::Text");
         };
         assert_eq!(content.body, "<b>bold</b>");
         assert!(content.formatted.is_none(), "{:?}", content.formatted);
 
-        let MessageType::Text(content) = text_to_message("/p <b>bold</b>".into()).msgtype else {
+        let MessageType::Text(content) =
+            text_to_message("/p <b>bold</b>".into(), Default::default()).msgtype
+        else {
             panic!("Expected MessageType::Text");
         };
         assert_eq!(content.body, "<b>bold</b>");
         assert!(content.formatted.is_none(), "{:?}", content.formatted);
 
-        let MessageType::Emote(content) = text_to_message("/me *bold*".into()).msgtype else {
+        let MessageType::Emote(content) =
+            text_to_message("/me *bold*".into(), Default::default()).msgtype
+        else {
             panic!("Expected MessageType::Emote");
         };
         assert_eq!(content.body, "*bold*");
         assert_eq!(content.formatted.unwrap().body, "<p><em>bold</em></p>\n");
 
-        let content = text_to_message("/confetti hello".into()).msgtype;
+        let content = text_to_message("/confetti hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "nic.custom.confetti");
         assert_eq!(content.body(), "hello");
 
-        let content = text_to_message("/fireworks hello".into()).msgtype;
+        let content = text_to_message("/fireworks hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "nic.custom.fireworks");
         assert_eq!(content.body(), "hello");
 
-        let content = text_to_message("/hearts hello".into()).msgtype;
+        let content = text_to_message("/hearts hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "io.element.effect.hearts");
         assert_eq!(content.body(), "hello");
 
-        let content = text_to_message("/rainfall hello".into()).msgtype;
+        let content = text_to_message("/rainfall hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "io.element.effect.rainfall");
         assert_eq!(content.body(), "hello");
 
-        let content = text_to_message("/snowfall hello".into()).msgtype;
+        let content = text_to_message("/snowfall hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "io.element.effect.snowfall");
         assert_eq!(content.body(), "hello");
 
-        let content = text_to_message("/spaceinvaders hello".into()).msgtype;
+        let content = text_to_message("/spaceinvaders hello".into(), Default::default()).msgtype;
         assert_eq!(content.msgtype(), "io.element.effects.space_invaders");
         assert_eq!(content.body(), "hello");
+    }
+
+    #[test]
+    fn text_to_message_slash_default() {
+        let MessageType::Text(content) =
+            text_to_message("*hello*".into(), MarkupFormat::Html).msgtype
+        else {
+            panic!("Expected MessageType::Text");
+        };
+        assert_eq!(content.body, "*hello*");
+        assert_eq!(content.formatted.unwrap().body, "*hello*");
+
+        let MessageType::Text(content) =
+            text_to_message("/markdown *hello*".into(), MarkupFormat::Html).msgtype
+        else {
+            panic!("Expected MessageType::Text");
+        };
+        assert_eq!(content.body, "*hello*");
+        assert_eq!(content.formatted.unwrap().body, "<p><em>hello</em></p>\n");
+
+        let MessageType::Text(content) =
+            text_to_message("<b>hello</b>".into(), MarkupFormat::Plaintext).msgtype
+        else {
+            panic!("Expected MessageType::Text");
+        };
+        assert_eq!(content.body, "<b>hello</b>");
+        assert!(content.formatted.is_none(), "{:?}", content.formatted);
+
+        let MessageType::Text(content) =
+            text_to_message("/html <b>hello</b>".into(), MarkupFormat::Plaintext).msgtype
+        else {
+            panic!("Expected MessageType::Text");
+        };
+        assert_eq!(content.body, "<b>hello</b>");
+        assert_eq!(content.formatted.unwrap().body, "<b>hello</b>");
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -166,6 +166,7 @@ pub fn mock_dirs() -> DirectoryValues {
 
 pub fn mock_tunables() -> TunableValues {
     TunableValues {
+        default_markup: Default::default(),
         default_room: None,
         encryption: Encryption::default().values(),
         log_level: "warn".into(),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -89,7 +89,7 @@ use crate::base::{
     SendAction,
 };
 
-use crate::config::EncryptionIndicatorLocation;
+use crate::config::{ApplicationSettings, EncryptionIndicatorLocation};
 use crate::message::{
     MessageEvent,
     MessageId,
@@ -604,13 +604,18 @@ impl ChatState {
     }
 
     /// Generate an attachment for this room based on the current message bar state.
-    fn generate_attachment_config(&self, info: &RoomInfo, add_caption: bool) -> AttachmentConfig {
+    fn generate_attachment_config(
+        &self,
+        info: &RoomInfo,
+        add_caption: bool,
+        settings: &ApplicationSettings,
+    ) -> AttachmentConfig {
         let mut config = AttachmentConfig::new();
         config.caption = add_caption
             .then(|| self.tbox.get())
             .filter(|c| !c.is_blank())
             .map(|c| c.trim_end().to_string())
-            .and_then(text_to_text_message_event_content);
+            .and_then(|c| text_to_text_message_event_content(c, settings.tunables.default_markup));
         config.reply = self.generate_reply_info(info, add_caption);
         config
     }
@@ -647,7 +652,7 @@ impl ChatState {
                     msg.trim_end().to_string()
                 };
 
-                let mut msg = text_to_message(msg);
+                let mut msg = text_to_message(msg, tunables.default_markup);
 
                 if let Some(key) = &self.editing {
                     let id = match &key.id {
@@ -740,7 +745,7 @@ impl ChatState {
                     .unwrap_or_else(|| Cow::from("Attachment"));
 
                 let add_caption = add_caption.unwrap_or(false);
-                let config = self.generate_attachment_config(info, add_caption);
+                let config = self.generate_attachment_config(info, add_caption, settings);
 
                 room.send_queue()
                     .send_attachment(name.as_ref(), mime, bytes, config)
@@ -766,7 +771,7 @@ impl ChatState {
                 let mime = mime::IMAGE_PNG;
                 let name = "Clipboard.png";
 
-                let mut config = self.generate_attachment_config(info, add_caption);
+                let mut config = self.generate_attachment_config(info, add_caption, settings);
                 config.info = Some(AttachmentInfo::Image(BaseImageInfo {
                     height: height.try_into().ok(),
                     width: width.try_into().ok(),


### PR DESCRIPTION
This PR resolves #383 by adding a new `default_markup` configuration option, which can be set to `markdown`, `html`, or `plaintext` to control how the message bar contents are interpreted (including for the media captions support added in #592).