### PR TITLE
Truncate usernames by grapheme instead of word boundaries

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -68,7 +68,7 @@ use crate::{
     base::RoomInfo,
     config::ApplicationSettings,
     message::html::{StyleTree, parse_matrix_html},
-    util::{replace_emojis_in_str, space, space_span, take_width, wrapped_text},
+    util::{replace_emojis_in_str, space, space_span, take_width_grapheme, wrapped_text},
 };
 
 mod compose;
@@ -1281,14 +1281,14 @@ impl Message {
         let show_in_gutter = gutter_enabled && user_gutter > 2;
 
         if show_in_gutter {
-            let ((truncated, width), _) = take_width(content, user_gutter - 2);
+            let ((truncated, width), _) = take_width_grapheme(content, user_gutter - 2);
             let padding = user_gutter - 2 - width;
 
             let sender = format!("{}{}  ", space(padding), truncated);
 
             SenderSpan::Gutter(Span::styled(sender, style))
         } else if UnicodeWidthStr::width(content.as_ref()) > width {
-            let ((truncated, _), _) = take_width(content, width);
+            let ((truncated, _), _) = take_width_grapheme(content, width);
 
             SenderSpan::Line(Span::styled(truncated, style))
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,12 +23,11 @@ pub fn split_cow(cow: Cow<'_, str>, idx: usize) -> (Cow<'_, str>, Cow<'_, str>) 
         },
     }
 }
-
 pub fn take_width(s: Cow<'_, str>, width: usize) -> ((Cow<'_, str>, usize), Cow<'_, str>) {
     // Find where to split the line.
     let mut cur_width = 0;
 
-    let mut idx = UnicodeSegmentation::split_word_bound_indices(s.as_ref())
+    let idx = UnicodeSegmentation::split_word_bound_indices(s.as_ref())
         .find_map(|(i, word)| {
             let word_width = UnicodeWidthStr::width(word);
             if cur_width + word_width > width {
@@ -42,21 +41,29 @@ pub fn take_width(s: Cow<'_, str>, width: usize) -> ((Cow<'_, str>, usize), Cow<
 
     if idx == 0 {
         // first word is wider than available; fall back to splitting by width
-        idx = UnicodeSegmentation::grapheme_indices(s.as_ref(), true)
-            .find_map(|(i, graph)| {
-                let graph_width = UnicodeWidthStr::width(graph);
-                if cur_width + graph_width > width {
-                    Some(i)
-                } else {
-                    cur_width += graph_width;
-                    None
-                }
-            })
-            .unwrap_or(s.len());
+        return take_width_grapheme(s, width);
     }
 
     let (s0, s1) = split_cow(s, idx);
 
+    ((s0, cur_width), s1)
+}
+
+pub fn take_width_grapheme(s: Cow<'_, str>, width: usize) -> ((Cow<'_, str>, usize), Cow<'_, str>) {
+    let mut cur_width = 0;
+    let idx = UnicodeSegmentation::grapheme_indices(s.as_ref(), true)
+        .find_map(|(i, graph)| {
+            let graph_width = UnicodeWidthStr::width(graph);
+            if cur_width + graph_width > width {
+                Some(i)
+            } else {
+                cur_width += graph_width;
+                None
+            }
+        })
+        .unwrap_or(s.len());
+
+    let (s0, s1) = split_cow(s, idx);
     ((s0, cur_width), s1)
 }
 


### PR DESCRIPTION
Previously, usernames truncated by user_gutter_width with word boundaries, such as display names like [somelongtexthere] or more relevant, usernames like @username:some.domain would be completely cut off after the first character. This pr makes it so that these will always just use the grapheme calculation directly.

Maybe this should be a config option? Although I do think it is usually preferable to have the username as visible as possible, it might still be useful to not always  have this behavior.