### PR TITLE
Refactor sticker and image preview

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -15,9 +15,11 @@ use emojis::Emoji;
 
 use matrix_sdk::ruma::OwnedMxcUri;
 use matrix_sdk::ruma::OwnedTransactionId;
+use matrix_sdk::ruma::events::OriginalMessageLikeEvent;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::events::sticker::StickerEvent;
+use matrix_sdk::ruma::events::room::message::MessageType;
+use matrix_sdk::ruma::events::sticker::{StickerEvent, StickerEventContent};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -100,7 +102,7 @@ use crate::{
     config::{ApplicationSettings, ImagePreviewProtocolValues},
     message::{Message, MessageEvent, MessageKey, MessageTimeStamp, Messages},
     notifications::NotificationHandle,
-    preview::{PreviewManager, source_from_event},
+    preview::PreviewManager,
     worker::Requester,
 };
 
@@ -876,9 +878,6 @@ pub enum EventLocation {
     /// The [EventId] belongs to a state event in the main timeline of the room.
     State(MessageKey),
 
-    /// The [EventId] belongs to a sticker event in the main scrollback
-    Sticker(MessageKey),
-
     /// The [EventId] belongs to an edit for the given event and has key [MessageKey].
     Edit(OwnedEventId, MessageKey),
 }
@@ -887,7 +886,6 @@ impl EventLocation {
     fn to_message_key(&self) -> Option<&MessageKey> {
         match self {
             EventLocation::Message(_, key) => Some(key),
-            EventLocation::Sticker(key) => Some(key),
             _ => None,
         }
     }
@@ -1253,12 +1251,6 @@ impl RoomInfo {
 
                 self.keys.remove(redacts);
             },
-            Some(EventLocation::Sticker(key)) => {
-                if let Some(msg) = self.messages.get_mut(key) {
-                    let ev = SyncRoomRedactionEvent::Original(ev);
-                    msg.redact(ev);
-                }
-            },
         }
     }
 
@@ -1281,49 +1273,52 @@ impl RoomInfo {
     }
 
     /// Insert a sticker
-    pub fn insert_sticker(
+    pub fn insert_sticker_with_preview(
         &mut self,
         sticker: StickerEvent,
         settings: &ApplicationSettings,
         previews: &mut PreviewManager,
         worker: &Requester,
     ) {
-        match sticker {
-            MessageLikeEvent::Original(ref sticker_content) => {
-                let key = MessageKey {
-                    ts: sticker_content.origin_server_ts.into(),
-                    id: sticker_content.event_id.clone().into(),
-                };
+        let event_id = sticker.event_id().to_owned();
+        let key = MessageKey {
+            ts: sticker.origin_server_ts().into(),
+            id: event_id.clone().into(),
+        };
 
-                let loc = EventLocation::Sticker(key.clone());
+        let thread_root = match &sticker {
+            MessageLikeEvent::Original(OriginalMessageLikeEvent {
+                content:
+                    StickerEventContent {
+                        relates_to: Some(Relation::Thread(Thread { event_id, .. })),
+                        ..
+                    },
+                ..
+            }) => Some(event_id.to_owned()),
+            _ => None,
+        };
 
-                self.keys.insert(sticker_content.event_id.clone(), loc);
-                self.messages.insert_message(key.clone(), sticker.clone());
-
-                if let (Some(msg), Some(image_preview)) = (
-                    self.get_event_mut(&sticker_content.event_id),
-                    &settings.tunables.image_preview,
-                ) {
-                    let source: MediaSource = sticker_content.content.source.clone().into();
-                    msg.image_preview = Some(source.clone());
-                    previews.register_preview(
-                        settings,
-                        source,
-                        PreviewKind::Message,
-                        image_preview.size,
-                        worker,
-                    );
-                }
-            },
-            MessageLikeEvent::Redacted(ref redaction) => {
-                let key = MessageKey {
-                    ts: redaction.origin_server_ts.into(),
-                    id: redaction.event_id.clone().into(),
-                };
-
-                self.messages.insert_message(key.clone(), sticker.clone());
-            },
+        if let MessageLikeEvent::Original(OriginalMessageLikeEvent {
+            content: StickerEventContent { source, .. },
+            ..
+        }) = &sticker &&
+            let Some(image_preview) = &settings.tunables.image_preview
+        {
+            let source = source.clone().into();
+            previews.register_preview(
+                settings,
+                &source,
+                PreviewKind::Message,
+                image_preview.size,
+                worker,
+            );
         }
+
+        let loc = EventLocation::Message(thread_root.clone(), key.clone());
+        self.keys.insert(event_id, loc);
+
+        let thread = self.get_thread_mut(thread_root);
+        thread.insert_message(key, sticker);
     }
 
     /// Insert a reaction to a message.
@@ -1348,7 +1343,7 @@ impl RoomInfo {
 
         if let (Some(source), Some(_)) = (source, &settings.tunables.image_preview) {
             let size = ImagePreviewSize { width: 2, height: 1 };
-            previews.register_preview(settings, source, PreviewKind::Reaction, size, worker);
+            previews.register_preview(settings, &source, PreviewKind::Reaction, size, worker);
         }
     }
 
@@ -1493,22 +1488,22 @@ impl RoomInfo {
         previews: &mut PreviewManager,
         worker: &Requester,
     ) {
-        let source = source_from_event(&ev);
-        self.insert(ev);
-
-        if let Some((event_id, source)) = source &&
-            let (Some(msg), Some(image_preview)) =
-                (self.get_event_mut(&event_id), &settings.tunables.image_preview)
+        if let MessageLikeEvent::Original(OriginalMessageLikeEvent {
+            content: RoomMessageEventContent { msgtype: MessageType::Image(c), .. },
+            ..
+        }) = &ev &&
+            let Some(image_preview) = &settings.tunables.image_preview
         {
-            msg.image_preview = Some(source.clone());
             previews.register_preview(
                 settings,
-                source,
+                &c.source,
                 PreviewKind::Message,
                 image_preview.size,
                 worker,
             )
         }
+
+        self.insert(ev);
     }
 
     /// Indicates whether we've recently fetched scrollback for this room.

--- a/src/base.rs
+++ b/src/base.rs
@@ -13,12 +13,12 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 
-use matrix_sdk::ruma::{OwnedMxcUri, OwnedTransactionId, RoomVersionId};
 use matrix_sdk::ruma::events::OriginalMessageLikeEvent;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::events::room::message::MessageType;
 use matrix_sdk::ruma::events::sticker::{StickerEvent, StickerEventContent};
+use matrix_sdk::ruma::{OwnedMxcUri, OwnedTransactionId, RoomVersionId};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -14,7 +14,7 @@ use matrix_sdk::ruma::OwnedTransactionId;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::events::room::message::RoomMessageEventContentWithoutRelation;
-use matrix_sdk::ruma::events::sticker::StickerEvent;
+use matrix_sdk::ruma::events::sticker::{OriginalStickerEvent, RedactedStickerEvent, StickerEvent};
 use matrix_sdk::ruma::events::{AnyRedactionEvent, MessageLikeEvent};
 use matrix_sdk::send_queue::SendHandle;
 use ratatui::style::Color;
@@ -441,7 +441,7 @@ pub enum MessageEvent {
     Original(Box<OriginalRoomMessageEvent>, MessageEdits),
     Redacted(OwnedEventId, Option<String>),
     State(Box<AnySyncStateEvent>),
-    Sticker(Box<StickerEvent>),
+    Sticker(Box<OriginalStickerEvent>, MediaSource),
     Local(OwnedTransactionId, SendHandle, Box<RoomMessageEventContent>),
 }
 
@@ -454,7 +454,7 @@ impl MessageEvent {
             MessageEvent::Redacted(event_id, _) => event_id.as_ref(),
             MessageEvent::State(ev) => ev.event_id(),
             MessageEvent::Local(..) => return None,
-            MessageEvent::Sticker(ev) => ev.event_id(),
+            MessageEvent::Sticker(ev, ..) => ev.event_id.as_ref(),
         };
 
         Some(event_id)
@@ -472,7 +472,7 @@ impl MessageEvent {
             MessageEvent::EncryptedRedacted(_) => None,
             MessageEvent::Redacted(_, _) => None,
             MessageEvent::State(_) => None,
-            MessageEvent::Sticker(_) => None,
+            MessageEvent::Sticker(..) => None,
             MessageEvent::Local(_, _, content) => Some(&content.msgtype),
         }
     }
@@ -491,7 +491,7 @@ impl MessageEvent {
                 body_cow_reason(redaction_reason_unsigned(&ev.unsigned).as_deref())
             },
             MessageEvent::Redacted(_, reason) => body_cow_reason(reason.as_deref()),
-            MessageEvent::Sticker(ev) => body_cow_sticker(ev),
+            MessageEvent::Sticker(ev, ..) => body_cow_sticker(ev),
             MessageEvent::State(ev) => body_cow_state(ev),
             MessageEvent::Local(_, _, content) => body_cow_content(&content.msgtype),
         }
@@ -515,8 +515,8 @@ impl MessageEvent {
             MessageEvent::EncryptedRedacted(_) => return,
             MessageEvent::Redacted(_, _) => return,
             MessageEvent::State(_) => return,
-            MessageEvent::Sticker(ev) => {
-                let event_id = ev.event_id().to_owned();
+            MessageEvent::Sticker(ev, ..) => {
+                let event_id = ev.event_id.to_owned();
                 let reason = redaction_reason_event(redaction);
                 *self = MessageEvent::Redacted(event_id, reason);
             },
@@ -617,13 +617,8 @@ fn body_cow_content(msgtype: &MessageType) -> Cow<'_, str> {
     Cow::Borrowed(s)
 }
 
-fn body_cow_sticker(content: &StickerEvent) -> Cow<'_, str> {
-    match content {
-        MessageLikeEvent::Original(sticker) => {
-            Cow::Owned(format!("* sent a sticker: {}", sticker.content.body))
-        },
-        MessageLikeEvent::Redacted(_) => Cow::Borrowed("[Redacted]"),
-    }
+fn body_cow_sticker(sticker: &OriginalStickerEvent) -> Cow<'_, str> {
+    Cow::Owned(format!("* sent a sticker: {}", sticker.content.body))
 }
 
 fn redaction_reason_unsigned(unsigned: &RedactedUnsigned) -> Option<String> {
@@ -958,7 +953,6 @@ pub struct Message {
     pub timestamp: MessageTimeStamp,
     pub downloaded: bool,
     pub html: Option<StyleTree>,
-    pub image_preview: Option<MediaSource>,
 }
 
 impl Message {
@@ -966,14 +960,7 @@ impl Message {
         let html = event.html();
         let downloaded = false;
 
-        Message {
-            event,
-            sender,
-            timestamp,
-            downloaded,
-            html,
-            image_preview: None,
-        }
+        Message { event, sender, timestamp, downloaded, html }
     }
 
     pub fn reply_to(&self) -> Option<OwnedEventId> {
@@ -984,7 +971,17 @@ impl Message {
             MessageEvent::Original(ev, _) => &ev.content,
             MessageEvent::Redacted(_, _) => return None,
             MessageEvent::State(_) => return None,
-            MessageEvent::Sticker(_) => return None,
+            MessageEvent::Sticker(ev, ..) => {
+                return match &ev.content.relates_to {
+                    Some(Relation::Reply(reply)) => Some(reply.in_reply_to.event_id.clone()),
+                    Some(Relation::Thread(Thread {
+                        in_reply_to: Some(in_reply_to),
+                        is_falling_back: false,
+                        ..
+                    })) => Some(in_reply_to.event_id.clone()),
+                    Some(_) | None => None,
+                };
+            },
         };
 
         match &content.relates_to {
@@ -1006,7 +1003,7 @@ impl Message {
             MessageEvent::Original(ev, _) => &ev.content,
             MessageEvent::Redacted(_, _) => return None,
             MessageEvent::State(_) => return None,
-            MessageEvent::Sticker(_) => return None,
+            MessageEvent::Sticker(..) => return None,
         };
 
         match &content.relates_to {
@@ -1017,6 +1014,18 @@ impl Message {
                 ..
             })) if event_id == &in_reply_to.event_id => Some(event_id.clone()),
             Some(_) | None => None,
+        }
+    }
+
+    pub fn image_preview(&self) -> Option<&MediaSource> {
+        if let Some(MessageType::Image(c)) = self.event.msgtype() {
+            return Some(&c.source);
+        }
+
+        match &self.event {
+            MessageEvent::Sticker(_, source) => Some(source),
+
+            _ => None,
         }
     }
 
@@ -1206,8 +1215,7 @@ impl Message {
     ) -> (Text<'a>, Option<&'a Protocol>) {
         let mut proto = None;
         let placeholder = match self
-            .image_preview
-            .as_ref()
+            .image_preview()
             .and_then(|source| previews.get(source, PreviewKind::Message))
         {
             None => None,
@@ -1300,7 +1308,6 @@ impl Message {
         self.event.redact(redaction);
         self.html = None;
         self.downloaded = false;
-        self.image_preview = None;
     }
 
     pub fn set_edits(&mut self, new_edits: MessageEdits) {
@@ -1403,13 +1410,36 @@ impl From<AnySyncStateEvent> for Message {
     }
 }
 
+impl From<OriginalStickerEvent> for Message {
+    fn from(event: OriginalStickerEvent) -> Self {
+        let timestamp = event.origin_server_ts.into();
+        let user_id = event.sender.clone();
+        let source = event.content.source.clone().into();
+        let content = MessageEvent::Sticker(event.into(), source);
+
+        Message::new(content, user_id, timestamp)
+    }
+}
+
+impl From<RedactedStickerEvent> for Message {
+    fn from(event: RedactedStickerEvent) -> Self {
+        let timestamp = event.origin_server_ts.into();
+        let user_id = event.sender.clone();
+
+        let event_id = event.event_id;
+        let reason = redaction_reason_unsigned(&event.unsigned);
+        let content = MessageEvent::Redacted(event_id, reason);
+
+        Message::new(content, user_id, timestamp)
+    }
+}
+
 impl From<StickerEvent> for Message {
     fn from(event: StickerEvent) -> Self {
-        let timestamp = event.origin_server_ts().into();
-        let user_id = event.sender().to_owned();
-        let event = MessageEvent::Sticker(event.into());
-
-        Message::new(event, user_id, timestamp)
+        match event {
+            MessageLikeEvent::Original(ev) => ev.into(),
+            MessageLikeEvent::Redacted(ev) => ev.into(),
+        }
     }
 }
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -3,16 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use matrix_sdk::{
     Media,
     media::{MediaFormat, MediaRequestParameters, UniqueKey},
-    ruma::{
-        OwnedEventId,
-        events::{
-            MessageLikeEvent,
-            room::{
-                MediaSource,
-                message::{MessageType, RoomMessageEventContent},
-            },
-        },
-    },
+    ruma::events::room::MediaSource,
 };
 use ratatui::layout::Rect;
 use ratatui_image::{Resize, picker::Picker, protocol::Protocol};
@@ -89,7 +80,7 @@ impl PreviewManager {
     pub fn register_preview(
         &mut self,
         settings: &ApplicationSettings,
-        source: MediaSource,
+        source: &MediaSource,
         kind: PreviewKind,
         size: ImagePreviewSize,
         worker: &Requester,
@@ -110,20 +101,9 @@ impl PreviewManager {
             .as_ref()
             .is_some_and(|setting| !setting.lazy_load)
         {
-            self.load(&source, kind, worker);
+            self.load(source, kind, worker);
         }
     }
-}
-
-pub fn source_from_event(
-    ev: &MessageLikeEvent<RoomMessageEventContent>,
-) -> Option<(OwnedEventId, MediaSource)> {
-    if let MessageLikeEvent::Original(ev) = &ev &&
-        let MessageType::Image(c) = &ev.content.msgtype
-    {
-        return Some((ev.event_id.clone(), c.source.clone()));
-    }
-    None
 }
 
 impl From<ImagePreviewSize> for Rect {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -402,7 +402,7 @@ impl ChatState {
                         return Err(err);
                     },
                     MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Sticker(ev) => ev.event_id().to_owned(),
+                    MessageEvent::Sticker(ev, ..) => ev.event_id.to_owned(),
                     MessageEvent::Redacted(_, _) => {
                         let msg = "Cannot react to a redacted message";
                         let err = UIError::Failure(msg.into());
@@ -457,7 +457,7 @@ impl ChatState {
                         return Ok(None);
                     },
                     MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Sticker(ev) => ev.event_id().to_owned(),
+                    MessageEvent::Sticker(ev, ..) => ev.event_id.to_owned(),
                     MessageEvent::Redacted(_, _) => {
                         let msg = "Cannot redact already redacted message";
                         let err = UIError::Failure(msg.into());
@@ -528,7 +528,7 @@ impl ChatState {
                         return Err(err);
                     },
                     MessageEvent::State(ev) => ev.event_id().to_owned(),
-                    MessageEvent::Sticker(ev) => ev.event_id().to_owned(),
+                    MessageEvent::Sticker(ev, ..) => ev.event_id.to_owned(),
                     MessageEvent::Redacted(_, _) => {
                         let msg = "Cannot unreact to a redacted message";
                         let err = UIError::Failure(msg.into());

--- a/src/windows/room/scrollback.rs
+++ b/src/windows/room/scrollback.rs
@@ -1365,7 +1365,7 @@ impl StatefulWidget for Scrollback<'_> {
 
         // load image previews
         for (key, item) in thread.range(&corner_key..).rev() {
-            if let Some(source) = &item.image_preview {
+            if let Some(source) = item.image_preview() {
                 self.store.application.previews.load(
                     source,
                     PreviewKind::Message,
@@ -1376,7 +1376,7 @@ impl StatefulWidget for Scrollback<'_> {
                 .reply_to()
                 .or_else(|| item.thread_root())
                 .and_then(|e| info.get_event(&e))
-                .and_then(|msg| msg.image_preview.as_ref());
+                .and_then(|msg| msg.image_preview());
             if let Some(source) = reply {
                 self.store.application.previews.load(
                     source,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -329,7 +329,7 @@ fn load_insert(
                         info.insert_reaction_with_preview(ev, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::Sticker(ev)) => {
-                        info.insert_sticker(ev, settings, previews, worker);
+                        info.insert_sticker_with_preview(ev, settings, previews, worker);
                     },
                     AnyTimelineEvent::MessageLike(_) => {
                         continue;
@@ -1238,7 +1238,7 @@ impl ClientWorker {
                     update_event_receipts(info, &room, ev.event_id()).await;
 
                     let full_ev = ev.into_full_event(room_id.to_owned());
-                    info.insert_sticker(full_ev, settings, previews, worker);
+                    info.insert_sticker_with_preview(full_ev, settings, previews, worker);
                 }
             },
         );


### PR DESCRIPTION
- support stickers in threads
- only have one way to store a redacted sticker
- reduce `clone`s of the `MediaSource` when working with image previews