### PR TITLE
Fix image preview position for narrow windows

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -656,7 +656,7 @@ enum MessageColumns {
 impl MessageColumns {
     fn user_gutter_width(&self, settings: &ApplicationSettings) -> u16 {
         if let MessageColumns::One = self {
-            0
+            2
         } else {
             settings.tunables.user_gutter_width as u16
         }


### PR DESCRIPTION
If only one message column is shown, the message text is indented by two spaces instead of the `user_gutter_width`. The method `user_gutter_width()` is used to calculate the x offset of the message for image previews and reports 0, leading to image previews being rendered two characters left of the placeholder.