### PR TITLE
Fix crash from value underflow while rendering timeline

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1173,7 +1173,7 @@ impl Message {
             fmt.push_spans(
                 Line::from(vec![
                     Span::styled("(edited)", style.fg(Color::Gray)),
-                    space_span(fmt.width() - 8, style),
+                    space_span(fmt.width().saturating_sub(8), style),
                 ]),
                 style,
                 &mut text,


### PR DESCRIPTION
While resizing my terminal, iamb crashed inside the `repeat` method due to trying to allocate a `Vec` with a huge capacity. I was able to reproduce it with a debug binary and get the backtrace to find the right line. Switching to using `saturating_sub` should do the right thing here since we'll just allocate an empty string instead.