### PR TITLE
Work around `cargo-generate-rpm` issue with pre-release versions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,6 +25,7 @@ jobs:
             triple: apple-darwin
           - platform: windows-latest
             triple: pc-windows-msvc
+      fail-fast: false
     runs-on: ${{ matrix.platform }}
     env:
       TARGET: ${{ matrix.arch }}-${{ matrix.triple }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ assets = [
 ]
 
 [package.metadata.generate-rpm]
+version = "0.0.12_alpha.1"
 assets = [
     # Binary:
     { source = "target/release/iamb", dest = "/usr/bin/iamb", mode = "755" },


### PR DESCRIPTION
It looks like setting the version to `0.0.12-alpha.1` broke building the RPM. This used to work with `0.0.11-alpha.1`, so I think something changed in how it or the `rpm` crate validates the package version.

Tracking issue is https://github.com/cat-in-136/cargo-generate-rpm/issues/154