### PR TITLE
Document how to build size-optimized binaries in the README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ build = "build.rs"
 default = ["bundled", "desktop"]
 bundled = ["matrix-sdk/bundled-sqlite"]
 desktop = ["dep:notify-rust", "modalkit/clipboard"]
+max_level_warn = ["tracing/max_level_warn"]
+max_level_error = ["tracing/max_level_error"]
+max_level_off = ["tracing/max_level_off"]
 
 [build-dependencies.vergen-gitcl]
 version = "9"
@@ -107,6 +110,12 @@ pretty_assertions = "1.4.0"
 inherits = "release"
 incremental = false
 lto = true
+
+[profile.release-light]
+inherits = "release-lto"
+opt-level = "z"
+strip = true
+panic = "abort"
 
 [package.metadata.deb]
 section = "net"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ containing the sources (ie: from a git clone):
 cargo install --locked --path .
 ```
 
+If you're willing to wait longer on the build, you can use the `release-lto`
+profile to enable link-time optimization:
+
+```
+cargo install --profile release-lto --locked --path .
+```
+
+If you would prefer to optimize for a smaller binary, you can use the
+`release-light` profile, which will do LTO, optimize code generation
+for smaller output, and strip the binary. The `max_level_error` feature
+will also make sure that any `tracing` logs below the error level have
+their strings removed during compile-time, so that you only get `error`
+logs.
+
+```
+cargo install --profile release-light --features max_level_error --path .
+```
+
+Add `--no-default-features` if you want to skip desktop integration (e.g.
+clipboard and notifications support) and you would like to link against
+your system's OpenSSL and SQLite instead of using rustls and a bundled
+SQLite.
+
 ## Installation (via `crates.io`)
 
 Install Rust (1.83.0 or above) and Cargo, and then run:

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,12 @@ const DEFAULT_ENABLE_TITLE: bool = true;
 const DEFAULT_ENC_INDICATOR_LOC: EncryptionIndicatorLocation = EncryptionIndicatorLocation::PROMPT;
 const DEFAULT_REQ_TIMEOUT: u64 = 120;
 
+const DEFAULT_LOG_LEVEL: &str = if cfg!(feature = "max_level_error") {
+    "error"
+} else {
+    "warn"
+};
+
 const COLORS: [Color; 13] = [
     Color::Blue,
     Color::Cyan,
@@ -940,7 +946,7 @@ impl Tunables {
             users: self.users.unwrap_or_default(),
 
             default_markup: self.default_markup.unwrap_or_default(),
-            log_level: self.log_level.unwrap_or_else(|| "warn".to_string()),
+            log_level: self.log_level.unwrap_or_else(|| DEFAULT_LOG_LEVEL.to_owned()),
             max_log_files: self.max_log_files.unwrap_or(7),
             message_shortcode_display: self.message_shortcode_display.unwrap_or(false),
             normal_after_send: self.normal_after_send.unwrap_or(false),

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -945,6 +945,7 @@ impl Editable<ProgramContext, ProgramStore, IambInfo> for ChatState {
                 // Run command again.
                 delegate!(self, w => w.editor_command(act, ctx, store))
             },
+            #[cfg(feature = "desktop")]
             Err(EditError::Register(RegisterError::ClipboardImage(data))) => {
                 let info = store.application.rooms.get_or_default(self.id().to_owned());
                 let prompt = if self.tbox.get().is_blank() && self.get_reply_to(info).is_none() {


### PR DESCRIPTION
This adds a new `release-light` cargo profile, which can be used to enable the cargo options for getting a smaller binary.

Combined with enabling the `max_level_error` feature for the `tracing` crate, I can get a 30M binary locally (as opposed to the 106M binary):

```
cargo build --profile release-light --features max_level_error
```

If I build without the `desktop` and `bundled` features, that goes down to ~28M:

```
cargo build --profile release-light --features max_level_error --no-default-features
```

Building with `codegen-units=1`, that takes it down to ~25M:

```
RUSTFLAGS="-C codegen-units=1" cargo build --profile release-light --features max_level_error --no-default-features 
```

Using `cargo-bloat`, it looks like nearly 10M comes from `libstd`, so I tried building it from source, which gets it down to ~22M:

```
RUSTFLAGS="-C codegen-units=1 -Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build --profile release-light --features max_level_error --no-default-features -Z build-std=std,panic_abort -Z build-std-features="optimize_for_size" --target x86_64-unknown-linux-gnu
```


