### PR TITLE
Add support for room knocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "linkify",
  "markup5ever_rcdom",
  "matrix-sdk",
+ "matrix-sdk-base",
  "matrix-sdk-crypto",
  "mime",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ version = "0.0.25"
 #git = "https://github.com/ulyssa/modalkit"
 #rev = "e40dbb0bfeabe4cfd08facd2acb446080a330d75"
 
+[dependencies.matrix-sdk-base]
+version = "0.18.0"
+
 [dependencies.matrix-sdk]
 version = "0.18.0"
 default-features = false

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -144,6 +144,14 @@ Reject an invitation to the currently focused room.
 Send an invitation to a user to join the currently focused room.
 .It Sy ":join [room]"
 Join a room or open it if you are already joined.
+.It Sy ":knock accept [user]"
+Accept a knock from the specified user in the currently focused room.
+.It Sy ":knock ban [user] [reason]"
+Reject a knock from the specified user to the currently focused room, and ban them with an optional reason.
+.It Sy ":knock reject [user] [reason]"
+Reject a knock from the specified user to the currently focused room with an optional reason.
+.It Sy ":knock send [room] [reason]"
+Send an invitation to a user to join the currently focused room with an optional reason.
 .It Sy ":leave"
 Leave the currently focused room.
 .It Sy ":members"

--- a/docs/iamb.5
+++ b/docs/iamb.5
@@ -485,7 +485,7 @@ How to sort the
 .Sy :members
 window.
 Defaults to
-.Sy ["power",\ "id"] .
+.Sy ["power",\ "knock",\ "~invite",\ "id"] .
 .El
 .Pp
 The available values for sorting rooms are:

--- a/src/base.rs
+++ b/src/base.rs
@@ -13,12 +13,6 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 
-use matrix_sdk::ruma::events::OriginalMessageLikeEvent;
-use matrix_sdk::ruma::events::receipt::ReceiptThread;
-use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::events::room::message::MessageType;
-use matrix_sdk::ruma::events::sticker::{StickerEvent, StickerEventContent};
-use matrix_sdk::ruma::{OwnedMxcUri, OwnedTransactionId, RoomVersionId};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -44,17 +38,25 @@ use matrix_sdk::{
     ruma::{
         EventId,
         OwnedEventId,
+        OwnedMxcUri,
         OwnedRoomId,
+        OwnedRoomOrAliasId,
+        OwnedTransactionId,
         OwnedUserId,
         RoomId,
+        RoomVersionId,
         UserId,
         events::{
             AnySyncStateEvent,
             MessageLikeEvent,
+            OriginalMessageLikeEvent,
             reaction::ReactionEvent,
+            receipt::ReceiptThread,
             relation::{Replacement, Thread},
+            room::MediaSource,
             room::encrypted::RoomEncryptedEvent,
             room::message::{
+                MessageType,
                 OriginalRoomMessageEvent,
                 Relation,
                 RoomMessageEvent,
@@ -62,6 +64,7 @@ use matrix_sdk::{
                 RoomMessageEventContentWithoutRelation,
             },
             room::redaction::{OriginalSyncRoomRedactionEvent, SyncRoomRedactionEvent},
+            sticker::{StickerEvent, StickerEventContent},
             tag::{TagName, Tags},
         },
         presence::PresenceState,
@@ -283,6 +286,8 @@ pub enum SortFieldUser {
     UserId,
     LocalPart,
     Server,
+    Knock,
+    Invite,
 }
 
 /// Whether to use the default sort direction for a field, or to reverse it.
@@ -389,6 +394,8 @@ impl Visitor<'_> for SortUserVisitor {
             "localpart" => SortFieldUser::LocalPart,
             "server" => SortFieldUser::Server,
             "power" => SortFieldUser::PowerLevel,
+            "knock" => SortFieldUser::Knock,
+            "invite" => SortFieldUser::Invite,
             _ => {
                 let msg = format!("Unknown sort field: {value:?}");
                 return Err(E::custom(msg));
@@ -469,6 +476,16 @@ pub enum RoomAction {
     /// Invite a user to this room.
     InviteSend(OwnedUserId),
 
+    /// Accept a knock from someone who wants to join this room.
+    KnockAccept(OwnedUserId),
+
+    /// Reject a knock from someone who wants to join this room.
+    KnockReject(OwnedUserId, Option<String>),
+
+    /// Reject a knock from someone who wants to join this room and ban them
+    /// to prevent them from being able to try knocking again.
+    KnockBan(OwnedUserId, Option<String>),
+
     /// Leave this room.
     Leave(bool),
 
@@ -523,7 +540,13 @@ pub enum SendAction {
 pub enum HomeserverAction {
     /// Create a new room with an optional localpart.
     CreateRoom(Option<String>, CreateRoomType, CreateRoomFlags),
+
+    /// "Knock" on a room, aka "request to join".
+    KnockSend(OwnedRoomOrAliasId, Option<String>),
+
+    /// Logout the current iamb session on the homeserver.
     Logout(String, bool),
+
     /// Forget all left rooms
     Forget,
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,7 +4,13 @@
 //! [modalkit::env::vim::command] for additional Vim commands we pull in.
 use std::{convert::TryFrom, str::FromStr as _};
 
-use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, RoomVersionId, events::tag::TagName};
+use matrix_sdk::ruma::{
+    OwnedRoomId,
+    OwnedRoomOrAliasId,
+    OwnedUserId,
+    RoomVersionId,
+    events::tag::TagName,
+};
 
 use modalkit::{
     commands::{CommandError, CommandResult, CommandStep},
@@ -124,6 +130,63 @@ fn iamb_keys(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let vact = IambAction::Keys(act);
     let step = CommandStep::Continue(vact.into(), ctx.context.clone());
+
+    return Ok(step);
+}
+
+fn iamb_knock(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let mut args = desc.arg.strings()?;
+
+    if args.len() < 2 || args.len() > 3 {
+        return Err(CommandError::InvalidArgument);
+    }
+
+    let cmd = args.remove(0);
+    let arg = args.remove(0);
+    let reason = args.pop();
+
+    let act: IambAction = match (cmd.as_str(), arg, reason) {
+        // :knock send #room:example.org "reason"
+        ("send", alias, reason) => {
+            let alias = OwnedRoomOrAliasId::from_str(&alias).map_err(|e| {
+                CommandError::Error(format!(
+                    "{alias:?} is not a valid alias or room identifier: {e}"
+                ))
+            })?;
+            HomeserverAction::KnockSend(alias, reason).into()
+        },
+
+        // :knock accept @user:example.org
+        ("accept", user, None) => {
+            let user = OwnedUserId::from_str(&user).map_err(|e| {
+                CommandError::Error(format!("{user:?} is not a valid user identifier: {e}"))
+            })?;
+            RoomAction::KnockAccept(user).into()
+        },
+        ("accept", _, Some(_)) => return Err(CommandError::InvalidArgument),
+
+        // :knock reject @user:example.org "reason"
+        ("reject", user, reason) => {
+            let user = OwnedUserId::from_str(&user).map_err(|e| {
+                CommandError::Error(format!("{user:?} is not a valid user identifier: {e}"))
+            })?;
+            RoomAction::KnockReject(user, reason).into()
+        },
+
+        // :knock ban @user:example.org "reason"
+        ("ban", user, reason) => {
+            let user = OwnedUserId::from_str(&user).map_err(|e| {
+                CommandError::Error(format!("{user:?} is not a valid user identifier: {e}"))
+            })?;
+            RoomAction::KnockBan(user, reason).into()
+        },
+
+        (cmd, _, _) => {
+            return Err(CommandError::Error(format!("unrecognized `knock` subcommand: {cmd:?}")));
+        },
+    };
+
+    let step = CommandStep::Continue(act.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -858,6 +921,11 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
     });
     cmds.add_command(ProgramCommand { name: "join".into(), aliases: vec![], f: iamb_join });
     cmds.add_command(ProgramCommand { name: "keys".into(), aliases: vec![], f: iamb_keys });
+    cmds.add_command(ProgramCommand {
+        name: "knock".into(),
+        aliases: vec![],
+        f: iamb_knock,
+    });
     cmds.add_command(ProgramCommand {
         name: "leave".into(),
         aliases: vec![],

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,10 @@ macro_rules! usage {
     }
 }
 
-const DEFAULT_MEMBERS_SORT: [SortColumn<SortFieldUser>; 2] = [
+const DEFAULT_MEMBERS_SORT: [SortColumn<SortFieldUser>; 4] = [
     SortColumn(SortFieldUser::PowerLevel, SortOrder::Ascending),
+    SortColumn(SortFieldUser::Knock, SortOrder::Ascending),
+    SortColumn(SortFieldUser::Invite, SortOrder::Descending),
     SortColumn(SortFieldUser::UserId, SortOrder::Ascending),
 ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -651,6 +651,15 @@ impl Application {
 
                 Ok(vec![(action.into(), ctx)])
             },
+            HomeserverAction::KnockSend(alias, reason) => {
+                let _ = self
+                    .worker
+                    .client
+                    .knock(alias, reason, vec![])
+                    .await
+                    .map_err(IambError::from)?;
+                Ok(vec![])
+            },
             HomeserverAction::Logout(user, true) => {
                 self.worker.logout(user)?;
                 let flags = CloseFlags::QUIT | CloseFlags::FORCE;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -128,6 +128,7 @@ fn selected_text(s: &str, selected: bool) -> Text<'_> {
 fn name_and_labels<'a>(
     name: &'a str,
     unread: &UnreadInfo,
+    room: &MatrixRoom,
     style: Style,
 ) -> (Span<'a>, Vec<Vec<Span<'static>>>) {
     // TODO: use different colors for "mention", "notification", "muted room"
@@ -140,6 +141,14 @@ fn name_and_labels<'a>(
     let name = Span::styled(name, name_style);
 
     let mut labels = vec![];
+
+    match room.state() {
+        MatrixRoomState::Joined => {},
+        MatrixRoomState::Left => labels.push(vec![Span::styled("Left", style)]),
+        MatrixRoomState::Banned => labels.push(vec![Span::styled("Banned", style)]),
+        MatrixRoomState::Knocked => labels.push(vec![Span::styled("Knocked", style)]),
+        MatrixRoomState::Invited => labels.push(vec![Span::styled("Invited", style)]),
+    }
 
     if unread.unread_mentions > 0 {
         labels.push(vec![Span::styled("Unread Mention", style)]);
@@ -172,6 +181,14 @@ fn user_cmp(a: &MemberItem, b: &MemberItem, field: &SortFieldUser) -> Ordering {
         SortFieldUser::UserId => a_id.cmp(b_id),
         SortFieldUser::LocalPart => a_id.localpart().cmp(b_id.localpart()),
         SortFieldUser::Server => a_id.server_name().cmp(b_id.server_name()),
+        SortFieldUser::Knock => {
+            // Sort knocks before non-knocks:
+            b.is_knock().cmp(&a.is_knock())
+        },
+        SortFieldUser::Invite => {
+            // Sort invites before non-invites:
+            b.is_invite().cmp(&a.is_invite())
+        },
         SortFieldUser::PowerLevel => {
             // Sort higher power levels towards the top of the list.
             b.member.power_level().cmp(&a.member.power_level())
@@ -1048,7 +1065,7 @@ impl ListItem<IambInfo> for GenericChatItem {
         _: &mut ProgramStore,
     ) -> Text<'_> {
         let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, &self.unread, style);
+        let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
 
         labels.push(if self.is_dm {
@@ -1166,7 +1183,7 @@ impl ListItem<IambInfo> for RoomItem {
         _: &mut ProgramStore,
     ) -> Text<'_> {
         let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, &self.unread, style);
+        let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
 
         if let Some(tags) = &self.tags() {
@@ -1275,7 +1292,7 @@ impl ListItem<IambInfo> for DirectItem {
         _: &mut ProgramStore,
     ) -> Text<'_> {
         let style = selected_style(selected);
-        let (name, mut labels) = name_and_labels(&self.name, &self.unread, style);
+        let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
 
         if let Some(tags) = &self.tags() {
@@ -1611,6 +1628,14 @@ pub struct MemberItem {
 impl MemberItem {
     fn new(member: RoomMember, room_id: OwnedRoomId) -> Self {
         Self { member, room_id }
+    }
+
+    fn is_knock(&self) -> bool {
+        self.member.membership() == &MembershipState::Knock
+    }
+
+    fn is_invite(&self) -> bool {
+        self.member.membership() == &MembershipState::Invite
     }
 }
 

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -171,6 +171,21 @@ pub async fn room_command(
                 Err(IambError::NotJoined.into())
             }
         },
+        RoomAction::KnockAccept(user) => {
+            let room = worker.client.get_room(id).ok_or(IambError::NotJoined)?;
+            room.invite_user_by_id(&user).await.map_err(IambError::from)?;
+            Ok(vec![])
+        },
+        RoomAction::KnockReject(user, reason) => {
+            let room = worker.client.get_room(id).ok_or(IambError::NotJoined)?;
+            room.kick_user(&user, reason.as_deref()).await.map_err(IambError::from)?;
+            Ok(vec![])
+        },
+        RoomAction::KnockBan(user, reason) => {
+            let room = worker.client.get_room(id).ok_or(IambError::NotJoined)?;
+            room.ban_user(&user, reason.as_deref()).await.map_err(IambError::from)?;
+            Ok(vec![])
+        },
         RoomAction::Leave(skip_confirm) => {
             if let Some(room) = store.application.worker.client.get_room(id) {
                 if skip_confirm {
@@ -681,7 +696,7 @@ impl RoomState {
 
     fn draw_invite(
         &self,
-        invited: MatrixRoom,
+        invited: &MatrixRoom,
         area: Rect,
         buf: &mut Buffer,
         store: &mut ProgramStore,
@@ -706,6 +721,48 @@ impl RoomState {
             "You can run `:invite accept` or `:invite reject` to accept or reject this invitation.",
         );
         let text = Text::from(vec![l1, l2]);
+
+        Paragraph::new(text).alignment(Alignment::Center).render(area, buf);
+
+        return;
+    }
+
+    fn draw_knock(
+        &self,
+        knocked: &MatrixRoom,
+        area: Rect,
+        buf: &mut Buffer,
+        store: &mut ProgramStore,
+    ) {
+        let name = match knocked.canonical_alias() {
+            Some(alias) => alias.to_string(),
+            None => format!("{:?}", store.application.get_room_title(self.id())),
+        };
+
+        let l1 = Line::from(format!(
+            "Your request to join {name} is pending review by room moderators."
+        ));
+        let l2 = Line::from("You can run `:leave` to withdraw your knock request.");
+        let text = Text::from(vec![l1, l2]);
+
+        Paragraph::new(text).alignment(Alignment::Center).render(area, buf);
+
+        return;
+    }
+
+    fn draw_left(&self, room: &MatrixRoom, area: Rect, buf: &mut Buffer, store: &mut ProgramStore) {
+        let name = match room.canonical_alias() {
+            Some(alias) => alias.to_string(),
+            None => format!("{:?}", store.application.get_room_title(self.id())),
+        };
+
+        let mut lines = vec![Line::from(format!("You have left {name}!"))];
+
+        if room.is_public().is_some_and(|b| b) {
+            lines.push(Line::from(format!("You can run `:join {name}` to rejoin.")));
+        }
+
+        let text = Text::from(lines);
 
         Paragraph::new(text).alignment(Alignment::Center).render(area, buf);
 
@@ -859,12 +916,15 @@ impl TerminalCursor for RoomState {
 
 impl WindowOps<IambInfo> for RoomState {
     fn draw(&mut self, area: Rect, buf: &mut Buffer, focused: bool, store: &mut ProgramStore) {
-        if self.room().state() == MatrixRoomState::Invited {
+        if self.room().state() != MatrixRoomState::Joined {
             self.refresh_room(store);
         }
 
-        if self.room().state() == MatrixRoomState::Invited {
-            self.draw_invite(self.room().clone(), area, buf, store);
+        match self.room().state() {
+            MatrixRoomState::Invited => return self.draw_invite(self.room(), area, buf, store),
+            MatrixRoomState::Knocked => return self.draw_knock(self.room(), area, buf, store),
+            MatrixRoomState::Left => return self.draw_left(self.room(), area, buf, store),
+            _ => (),
         }
 
         match self {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,12 +13,7 @@ use std::time::{Duration, Instant};
 
 use futures::{StreamExt, stream::FuturesUnordered};
 use gethostname::gethostname;
-use matrix_sdk::ruma::events::AnyMessageLikeEventContent;
-use matrix_sdk::ruma::events::relation::Thread;
-use matrix_sdk::ruma::events::room::MediaSource;
-use matrix_sdk::ruma::events::room::message::Relation;
-use matrix_sdk::ruma::events::sticker::StickerEventContent;
-use matrix_sdk::send_queue::{LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendQueueUpdate};
+use matrix_sdk_base::RoomStateFilter;
 use ratatui_image::picker::Picker;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
@@ -60,6 +55,7 @@ use matrix_sdk::{
         assign,
         events::{
             AnyMessageLikeEvent,
+            AnyMessageLikeEventContent,
             AnySyncStateEvent,
             AnyTimelineEvent,
             InitialStateEvent,
@@ -76,19 +72,23 @@ use matrix_sdk::{
             presence::PresenceEvent,
             reaction::ReactionEventContent,
             receipt::{ReceiptEventContent, ReceiptThread, ReceiptType},
+            relation::Thread,
             room::{
+                MediaSource,
                 encryption::RoomEncryptionEventContent,
                 member::OriginalSyncRoomMemberEvent,
-                message::{MessageType, RoomMessageEventContent},
+                message::{MessageType, Relation, RoomMessageEventContent},
                 name::RoomNameEventContent,
                 redaction::OriginalSyncRoomRedactionEvent,
             },
+            sticker::StickerEventContent,
             tag::Tags,
             typing::SyncTypingEvent,
         },
         room::RoomType,
         serde::Raw,
     },
+    send_queue::{LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendQueueUpdate},
 };
 
 use modalkit::errors::UIError;
@@ -431,7 +431,11 @@ async fn refresh_rooms(client: &Client, store: &AsyncProgramStore, first_sync: b
     let mut rooms = vec![];
     let mut dms = vec![];
 
-    for room in client.invited_rooms().into_iter().chain(client.joined_rooms().into_iter()) {
+    let iter = client.rooms_filtered(
+        RoomStateFilter::JOINED | RoomStateFilter::INVITED | RoomStateFilter::KNOCKED,
+    );
+
+    for room in iter {
         let display = if let Some(name) = room.cached_display_name() {
             name
         } else if !first_sync && let Ok(name) = room.display_name().await {
@@ -1598,7 +1602,10 @@ impl ClientWorker {
 
     async fn members(&mut self, room_id: OwnedRoomId) -> IambResult<Vec<RoomMember>> {
         if let Some(room) = self.client.get_room(room_id.as_ref()) {
-            Ok(room.members(RoomMemberships::ACTIVE).await.map_err(IambError::from)?)
+            Ok(room
+                .members(RoomMemberships::ACTIVE | RoomMemberships::KNOCK)
+                .await
+                .map_err(IambError::from)?)
         } else {
             Err(IambError::UnknownRoom(room_id).into())
         }


### PR DESCRIPTION
This adds support for room knocking. Specifically, this PR includes:

- `:knock send` for sending the room knock
- `:knock accept`/`:knock reject`/`:knock ban` for managing the received room knock
- New `"knock"` and `"invite"` options for user sorting
  - The default `:members` sorting has been updated to be `["power", "knock", "~invite", "id"]`, which should ensure that room knocks become visible when they appear, and the get moved to the end of the list when they are converted into an invite.
- Rooms are now shown with "Invite" and "Knocked" in room lists to make it clear when they change state. 

Currently, when the sent knock is accepted and turned into an invitation it will not be auto-accepted, either by Synapse or iamb. (I am unsure about what other homeservers do.) It looks like Synapse plans to switch to auto-accepting the invitation of an accepted knock, though, as allowed by the Matrix specification. (Refer to element-hq/synapse#19958 for more details.)