### PR TITLE
Update `Cargo.toml` to `0.0.12-alpha.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "iamb"
-version = "0.0.12-alpha.1"
+version = "0.0.12-alpha.2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iamb"
-version = "0.0.12-alpha.1"
+version = "0.0.12-alpha.2"
 edition = "2024"
 authors = ["Ulyssa <git@ulyssa.dev>"]
 repository = "https://github.com/ulyssa/iamb"
@@ -143,7 +143,7 @@ assets = [
 ]
 
 [package.metadata.generate-rpm]
-version = "0.0.12_alpha.1"
+version = "0.0.12_alpha.2"
 assets = [
     # Binary:
     { source = "target/release/iamb", dest = "/usr/bin/iamb", mode = "755" },


### PR DESCRIPTION
A `0.0.12-alpha.2` pre-release with some of the more recent changes. 