### PR TITLE
Support upgrading rooms and following tombstone information

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -72,7 +72,6 @@ View the startup Welcome window.
 .It Sy ":forget"
 Remove all left rooms from the internal database.
 .El
-
 .Sh "E2EE COMMANDS"
 .Bl -tag -width Ds
 .It Sy ":keys export [path] [passphrase]"
@@ -133,6 +132,10 @@ Create a new room. Arguments can be
 .Dq ++space ,
 and
 .Dq ++encrypted .
+.It Sy ":follow next"
+Follow the tombstone information to the upgraded room.
+.It Sy ":follow previous"
+Follow the room creation information to the pre-upgraded room.
 .It Sy ":invite accept"
 Accept an invitation to the currently focused room.
 .It Sy ":invite reject"
@@ -160,6 +163,11 @@ Mark the currently focused room as read.
 .It Sy ":room unread clear"
 Alias for
 .Sy :room unread unset .
+.It Sy ":room version show"
+Show the Matrix version for this room.
+.It Sy ":room version upgrade [version] [additional creators...]"
+Upgrade the Matrix version for this room to the specified version.
+Note that room upgrading in Matrix works by creating a new room that everyone else will then need to join.
 .It Sy ":room notify set [level]"
 Set a notification level for the currently focused room.
 Valid levels are

--- a/src/base.rs
+++ b/src/base.rs
@@ -14,10 +14,10 @@ use std::time::{Duration, Instant};
 use emojis::Emoji;
 
 use matrix_sdk::ruma::OwnedMxcUri;
-use matrix_sdk::ruma::OwnedTransactionId;
 use matrix_sdk::ruma::events::receipt::ReceiptThread;
 use matrix_sdk::ruma::events::room::MediaSource;
 use matrix_sdk::ruma::events::sticker::StickerEvent;
+use matrix_sdk::ruma::{OwnedTransactionId, RoomVersionId};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -91,7 +91,7 @@ use modalkit::{
     errors::{UIError, UIResult},
     key::TerminalKey,
     keybindings::SequenceStatus,
-    prelude::{CommandType, WordStyle},
+    prelude::{CommandType, MoveDir1D, WordStyle},
 };
 
 use crate::config::ImagePreviewSize;
@@ -407,6 +407,9 @@ pub enum RoomField {
     /// The room name.
     Name,
 
+    /// The room version.
+    Version,
+
     /// The room id.
     Id,
 
@@ -450,6 +453,9 @@ impl Display for MemberUpdateAction {
 /// An action that operates on a focused room.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RoomAction {
+    /// Follow the room upgrade information.
+    Follow(Box<CommandContext>, MoveDir1D),
+
     /// Accept an invitation to join this room.
     InviteAccept,
 
@@ -476,6 +482,9 @@ pub enum RoomAction {
 
     /// Unset a room property.
     Unset(RoomField),
+
+    /// Upgrade the version of a room.
+    Upgrade(RoomVersionId, Vec<OwnedUserId>, bool),
 
     /// List the values in a list room property.
     Show(RoomField),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,12 +4,12 @@
 //! [modalkit::env::vim::command] for additional Vim commands we pull in.
 use std::{convert::TryFrom, str::FromStr as _};
 
-use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, events::tag::TagName};
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, RoomVersionId, events::tag::TagName};
 
 use modalkit::{
     commands::{CommandError, CommandResult, CommandStep},
     env::vim::command::{CommandContext, CommandDescription, OptionType},
-    prelude::OpenTarget,
+    prelude::{MoveDir1D, OpenTarget},
 };
 
 use crate::base::{
@@ -196,6 +196,27 @@ fn iamb_leave(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let leave = IambAction::Room(RoomAction::Leave(desc.bang));
     let step = CommandStep::Continue(leave.into(), ctx.context.clone());
+
+    return Ok(step);
+}
+
+fn iamb_follow(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let mut args = desc.arg.strings()?;
+
+    if args.len() > 1 {
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    let dir = match args.pop().as_deref() {
+        None | Some("next") => MoveDir1D::Next,
+        Some("prev") | Some("previous") => MoveDir1D::Previous,
+        Some(_) => return Result::Err(CommandError::InvalidArgument),
+    };
+
+    let context = Box::new(ctx.clone());
+    let follow = RoomAction::Follow(context, dir);
+    let follow = IambAction::Room(follow);
+    let step = CommandStep::Continue(follow.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -448,20 +469,22 @@ fn iamb_create(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 }
 
 fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
-    let mut args = desc.arg.strings()?;
+    let mut iter = desc.arg.strings()?.into_iter();
+    let field = iter.next().ok_or(CommandError::InvalidArgument)?;
+    let action = iter.next().ok_or(CommandError::InvalidArgument)?;
+    let arg = iter.next();
+    let trailing = iter.collect::<Vec<_>>();
 
-    if args.len() < 2 {
-        return Result::Err(CommandError::InvalidArgument);
+    match (field.as_str(), action.as_str()) {
+        // Skip check for commands that takes a variable number of arguments:
+        ("version", "upgrade") => (),
+
+        // Reject if we have any trailing arguments:
+        (_, _) if !trailing.is_empty() => return Result::Err(CommandError::InvalidArgument),
+        (_, _) => (),
     }
 
-    let field = args.remove(0);
-    let action = args.remove(0);
-
-    if args.len() > 1 {
-        return Result::Err(CommandError::InvalidArgument);
-    }
-
-    let act: IambAction = match (field.as_str(), action.as_str(), args.pop()) {
+    let act: IambAction = match (field.as_str(), action.as_str(), arg) {
         // :room dm set
         ("dm", "set", None) => RoomAction::SetDirect(true).into(),
         ("dm", "set", Some(_)) => return Result::Err(CommandError::InvalidArgument),
@@ -532,6 +555,28 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         // :room notify show
         ("notify", "show", None) => RoomAction::Show(RoomField::NotificationMode).into(),
         ("notify", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room version show
+        ("version", "show", None) => RoomAction::Show(RoomField::Version).into(),
+        ("version", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room version upgrade
+        ("version", "upgrade", Some(s)) => {
+            let version = RoomVersionId::from_str(&s).map_err(|e| {
+                CommandError::Error(format!("{s:?} is not a valid room version: {e}"))
+            })?;
+            let additional_creators = trailing
+                .iter()
+                .map(|u| {
+                    OwnedUserId::from_str(u).map_err(|e| {
+                        let msg = format!("{u:?} is not a valid user identifier: {e}");
+                        CommandError::Error(msg)
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            RoomAction::Upgrade(version, additional_creators, desc.bang).into()
+        },
+        ("version", "upgrade", None) => return Result::Err(CommandError::InvalidArgument),
 
         // :room aliases show
         ("alias", "show", None) => RoomAction::Show(RoomField::Aliases).into(),
@@ -759,6 +804,16 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
     cmds.add_command(ProgramCommand { name: "open".into(), aliases: vec![], f: iamb_open });
     cmds.add_command(ProgramCommand { name: "edit".into(), aliases: vec![], f: iamb_edit });
     cmds.add_command(ProgramCommand {
+        name: "follow".into(),
+        aliases: vec![],
+        f: iamb_follow,
+    });
+    cmds.add_command(ProgramCommand {
+        name: "forget".into(),
+        aliases: vec![],
+        f: iamb_forget,
+    });
+    cmds.add_command(ProgramCommand {
         name: "invite".into(),
         aliases: vec![],
         f: iamb_invite,
@@ -769,11 +824,6 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         name: "leave".into(),
         aliases: vec![],
         f: iamb_leave,
-    });
-    cmds.add_command(ProgramCommand {
-        name: "forget".into(),
-        aliases: vec![],
-        f: iamb_forget,
     });
     cmds.add_command(ProgramCommand {
         name: "members".into(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1510,4 +1510,48 @@ mod tests {
         let res = cmds.input_cmd("keys import foo bar baz", ctx.clone());
         assert_eq!(res, Err(CommandError::InvalidArgument));
     }
+
+    #[test]
+    fn test_cmd_multiple_trailing() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        // Trailing arguments disallowed on commands that don't take any:
+        let res = cmds.input_cmd("room version show foo", ctx.clone()).unwrap_err();
+        let err = CommandError::InvalidArgument;
+        assert_eq!(res, err);
+
+        // Trailing arguments allowed on commands that take them:
+        let res = cmds.input_cmd("room version upgrade 12", ctx.clone()).unwrap();
+        let act = IambAction::Room(RoomAction::Upgrade(RoomVersionId::V12, vec![], false));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds
+            .input_cmd("room version upgrade 12 @foo:example.com", ctx.clone())
+            .unwrap();
+        let act = IambAction::Room(RoomAction::Upgrade(
+            RoomVersionId::V12,
+            vec![user_id!("@foo:example.com").to_owned()],
+            false,
+        ));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds
+            .input_cmd("room version upgrade 12 @foo:example.com @bar:example.com", ctx.clone())
+            .unwrap();
+        let act = IambAction::Room(RoomAction::Upgrade(
+            RoomVersionId::V12,
+            vec![
+                user_id!("@foo:example.com").to_owned(),
+                user_id!("@bar:example.com").to_owned(),
+            ],
+            false,
+        ));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        // But the command must take *some* arguments:
+        let res = cmds.input_cmd("room version upgrade", ctx.clone()).unwrap_err();
+        let err = CommandError::InvalidArgument;
+        assert_eq!(res, err);
+    }
 }

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -40,6 +40,7 @@ use matrix_sdk::{
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
+    prelude::Stylize,
     text::{Line, Span},
     widgets::{Paragraph, StatefulWidget, Widget},
 };
@@ -1109,9 +1110,25 @@ impl StatefulWidget for Chat<'_> {
     type State = ChatState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let settings = &self.store.application.settings;
+
         // Determine whether we have a description to show for the message bar.
         let desc_spans = match (&state.editing, &state.reply_to, state.thread()) {
-            (None, None, None) => None,
+            (None, None, None) => {
+                if state.room.is_tombstoned() {
+                    Some(
+                        Line::from(vec![
+                            Span::from("This room has been upgraded! ").bold(),
+                            Span::from("Use "),
+                            Span::from(":follow").bold(),
+                            Span::from(" to join everyone in the new room."),
+                        ])
+                        .centered(),
+                    )
+                } else {
+                    None
+                }
+            },
             (None, None, Some(_)) => Some(Line::from("Replying in thread")),
             (Some(_), None, None) => Some(Line::from("Editing message")),
             (Some(_), None, Some(_)) => Some(Line::from("Editing message in thread")),
@@ -1153,7 +1170,7 @@ impl StatefulWidget for Chat<'_> {
             Paragraph::new(desc_spans).render(descarea, buf);
         }
 
-        let encryption_settings = &self.store.application.settings.tunables.encryption;
+        let encryption_settings = &settings.tunables.encryption;
         let encryption_indicator = encryption_settings
             .get_indicator(EncryptionIndicatorLocation::PROMPT, state.room().encryption_state());
         let prompt = match (self.focused, encryption_indicator) {

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -1,7 +1,6 @@
 //! # Windows for Matrix rooms and spaces
 use std::collections::HashSet;
 
-use matrix_sdk::ruma::api::error::ErrorKind as ClientApiErrorKind;
 use matrix_sdk::{
     RoomDisplayName,
     RoomState as MatrixRoomState,
@@ -12,6 +11,10 @@ use matrix_sdk::{
         OwnedRoomAliasId,
         OwnedUserId,
         RoomId,
+        api::{
+            client::room::upgrade_room::v3::Request as UpgradeRoomRequest,
+            error::ErrorKind as ClientApiErrorKind,
+        },
         events::{
             room::{
                 canonical_alias::RoomCanonicalAliasEventContent,
@@ -40,6 +43,7 @@ use modalkit::actions::{
     PromptAction,
     Promptable,
     Scrollable,
+    WindowAction,
 };
 use modalkit::errors::{EditResult, UIError};
 use modalkit::prelude::*;
@@ -115,7 +119,32 @@ pub async fn room_command(
     ctx: ProgramContext,
     store: &mut ProgramStore,
 ) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
+    let worker = &store.application.worker;
+
     match act {
+        RoomAction::Follow(cmd, dir) => {
+            let room = worker.client.get_room(id).ok_or(IambError::NotJoined)?;
+            let room_id = match dir {
+                MoveDir1D::Next => {
+                    let successor = room
+                        .successor_room()
+                        .ok_or_else(|| UIError::Failure("No successor room found".into()))?;
+                    successor.room_id
+                },
+                MoveDir1D::Previous => {
+                    let predecessor = room
+                        .predecessor_room()
+                        .ok_or_else(|| UIError::Failure("No predecessor room found".into()))?;
+                    predecessor.room_id
+                },
+            };
+
+            let id = IambId::Room(room_id.to_owned(), None);
+            let target = OpenTarget::Application(id);
+            let act = cmd.switch(target);
+
+            Ok(vec![(act, cmd.context.clone())])
+        },
         RoomAction::InviteAccept => {
             if let Some(room) = store.application.worker.client.get_room(id) {
                 room.join().await.map_err(IambError::from)?;
@@ -361,6 +390,9 @@ pub async fn room_command(
                 RoomField::Id => {
                     // This never happens, id is only used for showing
                 },
+                RoomField::Version => {
+                    // This never happens, version is only used for showing or upgrading.
+                },
             }
 
             Ok(vec![])
@@ -457,6 +489,9 @@ pub async fn room_command(
                 RoomField::Id => {
                     // This never happens, id is only used for showing
                 },
+                RoomField::Version => {
+                    // This never happens, version is only used for showing or upgrading.
+                },
             }
 
             Ok(vec![])
@@ -476,6 +511,11 @@ pub async fn room_command(
                 RoomField::Id => {
                     let id = room.room_id();
                     format!("Room identifier: {id}")
+                },
+                RoomField::Version => {
+                    let v = room.version();
+                    let v = v.as_ref().map(|v| v.as_str()).unwrap_or("<version unknown>");
+                    format!("Room version: {v}")
                 },
                 RoomField::Name => {
                     match room.name() {
@@ -532,6 +572,32 @@ pub async fn room_command(
             let act = Action::ShowInfoMessage(msg);
 
             Ok(vec![(act, ctx)])
+        },
+        RoomAction::Upgrade(new_version, additional_creators, false) => {
+            let room = worker.client.get_room(id).ok_or(IambError::NotJoined)?;
+            let alias = room.canonical_alias();
+            let name = alias.as_ref().map(|c| c.as_str()).unwrap_or_else(|| id.as_str());
+            let msg = format!(
+                "Are you sure you want to upgrade {name} to version {new_version} with {} additional creators set?",
+                additional_creators.len()
+            );
+            let upgrade =
+                IambAction::Room(RoomAction::Upgrade(new_version, additional_creators, true));
+            let prompt = PromptYesNo::new(msg, vec![Action::from(upgrade)]);
+            let prompt = Box::new(prompt);
+
+            Err(UIError::NeedConfirm(prompt))
+        },
+        RoomAction::Upgrade(new_version, additional_creators, true) => {
+            let mut request = UpgradeRoomRequest::new(id.to_owned(), new_version);
+            request.additional_creators = additional_creators;
+
+            let response = worker.client.send(request).await.map_err(IambError::from)?;
+            let id = IambId::Room(response.replacement_room, None);
+            let target = OpenTarget::Application(id);
+            let act = WindowAction::Switch(target);
+
+            Ok(vec![(act.into(), ctx)])
         },
     }
 }


### PR DESCRIPTION
This resolves #41 and #296 by adding `:follow next`, `:follow prev`, `:room version show`, and `:room version upgrade` commands which can be used for follow the room tombstone to the next room version, and for upgrading your rooms to new versions (assuming you have the right power levels).