### PR TITLE
Add support for updating user profile information

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -232,7 +232,6 @@ Delete your per-room user display name.
 .It Sy ":room user name show"
 Show the display name you currently have in this room.
 .El
-
 .Sh "SPACE COMMANDS"
 .Bl -tag -width Ds
 .It Sy ":space child set [room_id] [arguments]"
@@ -244,7 +243,27 @@ specifies a string by which children are lexicographically ordered.
 .It Sy ":space child remove"
 Remove the selected room from the currently focused space.
 .El
-
+.Sh "PROFILE COMMANDS"
+.Bl -tag -width Ds
+.It Sy ":self avatar set [mxc://...]"
+Set the avatar URL for your profile.
+.It Sy ":self avatar unset"
+Unset the avatar for your profile.
+.It Sy ":self avatar show"
+Show the current avatar URL for your profile.
+.It Sy ":self name set [nickname]"
+Set the display name for your profile.
+.It Sy ":self name unset"
+Unset the display name for your profile.
+.It Sy ":self name show"
+Show the current display name for your profile.
+.It Sy ":self timezone set [tz]"
+Set the timezone for your profile.
+.It Sy ":self timezone unset"
+Unset the timezone for your profile.
+.It Sy ":self timezone show"
+Show the current timezone for your profile.
+.El
 .Sh "WINDOW COMMANDS"
 .Bl -tag -width Ds
 .It Sy ":horizontal [cmd]"

--- a/src/base.rs
+++ b/src/base.rs
@@ -67,6 +67,7 @@ use matrix_sdk::{
             tag::{TagName, Tags},
         },
         presence::PresenceState,
+        profile::{ProfileFieldName, ProfileFieldValue},
     },
 };
 
@@ -547,6 +548,15 @@ pub enum HomeserverAction {
 
     /// Forget all left rooms
     Forget,
+
+    /// Set a profile field.
+    ProfileFieldSet(ProfileFieldValue),
+
+    /// Set a profile field.
+    ProfileFieldUnset(ProfileFieldName),
+
+    /// Set a profile field.
+    ProfileFieldShow(ProfileFieldName),
 }
 
 /// An action performed against the user's room keys.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,11 +5,13 @@
 use std::{convert::TryFrom, str::FromStr as _};
 
 use matrix_sdk::ruma::{
+    OwnedMxcUri,
     OwnedRoomId,
     OwnedRoomOrAliasId,
     OwnedUserId,
     RoomVersionId,
     events::tag::TagName,
+    profile::{ProfileFieldName, ProfileFieldValue},
 };
 
 use modalkit::{
@@ -445,6 +447,90 @@ fn iamb_mentions(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult 
 
     let open = ctx.switch(OpenTarget::Application(IambId::MentionsList));
     let step = CommandStep::Continue(open, ctx.context.clone());
+
+    return Ok(step);
+}
+
+fn iamb_self(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let mut iter = desc.arg.strings()?.into_iter();
+    let field = iter.next().ok_or(CommandError::InvalidArgument)?;
+    let action = iter.next().ok_or(CommandError::InvalidArgument)?;
+    let arg = iter.next();
+    let trailing = iter.collect::<Vec<_>>();
+
+    if !trailing.is_empty() {
+        // Reject if we have any trailing arguments:
+        return Result::Err(CommandError::InvalidArgument);
+    }
+
+    let act: IambAction = match (field.as_str(), action.as_str(), arg) {
+        // :self avatar show
+        ("avatar", "show", None) => {
+            HomeserverAction::ProfileFieldShow(ProfileFieldName::AvatarUrl).into()
+        },
+        ("avatar", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self avatar set
+        ("avatar", "set", Some(s)) => {
+            let url = OwnedMxcUri::from(s.as_str());
+            if let Err(e) = url.validate() {
+                return Err(CommandError::Error(format!(
+                    "{s:?} is not a valid Matrix content URI: {e}"
+                )));
+            }
+            HomeserverAction::ProfileFieldSet(ProfileFieldValue::AvatarUrl(url)).into()
+        },
+        ("avatar", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self avatar unset
+        ("avatar", "unset", None) => {
+            HomeserverAction::ProfileFieldUnset(ProfileFieldName::AvatarUrl).into()
+        },
+        ("avatar", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self name show
+        ("name" | "nick", "show", None) => {
+            HomeserverAction::ProfileFieldShow(ProfileFieldName::DisplayName).into()
+        },
+        ("name" | "nick", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self name set
+        ("name" | "nick", "set", Some(s)) => {
+            HomeserverAction::ProfileFieldSet(ProfileFieldValue::DisplayName(s)).into()
+        },
+        ("name" | "nick", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self name unset
+        ("name" | "nick", "unset", None) => {
+            HomeserverAction::ProfileFieldUnset(ProfileFieldName::DisplayName).into()
+        },
+        ("name" | "nick", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self timezone show
+        ("timezone" | "tz", "show", None) => {
+            HomeserverAction::ProfileFieldShow(ProfileFieldName::TimeZone).into()
+        },
+        ("timezone" | "tz", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self timezone set
+        ("timezone" | "tz", "set", Some(s)) => {
+            HomeserverAction::ProfileFieldSet(ProfileFieldValue::TimeZone(s)).into()
+        },
+        ("timezone" | "tz", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :self timezone set
+        ("timezone" | "tz", "unset", None) => {
+            HomeserverAction::ProfileFieldUnset(ProfileFieldName::TimeZone).into()
+        },
+        ("timezone" | "tz", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // Reject anything we don't recognize:
+        (f, a, _) => {
+            return Result::Err(CommandError::Error(format!("unrecognized command: {f} {a}")));
+        },
+    };
+
+    let step = CommandStep::Continue(act.into(), ctx.context.clone());
 
     return Ok(step);
 }
@@ -982,6 +1068,7 @@ fn add_iamb_commands(cmds: &mut ProgramCommands) {
         aliases: vec![],
         f: iamb_mentions,
     });
+    cmds.add_command(ProgramCommand { name: "self".into(), aliases: vec![], f: iamb_self });
     cmds.add_command(ProgramCommand {
         name: "unreact".into(),
         aliases: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 use clap::{CommandFactory, Parser};
 use matrix_sdk::ruma::OwnedUserId;
 use matrix_sdk::ruma::api::error::ErrorKind;
+use matrix_sdk::ruma::profile::{ProfileFieldName, ProfileFieldValue};
 use matrix_sdk_crypto::encrypt_room_key_export;
 use modalkit::keybindings::InputBindings;
 use rand::RngExt as _;
@@ -681,6 +682,56 @@ impl Application {
                     room.forget().await.map_err(IambError::from)?;
                 }
                 Ok(vec![])
+            },
+            HomeserverAction::ProfileFieldSet(value) => {
+                let client = &store.application.worker.client;
+                let account = client.account();
+                account.set_profile_field(value).await.map_err(IambError::from)?;
+                Ok(vec![])
+            },
+            HomeserverAction::ProfileFieldUnset(field) => {
+                let client = &store.application.worker.client;
+                let account = client.account();
+                account.delete_profile_field(field).await.map_err(IambError::from)?;
+                Ok(vec![])
+            },
+            HomeserverAction::ProfileFieldShow(field) => {
+                let client = &store.application.worker.client;
+                let user_id = store.application.settings.profile.user_id.clone();
+                let account = client.account();
+                let value = account
+                    .fetch_profile_field_of(user_id, field.clone())
+                    .await
+                    .map_err(IambError::from)?;
+
+                let msg = match (field, value) {
+                    (_, Some(ProfileFieldValue::DisplayName(s))) => {
+                        format!("Your profile's display name is set to: {s}")
+                    },
+                    (_, Some(ProfileFieldValue::TimeZone(s))) => {
+                        format!("Your profile's timezone is set to: {s}")
+                    },
+                    (_, Some(ProfileFieldValue::AvatarUrl(s))) => {
+                        format!("Your profile's avatar URL is set to: {s}")
+                    },
+                    (ProfileFieldName::DisplayName, None) => {
+                        format!("Your profile's display name is currently unset")
+                    },
+                    (ProfileFieldName::TimeZone, None) => {
+                        format!("Your profile's timezone is currently unset")
+                    },
+                    (ProfileFieldName::AvatarUrl, None) => {
+                        format!("Your profile's avatar URL is currently unset")
+                    },
+                    (f, None) => {
+                        format!("Your profile's {f:?} is currently unset")
+                    },
+                    (f, Some(s)) => {
+                        format!("Your profile's {f:?} is set to {s:?}")
+                    },
+                };
+
+                Ok(vec![(Action::ShowInfoMessage(msg.into()), ctx)])
             },
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -715,13 +715,13 @@ impl Application {
                         format!("Your profile's avatar URL is set to: {s}")
                     },
                     (ProfileFieldName::DisplayName, None) => {
-                        format!("Your profile's display name is currently unset")
+                        "Your profile's display name is currently unset".into()
                     },
                     (ProfileFieldName::TimeZone, None) => {
-                        format!("Your profile's timezone is currently unset")
+                        "Your profile's timezone is currently unset".into()
                     },
                     (ProfileFieldName::AvatarUrl, None) => {
-                        format!("Your profile's avatar URL is currently unset")
+                        "Your profile's avatar URL is currently unset".into()
                     },
                     (f, None) => {
                         format!("Your profile's {f:?} is currently unset")


### PR DESCRIPTION
This adds new `:self [name|avatar|timezone]` commands for updating user profile information. (Although as far as I can tell, I don't think any servers have actually added support for `m.tz` information yet?)

I haven't included it here, but at some point it would be good to have a `:self avatar upload` command to upload a new file from disk.