### PR TITLE
Add MatrixRTC + LiveKit voice call support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - 'voip-**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - 'voip-**'
   pull_request:
     branches:
       - main
@@ -45,6 +46,67 @@ jobs:
         reporter: 'github-check'
     - name: Run tests
       run: cargo test --locked
+
+  voip:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            target-dir: target
+          - platform: macos-latest
+            target-dir: target
+          # Keep the target directory short: the prebuilt libwebrtc tree
+          # unpacks deeply and blows past MAX_PATH under D:\a\iamb\iamb.
+          - platform: windows-latest
+            target-dir: C:/t
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 90
+    env:
+      CARGO_TARGET_DIR: ${{ matrix.target-dir }}
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust (1.93 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.93
+      with:
+          components: clippy
+    # webrtc-sys unwraps pkg_config for glib-2.0/gobject-2.0/gio-2.0, so the
+    # headers are a hard build dependency. X11/drm/gbm/VA-API are not: they are
+    # dlopened through stubs shipped in the crate.
+    - name: Install system dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libglib2.0-dev
+    - name: Enable long paths (Windows)
+      if: runner.os == 'Windows'
+      run: git config --system core.longpaths true
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    # A cold build downloads and unpacks ~1.4GB of prebuilt libwebrtc into the
+    # `scratch` crate's directory under CARGO_TARGET_DIR. Cache it separately
+    # from the rest of target/, which we let cargo rebuild.
+    - name: Cache prebuilt libwebrtc
+      uses: actions/cache@v4
+      with:
+        path: ${{ matrix.target-dir }}/*/build/scratch-*/out/livekit_webrtc
+        key: ${{ runner.os }}-libwebrtc-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Check Clippy
+      run: cargo clippy --locked --features voip --all-targets -- --deny warnings
+    - name: Build
+      run: cargo build --locked --features voip
+    - name: Run tests
+      run: cargo test --locked --features voip
 
   nix-flake-test:
     name: Flake checks ❄️

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -728,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bmrng"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54df9073108f1558f90ae6c5bf5ab9c917c4185f5527b280c87a993cbead0ac"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +961,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -957,7 +979,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -985,6 +1007,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1300,6 +1333,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00424da159cc5adcb4eeea7e7b5cb1d96df41f5fa695ec596922181bdc36232a"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash 0.2.0",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e05269dbed4dab7072ae0f04ef31799ad189d52ce2ac12710c2997b754f86a"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f017b07e0da7f425642339faff0edc9f0de6459a18180183d086d1f3381e89"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293d267f43a5778bf3b89fff2a658f081166e7f152d9640e2ee3d917d065a5fc"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd233dc128223fe85d2afa5c617c79743c0f47fb495b69234b5da680d4986a"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1426,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -1329,7 +1448,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -1342,8 +1461,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1367,6 +1497,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "date_header"
@@ -1531,6 +1667,21 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "device-info"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ca8e71544c1b67dcdbc2699ab258828aff985e5bc8d5f6b486d90d7df2f848"
+dependencies = [
+ "core-foundation",
+ "jni 0.21.1",
+ "libc",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1997,6 +2148,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "from_variants"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e859c8f2057687618905dbe99fc76e836e0a69738865ef90e46fc214a41bbf2"
+dependencies = [
+ "from_variants_impl",
+]
+
+[[package]]
+name = "from_variants_impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a5e644a80e6d96b2b4910fa7993301d7b7926c045b475b62202b20a36ce69e"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2485,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2459,6 +2643,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2470,7 +2655,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2492,6 +2677,7 @@ name = "iamb"
 version = "0.0.12-alpha.2"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "chrono",
  "clap",
@@ -2511,6 +2697,7 @@ dependencies = [
  "lazy_static 1.5.0",
  "libc",
  "linkify",
+ "livekit",
  "markup5ever_rcdom",
  "matrix-sdk",
  "matrix-sdk-base",
@@ -2528,6 +2715,7 @@ dependencies = [
  "ratatui-image",
  "regex",
  "rpassword",
+ "rustls",
  "serde",
  "serde_json",
  "shellexpand",
@@ -2904,6 +3092,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2925,6 +3122,22 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2932,7 +3145,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -2951,6 +3164,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3009,6 +3231,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3096,6 +3333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,12 +3369,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "libwebrtc"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2da2ccaceaf34cf580c2b6819c57f80c85e53f7da7e8cf070b1d0a7ba12f3b3"
+dependencies = [
+ "cxx",
+ "jni 0.21.1",
+ "js-sys",
+ "lazy_static 1.5.0",
+ "livekit-runtime",
+ "log",
+ "parking_lot 0.12.5",
+ "rtrb",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webrtc-sys",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3164,6 +3444,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "livekit"
+version = "0.7.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63eeb45aa7d13d3e5c0009ea39c9ce8b7a3587f795eb7c3a13aa4880637295f"
+dependencies = [
+ "base64 0.22.1",
+ "bmrng",
+ "bytes",
+ "chrono",
+ "futures-util",
+ "lazy_static 1.5.0",
+ "libloading",
+ "libwebrtc",
+ "livekit-api",
+ "livekit-common",
+ "livekit-data-stream",
+ "livekit-datatrack",
+ "livekit-protocol",
+ "livekit-runtime",
+ "log",
+ "parking_lot 0.12.5",
+ "prost 0.12.6",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "livekit-api"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1006f7c009369fe5f16f2eb6e93d6d0dcb2b427306a2f61b26ff5d2e440ec282"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "device-info",
+ "flate2",
+ "futures-util",
+ "hmac",
+ "http",
+ "jsonwebtoken",
+ "livekit-protocol",
+ "livekit-runtime",
+ "log",
+ "os_info",
+ "parking_lot 0.12.5",
+ "pbjson-types",
+ "prost 0.12.6",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "rustls-native-certs",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "url",
+]
+
+[[package]]
+name = "livekit-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a76cd816c062654d105b697ebab136da87d14126ee77b2f13280cb895bcb58"
+dependencies = [
+ "livekit-protocol",
+]
+
+[[package]]
+name = "livekit-data-stream"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ad1cca8f05fbe29026d99931884641199df544c33777d1f1b321df6f1031dd"
+dependencies = [
+ "bmrng",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures-util",
+ "livekit-common",
+ "livekit-protocol",
+ "log",
+ "parking_lot 0.12.5",
+ "prost 0.12.6",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "livekit-datatrack"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201bec4becf4db2b0af616a73ff3b2421f6af3693c287b82f5182028ee36e5f5"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "from_variants",
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "livekit-protocol",
+ "livekit-runtime",
+ "log",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "livekit-protocol"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d26880e94e2f9bab298445e7d86a3794453d211a12ddbd051bd9991a343f9ff"
+dependencies = [
+ "pbjson",
+ "pbjson-types",
+ "prost 0.12.6",
+ "serde",
+]
+
+[[package]]
+name = "livekit-runtime"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532e84c6cdc5fe774f2b5d9912597b5f3bea561927a48296d03e24549d21c3f6"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3220,7 +3640,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -3380,7 +3800,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.1",
- "reqwest",
+ "reqwest 0.13.4",
  "ruma",
  "rustls",
  "rustls-native-certs",
@@ -3503,7 +3923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef37395fffb7c916f7109ab0d16d8ca599403dd8164d08c0d966176b66ede47"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures-util",
  "getrandom 0.4.2",
  "gloo-utils",
@@ -3575,7 +3995,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f48f304e553fb6200b1d7d1f77a88fd182076d4b25624e9dbfa42d6a37de35e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chacha20poly1305",
  "getrandom 0.2.17",
@@ -3762,6 +4182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,6 +4213,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3934,7 +4372,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -3954,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
 dependencies = [
  "oauth2",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -3975,6 +4413,27 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -4000,6 +4459,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4030,6 +4521,49 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4099,6 +4633,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4224,6 +4774,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbjson"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.11.0",
+ "prost 0.12.6",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost 0.12.6",
+ "prost-build",
+ "serde",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,6 +4865,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
 ]
 
 [[package]]
@@ -4569,12 +5166,56 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.11.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost 0.12.6",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4588,6 +5229,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5138,11 +5788,51 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5246,6 +5936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtrb"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
+
+[[package]]
 name = "ruma"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5291,7 +5987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3b4f00112791b490acce57df1ce3eb3f88899b045bebcff8a29f75369640cc"
 dependencies = [
  "as_variant",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "date_header",
  "form_urlencoded",
@@ -5442,6 +6138,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5478,7 +6175,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -5553,6 +6250,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "sealed"
@@ -5718,6 +6421,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -5934,6 +6648,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5953,7 +6673,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6072,6 +6792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termina"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6123,7 +6852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -6134,7 +6863,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -6301,6 +7030,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -6337,6 +7067,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6537,7 +7283,7 @@ checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
  "nom 8.0.0",
- "petgraph",
+ "petgraph 0.8.3",
 ]
 
 [[package]]
@@ -6545,6 +7291,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "url",
+]
 
 [[package]]
 name = "typed-arena"
@@ -6806,7 +7571,7 @@ checksum = "b98bf83c0992966775b8012f194b07b44928996163e5a05b741b43891571ae5b"
 dependencies = [
  "aes",
  "arrayvec",
- "base64",
+ "base64 0.22.1",
  "base64ct",
  "cbc",
  "chacha20poly1305",
@@ -6816,7 +7581,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "matrix-pickle",
- "prost",
+ "prost 0.14.4",
  "rand 0.8.6",
  "serde",
  "serde_bytes",
@@ -7128,6 +7893,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "webrtc-sys"
+version = "0.3.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca21867ef47ef33e43564a6d1e6947658728579216da9c97c2415ca555f2c96"
+dependencies = [
+ "cc",
+ "cxx",
+ "cxx-build",
+ "glob",
+ "log",
+ "pkg-config",
+ "webrtc-sys-build",
+]
+
+[[package]]
+name = "webrtc-sys-build"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d46da6b5a5cbd091fae0400f77189f4ca4807c0d9442b85838a584f28720570"
+dependencies = [
+ "anyhow",
+ "fs2",
+ "regex",
+ "reqwest 0.12.28",
+ "scratch",
+ "semver",
+ "zip",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7178,7 +7973,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float 4.6.0",
- "strsim",
+ "strsim 0.11.1",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -7471,6 +8266,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7503,6 +8307,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7558,6 +8377,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7570,6 +8395,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7579,6 +8410,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7606,6 +8443,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7615,6 +8458,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7630,6 +8479,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7639,6 +8494,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7683,7 +8544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -7694,7 +8555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -8021,6 +8882,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ max_level_error = ["tracing/max_level_error"]
 max_level_off = ["tracing/max_level_off"]
 chafa-dyn = ["ratatui-image/chafa-dyn"]
 chafa-static = ["ratatui-image/chafa-static"]
+voip = [
+    "dep:livekit",
+    "dep:base64",
+    "dep:rustls",
+    "matrix-sdk/experimental-send-custom-to-device",
+]
 
 [build-dependencies.vergen-gitcl]
 version = "9"
@@ -31,6 +37,7 @@ features = ["build"]
 
 [dependencies]
 anyhow = "1.0"
+base64 = { version = "0.22.1", optional = true }
 bitflags = "2.3"
 chrono = "0.4"
 clap = {version = "^4.6", features = ["derive"]}
@@ -93,6 +100,25 @@ version = "0.0.26"
 
 [dependencies.matrix-sdk-base]
 version = "0.18.0"
+
+# VoIP audio + LiveKit SFU, enabled by the `voip` feature.
+[dependencies.livekit]
+version = "0.7.52"
+optional = true
+default-features = false
+# `tokio` = signal-client-tokio + tokio runtime (livekit's default backend);
+# rustls-tls-native-roots keeps us on rustls instead of native-tls/OpenSSL.
+features = ["tokio", "rustls-tls-native-roots"]
+
+# LiveKit's WebSocket TLS goes through rustls, whose automatic CryptoProvider
+# selection panics when the dependency graph enables both `ring` and `aws-lc-rs`
+# (it does, via the two reqwest majors). We install the `ring` provider as the
+# process default at startup; this dependency is only to name that provider.
+[dependencies.rustls]
+version = "0.23"
+optional = true
+default-features = false
+features = ["ring"]
 
 [dependencies.matrix-sdk]
 version = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ voip = [
     "matrix-sdk/experimental-send-custom-to-device",
 ]
 
+# ruma's `EventContent` derive emits `#[cfg(ruma_unstable_exhaustive_types)]`,
+# which is not a cfg we set. Declare it so `clippy -- --deny warnings` passes.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ruma_unstable_exhaustive_types)'] }
+
 [build-dependencies.vergen-gitcl]
 version = "9"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -86,11 +86,56 @@ system's SQLite instead of using a bundled SQLite.
 
 - `bundled`: use bundled SQLite instead of system library (default)
 - `desktop`: enable desktop notifications and clipboard support (default)
+- `voip`: enable MatrixRTC voice calls over a LiveKit SFU (see [Voice calls](#voice-calls))
 - `max_level_warn`: disable support for more verbose logging than the default `warn` level
 - `max_level_error`: disable support for more verbose logging than the `error` level
 - `max_level_off`: disable all logs at compile time
 - `chafa-dyn`: use [chafa](https://hpjansson.org/chafa/) as a dynamic library for halfblock rendering
 - `chafa-static`: use [chafa](https://hpjansson.org/chafa/) as a static library for halfblock rendering
+
+### Voice calls
+
+The `voip` feature is off by default. Build it with:
+
+```
+cargo install --locked --features voip --path .
+```
+
+The first build downloads a prebuilt libwebrtc (about 1.4GB unpacked), so it
+takes a while.
+
+**Build dependencies.** On Linux, `webrtc-sys` compiles C++20 bindings, so it
+needs a C++ compiler. It also needs the GLib development headers, which it
+finds through `pkg-config` (`glib-2.0`, `gobject-2.0`, and `gio-2.0`). The
+build fails without either:
+
+- Debian/Ubuntu: `apt install g++ pkg-config libglib2.0-dev`
+- Fedora: `dnf install gcc-c++ pkgconf-pkg-config glib2-devel`
+- Arch Linux: `pacman -S gcc pkgconf glib2`
+
+The headers are only needed to compile. The finished binary does not link
+against GLib, and X11, DRM, GBM, and VA-API are loaded at runtime only if
+they are present. macOS and Windows need no extra packages.
+
+**Server requirements.** Calls use [MatrixRTC], with media relayed through a
+[LiveKit] SFU. Calling needs:
+
+- a reachable LiveKit SFU
+- a lk-jwt-service`endpoint, which exchanges your Matrix
+  OpenID token for a LiveKit access token
+- a homeserver whose `/.well-known/matrix/client` lists that service under
+  `org.matrix.msc4143.rtc_foci`, for example:
+
+  ```json
+  "org.matrix.msc4143.rtc_foci": [
+    { "type": "livekit", "livekit_service_url": "https://livekit-jwt.example.com" }
+  ]
+  ```
+
+When you join a call that has already started, iamb uses the SFU chosen by the
+people already in it, so the `.well-known` entry is only read when you start
+a call. This is the same setup Element Call uses; see its
+[Self Hosting Guide](https://element.io/blog/end-to-end-encrypted-voice-and-video-for-self-hosted-community-users/)
 
 ## Installation (via `crates.io`)
 
@@ -195,3 +240,7 @@ iamb is released under the [Apache License, Version 2.0].
 [iamb.chat]: https://iamb.chat
 [well_known_entry]: https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixclient
 [rustup]: https://rustup.rs/
+[MatrixRTC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4143
+[LiveKit]: https://github.com/livekit/livekit
+[lk-jwt-service]: https://github.com/element-hq/lk-jwt-service
+[element-call-self-hosting]: https://github.com/element-hq/element-call/blob/livekit/docs/self-hosting.md

--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -273,6 +273,28 @@ Delete your per-room user display name.
 .It Sy ":room user name show"
 Show the display name you currently have in this room.
 .El
+
+.Sh "CALL COMMANDS"
+.Bl -tag -width Ds
+.It Sy ":call"
+Join the voice call in the currently selected room, or answer a call you have been rung about.
+Your audio is encrypted when the room is encrypted, and sent in the clear when it is not.
+.It Sy ":call hangup"
+Leave the call and withdraw your membership from it.
+.It Sy ":call decline"
+Reject a call you have been rung about without joining it.
+.It Sy ":call mute"
+Mute your microphone.
+.It Sy ":call unmute"
+Unmute your microphone.
+.It Sy ":call devices"
+List the available microphones and speakers.
+.It Sy ":call device mic [device]"
+Choose the microphone by index or name.
+.It Sy ":call device speaker [device]"
+Choose the speaker by index or name.
+.El
+
 .Sh "SPACE COMMANDS"
 .Bl -tag -width Ds
 .It Sy ":space child set [room] [arguments]"

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,9 @@
             cargo-tarpaulin
             cargo-watch
             sqlite
+            # Needed to build `--features voip`.
+            pkg-config
+            glib
           ];
 
           shellHook = ''

--- a/src/base.rs
+++ b/src/base.rs
@@ -109,7 +109,7 @@ use crate::{
 };
 
 #[cfg(feature = "voip")]
-use crate::voip::{CallStatus, IncomingCall, devices::DeviceKind};
+use crate::voip::{IncomingCall, devices::DeviceKind};
 
 /// The set of characters used in different Matrix IDs.
 pub const MATRIX_ID_WORD: WordStyle = WordStyle::CharSet(is_mxid_char);
@@ -2016,23 +2016,12 @@ pub struct ChatStore {
 
     /// Notifications that should be dismissed when the user opens the room.
     pub open_notifications: HashMap<OwnedRoomId, Vec<NotificationHandle>>,
-
-    /// The call we are currently joined to, if any.
-    ///
-    /// Read-only here: the worker owns this state and is its only writer.
-    #[cfg(feature = "voip")]
-    pub call_status: CallStatus,
 }
 
 impl ChatStore {
     /// Create a new [ChatStore].
     pub fn new(worker: Requester, settings: ApplicationSettings) -> Self {
         let previews = PreviewManager::new(&settings);
-
-        // Share the worker's handle rather than keeping a second copy of the
-        // call state: the worker is the only thing that can know it.
-        #[cfg(feature = "voip")]
-        let call_status = worker.call_status.clone();
 
         ChatStore {
             worker,
@@ -2052,8 +2041,6 @@ impl ChatStore {
             ring_bell: false,
             focused: true,
             open_notifications: Default::default(),
-            #[cfg(feature = "voip")]
-            call_status,
         }
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -74,6 +74,10 @@ use matrix_sdk::{
     },
 };
 
+#[cfg(feature = "voip")]
+use crate::voip::devices::DeviceKind;
+#[cfg(feature = "voip")]
+use crate::voip::{CallStatus, IncomingCall};
 use modalkit::{
     actions::Action,
     editing::{
@@ -628,6 +632,30 @@ pub enum KeysAction {
     Import(String, String),
 }
 
+/// An action performed against the current room's call.
+#[cfg(feature = "voip")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CallAction {
+    /// Join the call in the currently focused room.
+    ///
+    /// Media encryption follows the room: an encrypted room gets encrypted
+    /// media, an unencrypted one sends in the clear. That is what Element Call
+    /// does, and matching it matters because LiveKit only installs a decryptor
+    /// when encryption is on, so a peer on the other setting is inaudible in
+    /// *both* directions.
+    Join,
+    /// Leave the call in the currently focused room.
+    Hangup,
+    /// Decline a call we have been rung about, without joining it.
+    Decline,
+    /// Set the local microphone mute state (`true` = muted).
+    Mute(bool),
+    /// Show the available audio devices.
+    Devices,
+    /// Choose an audio device, by index or by name.
+    SetDevice(DeviceKind, String),
+}
+
 /// An action that the main program loop should.
 ///
 /// See [the commands module][super::commands] for where these are usually created.
@@ -644,6 +672,10 @@ pub enum IambAction {
 
     /// Perform an action on the current space.
     Space(SpaceAction),
+
+    /// Perform an action on the current room's call.
+    #[cfg(feature = "voip")]
+    Call(CallAction),
 
     /// Open a URL.
     OpenLink(String),
@@ -680,6 +712,13 @@ impl From<HomeserverAction> for IambAction {
     }
 }
 
+#[cfg(feature = "voip")]
+impl From<CallAction> for IambAction {
+    fn from(act: CallAction) -> Self {
+        IambAction::Call(act)
+    }
+}
+
 impl From<MessageAction> for IambAction {
     fn from(act: MessageAction) -> Self {
         IambAction::Message(act)
@@ -712,6 +751,8 @@ impl ApplicationAction for IambAction {
             IambAction::Keys(..) => SequenceStatus::Break,
             IambAction::Message(..) => SequenceStatus::Break,
             IambAction::Space(..) => SequenceStatus::Break,
+            #[cfg(feature = "voip")]
+            IambAction::Call(..) => SequenceStatus::Break,
             IambAction::Room(..) => SequenceStatus::Break,
             IambAction::OpenLink(..) => SequenceStatus::Break,
             IambAction::Send(..) => SequenceStatus::Break,
@@ -728,6 +769,8 @@ impl ApplicationAction for IambAction {
             IambAction::Keys(..) => SequenceStatus::Atom,
             IambAction::Message(..) => SequenceStatus::Atom,
             IambAction::Space(..) => SequenceStatus::Atom,
+            #[cfg(feature = "voip")]
+            IambAction::Call(..) => SequenceStatus::Atom,
             IambAction::OpenLink(..) => SequenceStatus::Atom,
             IambAction::Room(..) => SequenceStatus::Atom,
             IambAction::Send(..) => SequenceStatus::Atom,
@@ -744,6 +787,8 @@ impl ApplicationAction for IambAction {
             IambAction::Keys(..) => SequenceStatus::Ignore,
             IambAction::Message(..) => SequenceStatus::Ignore,
             IambAction::Space(..) => SequenceStatus::Ignore,
+            #[cfg(feature = "voip")]
+            IambAction::Call(..) => SequenceStatus::Ignore,
             IambAction::Room(..) => SequenceStatus::Ignore,
             IambAction::OpenLink(..) => SequenceStatus::Ignore,
             IambAction::Send(..) => SequenceStatus::Ignore,
@@ -759,6 +804,8 @@ impl ApplicationAction for IambAction {
             IambAction::Homeserver(..) => false,
             IambAction::Message(..) => false,
             IambAction::Space(..) => false,
+            #[cfg(feature = "voip")]
+            IambAction::Call(..) => false,
             IambAction::Room(..) => false,
             IambAction::Keys(..) => false,
             IambAction::Send(..) => false,
@@ -945,6 +992,11 @@ pub enum IambError {
     /// A generic error that doesn't need a specific error type.
     #[error("{0}")]
     Custom(String),
+
+    /// A failure while setting up or tearing down a voice call.
+    #[cfg(feature = "voip")]
+    #[error("Call error: {0}")]
+    Call(String),
 }
 
 impl From<IambError> for UIError<IambInfo> {
@@ -1172,6 +1224,35 @@ pub struct RoomInfo {
 
     /// The last time the room was rendered, used to detect if it is currently open.
     pub draw_last: Option<Instant>,
+
+    /// Whether this room had a call in progress the last time an
+    /// `m.call.member` event arrived.
+    ///
+    /// Only used to spot the nobody-to-somebody transition worth notifying on.
+    /// The participants themselves are not tracked here - the SDK already keeps
+    /// that state, and [`crate::windows::call_participants`] reads it from
+    /// there.
+    #[cfg(feature = "voip")]
+    pub had_active_call: bool,
+
+    /// A call we have been rung about and have not yet answered or declined.
+    ///
+    /// Set from `m.rtc.notification`, and cleared when we join, when we decline,
+    /// or when the call it announced ends. Reads must also check
+    /// [`IncomingCall::is_live`], since a ring that simply timed out has nothing
+    /// to clear it.
+    #[cfg(feature = "voip")]
+    pub incoming_call: Option<IncomingCall>,
+
+    /// Whether this room's current call has already been announced to the user.
+    ///
+    /// A call generates *two* independent reasons to notify - the explicit
+    /// `m.rtc.notification` and the `m.call.member` state going from empty to
+    /// occupied - and clients that send both would otherwise pop two
+    /// notifications for one call. First one through wins; cleared when the call
+    /// ends, so the next call announces again.
+    #[cfg(feature = "voip")]
+    pub call_announced: bool,
 }
 
 impl Default for RoomInfo {
@@ -1194,6 +1275,12 @@ impl Default for RoomInfo {
             display_names: Default::default(),
             draw_last: Default::default(),
             unloaded_edits: Default::default(),
+            #[cfg(feature = "voip")]
+            had_active_call: false,
+            #[cfg(feature = "voip")]
+            incoming_call: None,
+            #[cfg(feature = "voip")]
+            call_announced: false,
         }
     }
 }
@@ -1930,12 +2017,23 @@ pub struct ChatStore {
 
     /// Notifications that should be dismissed when the user opens the room.
     pub open_notifications: HashMap<OwnedRoomId, Vec<NotificationHandle>>,
+
+    /// The call we are currently joined to, if any.
+    ///
+    /// Read-only here: the worker owns this state and is its only writer.
+    #[cfg(feature = "voip")]
+    pub call_status: CallStatus,
 }
 
 impl ChatStore {
     /// Create a new [ChatStore].
     pub fn new(worker: Requester, settings: ApplicationSettings) -> Self {
         let previews = PreviewManager::new(&settings);
+
+        // Share the worker's handle rather than keeping a second copy of the
+        // call state: the worker is the only thing that can know it.
+        #[cfg(feature = "voip")]
+        let call_status = worker.call_status.clone();
 
         ChatStore {
             worker,
@@ -1955,6 +2053,8 @@ impl ChatStore {
             ring_bell: false,
             focused: true,
             open_notifications: Default::default(),
+            #[cfg(feature = "voip")]
+            call_status,
         }
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -74,10 +74,6 @@ use matrix_sdk::{
     },
 };
 
-#[cfg(feature = "voip")]
-use crate::voip::devices::DeviceKind;
-#[cfg(feature = "voip")]
-use crate::voip::{CallStatus, IncomingCall};
 use modalkit::{
     actions::Action,
     editing::{
@@ -111,6 +107,9 @@ use crate::{
     preview::PreviewManager,
     worker::Requester,
 };
+
+#[cfg(feature = "voip")]
+use crate::voip::{CallStatus, IncomingCall, devices::DeviceKind};
 
 /// The set of characters used in different Matrix IDs.
 pub const MATRIX_ID_WORD: WordStyle = WordStyle::CharSet(is_mxid_char);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,6 +19,8 @@ use modalkit::{
     prelude::{MoveDir1D, OpenTarget},
 };
 
+#[cfg(feature = "voip")]
+use crate::base::CallAction;
 use crate::base::{
     CreateRoomFlags,
     CreateRoomType,
@@ -38,6 +40,8 @@ use crate::base::{
     SpaceAction,
     VerifyAction,
 };
+#[cfg(feature = "voip")]
+use crate::voip::devices::DeviceKind;
 
 type ProgContext = CommandContext;
 type ProgResult = CommandResult<ProgramCommand>;
@@ -190,6 +194,39 @@ fn iamb_knock(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
     let step = CommandStep::Continue(act.into(), ctx.context.clone());
 
+    return Ok(step);
+}
+
+#[cfg(feature = "voip")]
+fn iamb_call(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
+    let args = desc.arg.strings()?;
+
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+
+    let act = match args.as_slice() {
+        [] | ["join"] => CallAction::Join,
+        ["hangup"] => CallAction::Hangup,
+        ["decline"] => CallAction::Decline,
+        ["mute"] => CallAction::Mute(true),
+        ["unmute"] => CallAction::Mute(false),
+        ["devices"] => CallAction::Devices,
+        ["device", kind, spec @ ..] if !spec.is_empty() => {
+            let kind = match *kind {
+                "mic" | "microphone" => DeviceKind::Microphone,
+                "speaker" | "output" => DeviceKind::Speaker,
+                _ => return Err(CommandError::InvalidArgument),
+            };
+
+            // Device names almost always contain spaces ("Yeti Stereo
+            // Microphone"), so take the rest of the line rather than making the
+            // user quote it.
+            CallAction::SetDevice(kind, spec.join(" "))
+        },
+        _ => return Err(CommandError::InvalidArgument),
+    };
+
+    let iact = IambAction::from(act);
+    let step = CommandStep::Continue(iact.into(), ctx.context.clone());
     return Ok(step);
 }
 
@@ -1049,6 +1086,8 @@ pub fn add_iamb_commands(cmds: &mut ProgramCommands) {
         f: iamb_invite,
     });
     cmds.add_command(ProgramCommand { name: "join".into(), aliases: vec![], f: iamb_join });
+    #[cfg(feature = "voip")]
+    cmds.add_command(ProgramCommand { name: "call".into(), aliases: vec![], f: iamb_call });
     cmds.add_command(ProgramCommand { name: "keys".into(), aliases: vec![], f: iamb_keys });
     cmds.add_command(ProgramCommand {
         name: "knock".into(),
@@ -1159,6 +1198,56 @@ mod tests {
     use matrix_sdk::ruma::{owned_room_id, user_id};
     use modalkit::actions::WindowAction;
     use modalkit::editing::context::EditContext;
+
+    #[cfg(feature = "voip")]
+    #[test]
+    fn test_cmd_call() {
+        let mut cmds = setup_commands();
+
+        let call = |cmds: &mut ProgramCommands, cmd: &str| {
+            cmds.input_cmd(cmd, EditContext::default()).map(|res| {
+                assert_eq!(res.len(), 1);
+                res.into_iter().next().unwrap().0
+            })
+        };
+
+        for (cmd, expected) in [
+            (":call", CallAction::Join),
+            (":call join", CallAction::Join),
+            (":call hangup", CallAction::Hangup),
+            (":call decline", CallAction::Decline),
+            (":call mute", CallAction::Mute(true)),
+            (":call unmute", CallAction::Mute(false)),
+            (":call devices", CallAction::Devices),
+            (":call device mic 1", CallAction::SetDevice(DeviceKind::Microphone, "1".into())),
+            (":call device speaker 0", CallAction::SetDevice(DeviceKind::Speaker, "0".into())),
+            // A device name is the rest of the line, unquoted, because real
+            // names are full of spaces.
+            (
+                ":call device mic Yeti Stereo Microphone",
+                CallAction::SetDevice(DeviceKind::Microphone, "Yeti Stereo Microphone".into()),
+            ),
+        ] {
+            let act = IambAction::from(expected);
+            assert_eq!(call(&mut cmds, cmd).unwrap(), act.into(), "for {cmd:?}");
+        }
+
+        // A device kind with nothing to select, an unknown kind, and an unknown
+        // subcommand are all rejected rather than silently doing something.
+        // The encryption of a call's media is the room's to decide, so there is
+        // no longer a switch for it.
+        for cmd in [
+            ":call device mic",
+            ":call device",
+            ":call device ears 1",
+            ":call bogus",
+            ":call reject",
+            ":call unencrypted",
+            ":call join unencrypted",
+        ] {
+            assert!(call(&mut cmds, cmd).is_err(), "for {:?}", cmd);
+        }
+    }
 
     #[test]
     fn test_cmd_verify() {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,8 +19,6 @@ use modalkit::{
     prelude::{MoveDir1D, OpenTarget},
 };
 
-#[cfg(feature = "voip")]
-use crate::base::CallAction;
 use crate::base::{
     CreateRoomFlags,
     CreateRoomType,
@@ -40,8 +38,9 @@ use crate::base::{
     SpaceAction,
     VerifyAction,
 };
+
 #[cfg(feature = "voip")]
-use crate::voip::devices::DeviceKind;
+use crate::{base::CallAction, voip::devices::DeviceKind};
 
 type ProgContext = CommandContext;
 type ProgResult = CommandResult<ProgramCommand>;

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -419,6 +419,23 @@ fn complete_iamb_unreads(args: Vec<String>) -> Vec<String> {
     }
 }
 
+/// Tab completion for `:call`
+#[cfg(feature = "voip")]
+fn complete_iamb_call(args: Vec<String>) -> Vec<String> {
+    let subcmds = [
+        "join", "hangup", "decline", "mute", "unmute", "devices", "device",
+    ];
+
+    match args.len() {
+        1 => complete_choices(&args[0], &subcmds),
+        2 if args[0] == "device" => {
+            complete_choices(&args[1], &["mic", "microphone", "speaker", "output"])
+        },
+        // The device name is free text taken from the rest of the line.
+        _ => vec![],
+    }
+}
+
 /// Tab completion for `:create`
 fn complete_iamb_create(args: Vec<String>) -> Vec<String> {
     let options = ["++alias=", "++public", "++space", "++encrypted"];
@@ -583,6 +600,9 @@ fn complete_cmdarg(
     *cursor = new_cursor;
 
     let mut completions = match cmd.name.as_str() {
+        #[cfg(feature = "voip")]
+        "call" => complete_iamb_call(args),
+
         "create" => complete_iamb_create(args),
 
         "follow" => complete_choices(&args[0], &["next", "previous"]),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1188,6 +1188,10 @@ impl IambConfig {
 #[derive(Clone)]
 pub struct ApplicationSettings {
     pub layout_json: PathBuf,
+
+    /// Where the remembered call audio devices are stored.
+    #[cfg(feature = "voip")]
+    pub voip_json: PathBuf,
     pub session_json: PathBuf,
     pub session_json_old: PathBuf,
     pub sled_dir: PathBuf,
@@ -1325,9 +1329,18 @@ impl ApplicationSettings {
         let mut layout_json = cache_dir.clone();
         layout_json.push("layout.json");
 
+        #[cfg(feature = "voip")]
+        let voip_json = {
+            let mut path = cache_dir.clone();
+            path.push("voip.json");
+            path
+        };
+
         let settings = ApplicationSettings {
             sled_dir,
             layout_json,
+            #[cfg(feature = "voip")]
+            voip_json,
             session_json,
             session_json_old,
             sqlite_dir,
@@ -1347,6 +1360,35 @@ impl ApplicationSettings {
         let reader = BufReader::new(file);
         let session = serde_json::from_reader(reader).map_err(IambError::from)?;
         Ok(session)
+    }
+
+    /// Read the remembered call audio devices.
+    /// A missing or unreadable file just means no devices have been chosen yet.
+    #[cfg(feature = "voip")]
+    pub fn read_voip_devices(&self) -> crate::voip::devices::DevicePreferences {
+        let Ok(file) = File::open(self.voip_json.as_path()) else {
+            return Default::default();
+        };
+
+        serde_json::from_reader(BufReader::new(file)).unwrap_or_default()
+    }
+
+    /// Remember the chosen call audio devices for the next run.
+    #[cfg(feature = "voip")]
+    pub fn write_voip_devices(
+        &self,
+        devices: &crate::voip::devices::DevicePreferences,
+    ) -> Result<(), IambError> {
+        if let Some(dir) = self.voip_json.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+
+        let file = File::create(self.voip_json.as_path())?;
+        let writer = BufWriter::new(file);
+
+        serde_json::to_writer(writer, devices).map_err(IambError::from)?;
+
+        Ok(())
     }
 
     pub fn write_session(&self, session: MatrixSession) -> Result<(), IambError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1192,6 +1192,10 @@ pub struct ApplicationSettings {
     /// Where the remembered call audio devices are stored.
     #[cfg(feature = "voip")]
     pub voip_json: PathBuf,
+
+    /// The remembered call audio devices, read from `voip_json` once at startup.
+    #[cfg(feature = "voip")]
+    pub voip_devices: crate::voip::devices::DevicePreferences,
     pub session_json: PathBuf,
     pub session_json_old: PathBuf,
     pub sled_dir: PathBuf,
@@ -1336,11 +1340,16 @@ impl ApplicationSettings {
             path
         };
 
+        #[cfg(feature = "voip")]
+        let voip_devices = Self::read_voip_devices(&voip_json);
+
         let settings = ApplicationSettings {
             sled_dir,
             layout_json,
             #[cfg(feature = "voip")]
             voip_json,
+            #[cfg(feature = "voip")]
+            voip_devices,
             session_json,
             session_json_old,
             sqlite_dir,
@@ -1365,20 +1374,26 @@ impl ApplicationSettings {
     /// Read the remembered call audio devices.
     /// A missing or unreadable file just means no devices have been chosen yet.
     #[cfg(feature = "voip")]
-    pub fn read_voip_devices(&self) -> crate::voip::devices::DevicePreferences {
-        let Ok(file) = File::open(self.voip_json.as_path()) else {
+    fn read_voip_devices(path: &Path) -> crate::voip::devices::DevicePreferences {
+        let Ok(file) = File::open(path) else {
             return Default::default();
         };
 
         serde_json::from_reader(BufReader::new(file)).unwrap_or_default()
     }
 
-    /// Remember the chosen call audio devices for the next run.
+    /// Remember a chosen call audio device, now and for the next run.
+    ///
+    /// The in-memory preference is updated even if the write fails, since the
+    /// device has already been switched to for this session.
     #[cfg(feature = "voip")]
-    pub fn write_voip_devices(
-        &self,
-        devices: &crate::voip::devices::DevicePreferences,
+    pub fn set_voip_device(
+        &mut self,
+        kind: crate::voip::devices::DeviceKind,
+        name: String,
     ) -> Result<(), IambError> {
+        self.voip_devices.set(kind, name);
+
         if let Some(dir) = self.voip_json.parent() {
             std::fs::create_dir_all(dir)?;
         }
@@ -1386,7 +1401,7 @@ impl ApplicationSettings {
         let file = File::create(self.voip_json.as_path())?;
         let writer = BufWriter::new(file);
 
-        serde_json::to_writer(writer, devices).map_err(IambError::from)?;
+        serde_json::to_writer(writer, &self.voip_devices).map_err(IambError::from)?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,7 @@ impl Application {
         {
             // Only whether the banner is drawn matters: its content changing
             // does not move anything else on the screen.
-            let banner = _store.application.call_status.get().is_some();
+            let banner = _store.application.worker.call_status.get().is_some();
 
             if self.last_call_banner != banner {
                 self.last_call_banner = banner;
@@ -1224,9 +1224,7 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
     // Clean up the terminal on exit.
     restore_tty(enable_enhanced_keys, enable_mouse);
 
-    res?;
-
-    Ok(())
+    res.map_err(UIError::from)
 }
 
 fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocking::WorkerGuard {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,8 @@ use rand::distr::Alphanumeric;
 use temp_dir::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::Level;
+#[cfg(feature = "voip")]
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use modalkit::crossterm::{
@@ -88,6 +90,8 @@ mod worker;
 #[cfg(test)]
 mod tests;
 mod verifications;
+#[cfg(feature = "voip")]
+mod voip;
 
 use crate::{
     base::{
@@ -269,6 +273,14 @@ struct Application {
 
     /// Whether we need to do a full redraw (e.g., after running a subprocess).
     dirty: bool,
+
+    /// The window the last frame was drawn for, so that switching between them
+    /// can be noticed. See [`Application::resync_on_view_change`].
+    last_focus: Option<IambId>,
+
+    /// Whether the last frame was drawn with a call banner, for the same reason.
+    #[cfg(feature = "voip")]
+    last_call_banner: bool,
 }
 
 impl Application {
@@ -302,7 +314,40 @@ impl Application {
             focused: true,
             last_layout: None,
             dirty: true,
+            last_focus: None,
+            #[cfg(feature = "voip")]
+            last_call_banner: false,
         })
+    }
+
+    /// Ask for one full-clear redraw when the view is replaced wholesale.
+    ///
+    /// Switching rooms, and starting or ending a call, replace everything below
+    /// the border. The new view draws over the old one rather than replacing it,
+    /// leaving ghost text, so the screen has to be redrawn from scratch to
+    /// resync the terminal with ratatui's buffer.
+    ///
+    /// Setting [`Application::dirty`] gives exactly one cleared frame per
+    /// transition. Clearing for a *window of time* instead
+    fn resync_on_view_change(&mut self, _store: &ProgramStore) {
+        let focus = self.screen.current_window().map(|win| win.id());
+
+        if self.last_focus != focus {
+            self.last_focus = focus;
+            self.dirty = true;
+        }
+
+        #[cfg(feature = "voip")]
+        {
+            // Only whether the banner is drawn matters: its content changing
+            // does not move anything else on the screen.
+            let banner = _store.application.call_status.get().is_some();
+
+            if self.last_call_banner != banner {
+                self.last_call_banner = banner;
+                self.dirty = true;
+            }
+        }
     }
 
     fn redraw(&mut self, full: bool, store: &mut ProgramStore) -> Result<(), std::io::Error> {
@@ -364,7 +409,13 @@ impl Application {
 
     async fn step(&mut self) -> Result<TerminalKey, std::io::Error> {
         loop {
-            self.redraw(self.dirty, self.store.clone().lock().await.deref_mut())?;
+            {
+                let store = self.store.clone();
+                let mut locked = store.lock().await;
+
+                self.resync_on_view_change(&locked);
+                self.redraw(self.dirty, locked.deref_mut())?;
+            }
             self.dirty = false;
 
             if !poll(Duration::from_secs(1))? {
@@ -600,6 +651,10 @@ impl Application {
             },
             IambAction::Space(act) => {
                 self.screen.current_window_mut()?.space_command(act, ctx, store).await?
+            },
+            #[cfg(feature = "voip")]
+            IambAction::Call(act) => {
+                self.screen.current_window_mut()?.call_command(act, ctx, store).await?
             },
             IambAction::Room(act) => {
                 let acts = self.screen.current_window_mut()?.room_command(act, ctx, store).await?;
@@ -1044,11 +1099,80 @@ async fn login_normal(
     Ok(())
 }
 
+/// Saved duplicate of the real stderr, so it can be restored after being
+/// redirected by [`silence_native_stderr`]. `-1` means "not redirected".
+#[cfg(all(unix, feature = "voip"))]
+static SAVED_STDERR_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+/// Send native stderr to `/dev/null` while the TUI owns the terminal.
+///
+/// LiveKit pulls in libwebrtc, and opening audio devices goes through ALSA;
+/// both log directly to file descriptor 2, bypassing our file-based tracing. On
+/// the alternate screen those writes land on top of the UI and corrupt it -
+/// most visibly when a call starts (device + libwebrtc init) and ends (teardown).
+/// [`restore_native_stderr`] puts the real stderr back, and is called from
+/// [`restore_tty`] before any panic message is printed, so crashes are still
+/// visible.
+#[cfg(all(unix, feature = "voip"))]
+fn silence_native_stderr() {
+    use std::os::fd::AsRawFd;
+    use std::sync::atomic::Ordering;
+
+    if SAVED_STDERR_FD.load(Ordering::SeqCst) != -1 {
+        return;
+    }
+
+    let Ok(devnull) = std::fs::OpenOptions::new().write(true).open("/dev/null") else {
+        return;
+    };
+
+    // SAFETY: `dup`/`dup2` on the process's own descriptors. We keep the saved
+    // descriptor in `SAVED_STDERR_FD` and close it in `restore_native_stderr`.
+    unsafe {
+        let saved = libc::dup(libc::STDERR_FILENO);
+        if saved == -1 {
+            return;
+        }
+        if libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO) == -1 {
+            libc::close(saved);
+            return;
+        }
+        SAVED_STDERR_FD.store(saved, Ordering::SeqCst);
+    }
+}
+
+/// Restore the real stderr previously redirected by [`silence_native_stderr`].
+#[cfg(all(unix, feature = "voip"))]
+fn restore_native_stderr() {
+    use std::sync::atomic::Ordering;
+
+    let saved = SAVED_STDERR_FD.swap(-1, Ordering::SeqCst);
+    if saved == -1 {
+        return;
+    }
+
+    // SAFETY: `saved` is a descriptor we duplicated from stderr; move it back
+    // onto stderr and drop the duplicate.
+    unsafe {
+        libc::dup2(saved, libc::STDERR_FILENO);
+        libc::close(saved);
+    }
+}
+
+#[cfg(not(all(unix, feature = "voip")))]
+fn silence_native_stderr() {}
+
+#[cfg(not(all(unix, feature = "voip")))]
+fn restore_native_stderr() {}
+
 /// Set up the terminal for drawing the TUI, and getting additional info.
 fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std::io::Result<()> {
     // Enable raw mode and enter the alternate screen.
     crossterm::terminal::enable_raw_mode()?;
     crossterm::execute!(stdout(), EnterAlternateScreen)?;
+
+    // Keep native library logging (libwebrtc, ALSA) off the alternate screen.
+    silence_native_stderr();
 
     if enable_enhanced_keys {
         // Enable the Kitty keyboard enhancement protocol for improved keypresses.
@@ -1092,6 +1216,10 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
     );
 
     let _ = crossterm::terminal::disable_raw_mode();
+
+    // Now that we have left the alternate screen, put the real stderr back so
+    // that any panic message or exit output reaches the terminal.
+    restore_native_stderr();
 }
 
 async fn run(settings: ApplicationSettings) -> IambResult<()> {
@@ -1154,10 +1282,23 @@ async fn run(settings: ApplicationSettings) -> IambResult<()> {
 
     // And finally, start running the terminal UI.
     let mut application = Application::new(settings, store).await?;
-    application.run().await?;
+    let res = application.run().await;
+
+    // Leave any call still in progress before the worker goes away with the
+    // process. Dropping the runtime tears the SFU connection down, but nothing
+    // takes our `m.call.member` event back out of the room, so quitting mid-call
+    // would leave us in the room's participant list until the membership
+    // expires - which is up to `MEMBERSHIP_LIFETIME` of everyone else seeing a
+    // participant who is not there.
+    #[cfg(feature = "voip")]
+    if let Some(call) = worker.call_status.get() {
+        worker.call_hangup_on_exit(call.room_id);
+    }
 
     // Clean up the terminal on exit.
     restore_tty(enable_enhanced_keys, enable_mouse);
+
+    res?;
 
     Ok(())
 }
@@ -1195,12 +1336,27 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
         .with_env_filter(filter)
         .finish();
 
+    // `try_init` also installs the `log` compatibility bridge. LiveKit and
+    // libwebrtc log through `log` rather than `tracing` - including the sink
+    // carrying WebRTC's own C++ diagnostics - so without it everything either
+    // of them says is discarded, and a call that fails inside the media stack
+    // leaves nothing behind to debug with.
+    #[cfg(feature = "voip")]
+    subscriber.try_init().expect("setting default subscriber failed");
+
+    #[cfg(not(feature = "voip"))]
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     guard
 }
 
 fn main() {
+    // Both `ring` and `aws-lc-rs` are in the build, so rustls will not choose a
+    // CryptoProvider on its own and LiveKit's first TLS connection panics.
+    // No-op if one is already installed.
+    #[cfg(feature = "voip")]
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Parse command-line flags.
     let iamb = Iamb::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ use rand::distr::Alphanumeric;
 use temp_dir::TempDir;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::Level;
-#[cfg(feature = "voip")]
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
@@ -1099,80 +1098,11 @@ async fn login_normal(
     Ok(())
 }
 
-/// Saved duplicate of the real stderr, so it can be restored after being
-/// redirected by [`silence_native_stderr`]. `-1` means "not redirected".
-#[cfg(all(unix, feature = "voip"))]
-static SAVED_STDERR_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
-
-/// Send native stderr to `/dev/null` while the TUI owns the terminal.
-///
-/// LiveKit pulls in libwebrtc, and opening audio devices goes through ALSA;
-/// both log directly to file descriptor 2, bypassing our file-based tracing. On
-/// the alternate screen those writes land on top of the UI and corrupt it -
-/// most visibly when a call starts (device + libwebrtc init) and ends (teardown).
-/// [`restore_native_stderr`] puts the real stderr back, and is called from
-/// [`restore_tty`] before any panic message is printed, so crashes are still
-/// visible.
-#[cfg(all(unix, feature = "voip"))]
-fn silence_native_stderr() {
-    use std::os::fd::AsRawFd;
-    use std::sync::atomic::Ordering;
-
-    if SAVED_STDERR_FD.load(Ordering::SeqCst) != -1 {
-        return;
-    }
-
-    let Ok(devnull) = std::fs::OpenOptions::new().write(true).open("/dev/null") else {
-        return;
-    };
-
-    // SAFETY: `dup`/`dup2` on the process's own descriptors. We keep the saved
-    // descriptor in `SAVED_STDERR_FD` and close it in `restore_native_stderr`.
-    unsafe {
-        let saved = libc::dup(libc::STDERR_FILENO);
-        if saved == -1 {
-            return;
-        }
-        if libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO) == -1 {
-            libc::close(saved);
-            return;
-        }
-        SAVED_STDERR_FD.store(saved, Ordering::SeqCst);
-    }
-}
-
-/// Restore the real stderr previously redirected by [`silence_native_stderr`].
-#[cfg(all(unix, feature = "voip"))]
-fn restore_native_stderr() {
-    use std::sync::atomic::Ordering;
-
-    let saved = SAVED_STDERR_FD.swap(-1, Ordering::SeqCst);
-    if saved == -1 {
-        return;
-    }
-
-    // SAFETY: `saved` is a descriptor we duplicated from stderr; move it back
-    // onto stderr and drop the duplicate.
-    unsafe {
-        libc::dup2(saved, libc::STDERR_FILENO);
-        libc::close(saved);
-    }
-}
-
-#[cfg(not(all(unix, feature = "voip")))]
-fn silence_native_stderr() {}
-
-#[cfg(not(all(unix, feature = "voip")))]
-fn restore_native_stderr() {}
-
 /// Set up the terminal for drawing the TUI, and getting additional info.
 fn setup_tty(settings: &ApplicationSettings, enable_enhanced_keys: bool) -> std::io::Result<()> {
     // Enable raw mode and enter the alternate screen.
     crossterm::terminal::enable_raw_mode()?;
     crossterm::execute!(stdout(), EnterAlternateScreen)?;
-
-    // Keep native library logging (libwebrtc, ALSA) off the alternate screen.
-    silence_native_stderr();
 
     if enable_enhanced_keys {
         // Enable the Kitty keyboard enhancement protocol for improved keypresses.
@@ -1216,10 +1146,6 @@ fn restore_tty(enable_enhanced_keys: bool, enable_mouse: bool) {
     );
 
     let _ = crossterm::terminal::disable_raw_mode();
-
-    // Now that we have left the alternate screen, put the real stderr back so
-    // that any panic message or exit output reaches the terminal.
-    restore_native_stderr();
 }
 
 async fn run(settings: ApplicationSettings) -> IambResult<()> {
@@ -1336,16 +1262,7 @@ fn setup_logging(settings: &ApplicationSettings) -> tracing_appender::non_blocki
         .with_env_filter(filter)
         .finish();
 
-    // `try_init` also installs the `log` compatibility bridge. LiveKit and
-    // libwebrtc log through `log` rather than `tracing` - including the sink
-    // carrying WebRTC's own C++ diagnostics - so without it everything either
-    // of them says is discarded, and a call that fails inside the media stack
-    // leaves nothing behind to debug with.
-    #[cfg(feature = "voip")]
-    subscriber.try_init().expect("setting default subscriber failed");
-
-    #[cfg(not(feature = "voip"))]
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    subscriber.init();
 
     guard
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -111,6 +111,113 @@ pub async fn register_notifications(
         .await;
 }
 
+/// Announce that a call has started in a room the user is not currently looking
+/// at.
+///
+/// Unlike message notifications this deliberately ignores the room's push
+/// notification mode: a muted room mutes its *messages*, and someone calling you
+/// is not a message. It is still gated on the global notification tunable.
+///
+/// Takes the already-locked store because the caller is a sync event handler
+/// that holds it; locking it again here would deadlock.
+#[cfg(feature = "voip")]
+pub async fn notify_call_started(room_name: &str, room_id: OwnedRoomId, store: &mut ProgramStore) {
+    if !store.application.settings.tunables.notifications.enabled {
+        return;
+    }
+
+    if is_focused(store) && is_open(store, &room_id) {
+        return;
+    }
+
+    let summary = format!("📞 Call in {room_name}");
+
+    let _ = room_id;
+    send_call_notification(&summary, None, false, store).await;
+}
+
+/// Announce that someone is calling and waiting for an answer (MSC4075).
+///
+/// Unlike [`notify_call_started`] this fires even when the room is open and
+/// focused: a ring is a request for an answer, and silently dropping it because
+/// the user happens to be looking at the room means the call goes unanswered
+/// while they stare at it.
+///
+/// `ring` marks the notification urgent, which is what stops a compositor from
+/// expiring it after a few seconds - a ring the user missed because they were
+/// away from the keyboard is a ring that did not work.
+#[cfg(feature = "voip")]
+pub async fn notify_incoming_call(
+    room_name: &str,
+    caller: &str,
+    room_id: OwnedRoomId,
+    ring: bool,
+    store: &mut ProgramStore,
+) {
+    if !store.application.settings.tunables.notifications.enabled {
+        return;
+    }
+
+    let summary = format!("📞 {caller} is calling");
+    let body = format!("in {room_name} — :call to answer, :call decline to reject");
+
+    let _ = room_id;
+    send_call_notification(&summary, Some(&body), ring, store).await;
+}
+
+/// Deliver a call notification from a caller that already holds the store lock.
+///
+/// [`send_notification`] takes the unlocked store and locks it itself, which
+/// would deadlock the sync event handlers the call notices arrive on.
+#[cfg(feature = "voip")]
+async fn send_call_notification(
+    summary: &str,
+    body: Option<&str>,
+    urgent: bool,
+    store: &mut ProgramStore,
+) {
+    let via = store.application.settings.tunables.notifications.via;
+
+    #[cfg(feature = "desktop")]
+    if via.desktop {
+        let mut notification = notify_rust::Notification::new();
+        notification
+            .summary(summary)
+            .appname(IAMB_XDG_NAME)
+            .icon(IAMB_XDG_NAME)
+            .action("default", "default");
+
+        if let Some(body) = body {
+            notification.body(body);
+        }
+
+        // A ring stays up until it is dealt with; ordinary notifications expire
+        // on the compositor's own schedule.
+        #[cfg(all(unix, not(target_os = "macos")))]
+        notification.urgency(if urgent {
+            notify_rust::Urgency::Critical
+        } else {
+            notify_rust::Urgency::Normal
+        });
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let res = notification.show_async().await;
+        #[cfg(any(not(unix), target_os = "macos"))]
+        let res = notification.show();
+
+        if let Err(err) = res {
+            tracing::error!("Failed to send call notification: {err}");
+        }
+    }
+
+    #[cfg(not(feature = "desktop"))]
+    let _ = (summary, body, urgent);
+
+    if via.bell {
+        store.application.ring_bell = true;
+    }
+}
+
 async fn send_notification(
     via: &NotifyVia,
     summary: &str,

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -136,7 +136,7 @@ pub async fn notify_call_started(room_name: &str, room_id: OwnedRoomId, store: &
     send_call_notification(&summary, None, false, store).await;
 }
 
-/// Announce that someone is calling and waiting for an answer (MSC4075).
+/// Announce that someone is calling and waiting for an answer ([MSC4075]).
 ///
 /// Unlike [`notify_call_started`] this fires even when the room is open and
 /// focused: a ring is a request for an answer, and silently dropping it because
@@ -146,6 +146,8 @@ pub async fn notify_call_started(room_name: &str, room_id: OwnedRoomId, store: &
 /// `ring` marks the notification urgent, which is what stops a compositor from
 /// expiring it after a few seconds - a ring the user missed because they were
 /// away from the keyboard is a ring that did not work.
+///
+/// [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
 #[cfg(feature = "voip")]
 pub async fn notify_incoming_call(
     room_name: &str,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -217,6 +217,8 @@ pub fn mock_tunables() -> TunableValues {
 pub fn mock_settings() -> ApplicationSettings {
     ApplicationSettings {
         layout_json: PathBuf::new(),
+        #[cfg(feature = "voip")]
+        voip_json: PathBuf::new(),
         session_json: PathBuf::new(),
         session_json_old: PathBuf::new(),
         sled_dir: PathBuf::new(),
@@ -248,7 +250,12 @@ pub async fn mock_store() -> ProgramStore {
         .build()
         .await
         .unwrap();
-    let worker = Requester { tx, client };
+    let worker = Requester {
+        tx,
+        client,
+        #[cfg(feature = "voip")]
+        call_status: Default::default(),
+    };
 
     let mut store = ChatStore::new(worker, mock_settings());
 

--- a/src/voip/devices.rs
+++ b/src/voip/devices.rs
@@ -1,0 +1,334 @@
+//! Audio device selection for calls.
+//!
+//! LiveKit's platform audio device module owns the microphone and speaker, so
+//! everything here is a thin, human-friendly layer over [`PlatformAudio`]:
+//! turning its device lists into something printable, resolving what the user
+//! typed at `:call device` into a device id, and remembering the choice.
+//!
+//! Only compiled when the `voip` feature is enabled.
+
+use anyhow::{Result, anyhow};
+use livekit::{PlatformAudio, PlayoutDeviceId, RecordingDeviceId};
+use serde::{Deserialize, Serialize};
+
+/// Which end of the call a device sits on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeviceKind {
+    /// The capture device.
+    Microphone,
+
+    /// The playback device.
+    Speaker,
+}
+
+impl DeviceKind {
+    /// The word the user types for this kind at `:call device`.
+    pub fn keyword(&self) -> &'static str {
+        match self {
+            DeviceKind::Microphone => "mic",
+            DeviceKind::Speaker => "speaker",
+        }
+    }
+
+    /// The heading this kind gets in a device listing.
+    pub fn heading(&self) -> &'static str {
+        match self {
+            DeviceKind::Microphone => "Microphones",
+            DeviceKind::Speaker => "Speakers",
+        }
+    }
+}
+
+/// The devices the user has chosen, remembered between calls and between runs.
+///
+/// Devices are stored by name rather than by id: ids are opaque platform GUIDs,
+/// and a name is what the user recognises if they ever open the file.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DevicePreferences {
+    /// The chosen microphone, or `None` to use the system default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub microphone: Option<String>,
+
+    /// The chosen speaker, or `None` to use the system default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<String>,
+}
+
+impl DevicePreferences {
+    /// The remembered device of the given kind.
+    pub fn get(&self, kind: DeviceKind) -> Option<&str> {
+        let name = match kind {
+            DeviceKind::Microphone => &self.microphone,
+            DeviceKind::Speaker => &self.speaker,
+        };
+
+        name.as_deref()
+    }
+
+    /// Remember a device of the given kind.
+    pub fn set(&mut self, kind: DeviceKind, name: String) {
+        match kind {
+            DeviceKind::Microphone => self.microphone = Some(name),
+            DeviceKind::Speaker => self.speaker = Some(name),
+        }
+    }
+}
+
+/// One available audio device.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Device {
+    /// Position in the platform's device list.
+    index: usize,
+
+    /// Human-readable name. Not necessarily unique: two identical USB
+    /// microphones report the same name, so never use it to identify a device
+    /// we have already picked out.
+    name: String,
+
+    /// The platform's stable identifier for this device.
+    guid: String,
+}
+
+/// The devices of one kind.
+fn enumerate(audio: &PlatformAudio, kind: DeviceKind) -> Vec<Device> {
+    match kind {
+        DeviceKind::Microphone => {
+            audio
+                .recording_devices()
+                .map(|d| {
+                    Device {
+                        index: d.index,
+                        name: d.name,
+                        guid: d.id.as_str().to_string(),
+                    }
+                })
+                .collect()
+        },
+        DeviceKind::Speaker => {
+            audio
+                .playout_devices()
+                .map(|d| {
+                    Device {
+                        index: d.index,
+                        name: d.name,
+                        guid: d.id.as_str().to_string(),
+                    }
+                })
+                .collect()
+        },
+    }
+}
+
+/// Render the available devices, marking the remembered ones.
+///
+/// The mark says which device iamb will *ask* for; LiveKit offers no way to read
+/// back what the audio device module actually settled on, so an unmarked list
+/// means we have never chosen and the system default is in use.
+pub fn format_listing(audio: &PlatformAudio, prefs: &DevicePreferences) -> String {
+    let mut out = String::new();
+
+    for kind in [DeviceKind::Microphone, DeviceKind::Speaker] {
+        out.push_str(kind.heading());
+        out.push_str(":\n");
+
+        let devices = enumerate(audio, kind);
+
+        if devices.is_empty() {
+            out.push_str("  (none found)\n");
+            continue;
+        }
+
+        let chosen = prefs.get(kind);
+
+        for device in devices {
+            let mark = if Some(device.name.as_str()) == chosen {
+                "  (selected)"
+            } else {
+                ""
+            };
+
+            out.push_str(&format!("  {}  {}{mark}\n", device.index, device.name));
+        }
+    }
+
+    out.push_str("\nSelect with `:call device ");
+    out.push_str(DeviceKind::Microphone.keyword());
+    out.push_str(" <index|name>`.\n");
+
+    out
+}
+
+/// Find the device the user meant.
+///
+/// A bare number picks by index; anything else matches a device name, exactly if
+/// possible and otherwise as a case-insensitive substring so that `:call device
+/// mic yeti` does the obvious thing.
+fn resolve(audio: &PlatformAudio, kind: DeviceKind, spec: &str) -> Result<Device> {
+    resolve_in(&enumerate(audio, kind), kind, spec)
+}
+
+/// The matching rules behind [`resolve`], over an already enumerated list.
+fn resolve_in(devices: &[Device], kind: DeviceKind, spec: &str) -> Result<Device> {
+    if let Ok(wanted) = spec.parse::<usize>() {
+        return devices
+            .iter()
+            .find(|device| device.index == wanted)
+            .cloned()
+            .ok_or_else(|| anyhow!("no {} with index {wanted}", kind.keyword()));
+    }
+
+    if let Some(device) = devices.iter().find(|device| device.name == spec) {
+        return Ok(device.clone());
+    }
+
+    let spec_lower = spec.to_lowercase();
+    let mut matches = devices
+        .iter()
+        .filter(|device| device.name.to_lowercase().contains(&spec_lower));
+
+    let Some(device) = matches.next() else {
+        return Err(anyhow!("no {} matching {spec:?}", kind.keyword()));
+    };
+
+    if matches.next().is_some() {
+        return Err(anyhow!("{spec:?} matches more than one {}", kind.keyword()));
+    }
+
+    Ok(device.clone())
+}
+
+/// Switch to a device by its platform identifier, hot-swapping it if a call is
+/// already running.
+///
+/// Identifiers rather than names, because two devices can share a name and
+/// picking the wrong one would silently change which microphone is live.
+fn switch(audio: &PlatformAudio, kind: DeviceKind, guid: &str) -> Result<()> {
+    match kind {
+        DeviceKind::Microphone => {
+            audio.switch_recording_device(&RecordingDeviceId::from_unchecked_guid(guid))?
+        },
+        DeviceKind::Speaker => {
+            audio.switch_playout_device(&PlayoutDeviceId::from_unchecked_guid(guid))?
+        },
+    }
+
+    Ok(())
+}
+
+/// Resolve what the user typed, switch to that device, and return its full name.
+pub fn select(audio: &PlatformAudio, kind: DeviceKind, spec: &str) -> Result<String> {
+    let device = resolve(audio, kind, spec)?;
+
+    switch(audio, kind, &device.guid)?;
+
+    Ok(device.name)
+}
+
+/// Apply the remembered devices at the start of a call.
+///
+/// A device that is no longer plugged in is not an error: the call goes ahead on
+/// the system default rather than refusing to start.
+pub fn apply(audio: &PlatformAudio, prefs: &DevicePreferences) {
+    for kind in [DeviceKind::Microphone, DeviceKind::Speaker] {
+        let Some(name) = prefs.get(kind) else {
+            continue;
+        };
+
+        // Preferences are stored by name, which is all the user gave us. If two
+        // devices share a name we can only take the first.
+        let Some(device) = enumerate(audio, kind).into_iter().find(|d| d.name == name) else {
+            tracing::warn!("the remembered {} {name:?} is not available", kind.keyword());
+            continue;
+        };
+
+        if let Err(e) = switch(audio, kind, &device.guid) {
+            tracing::warn!("could not select the remembered {}: {e:#}", kind.keyword());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device(index: usize, name: &str, guid: &str) -> Device {
+        Device {
+            index,
+            name: name.to_string(),
+            guid: guid.to_string(),
+        }
+    }
+
+    fn devices() -> Vec<Device> {
+        vec![
+            device(0, "Built-in Audio Analog Stereo", "guid-builtin"),
+            device(1, "Yeti Stereo Microphone", "guid-yeti"),
+            device(2, "Yeti Nano", "guid-nano"),
+        ]
+    }
+
+    fn resolve(spec: &str) -> Result<Device> {
+        resolve_in(&devices(), DeviceKind::Microphone, spec)
+    }
+
+    #[test]
+    fn test_resolve_by_index() {
+        assert_eq!(resolve("1").unwrap().name, "Yeti Stereo Microphone");
+    }
+
+    #[test]
+    fn test_resolve_by_index_keeps_the_right_duplicate() {
+        // Two identical microphones report the same name, so an index must
+        // resolve to the device at that index and not to whichever one a later
+        // name lookup would have found first.
+        let devices = vec![
+            device(0, "USB Microphone", "guid-first"),
+            device(1, "USB Microphone", "guid-second"),
+        ];
+
+        let picked = resolve_in(&devices, DeviceKind::Microphone, "1").unwrap();
+
+        assert_eq!(picked.guid, "guid-second");
+    }
+
+    #[test]
+    fn test_resolve_index_out_of_range() {
+        assert!(resolve("9").is_err());
+    }
+
+    #[test]
+    fn test_resolve_exact_name_beats_substring() {
+        // "Yeti Nano" is also a substring match for two entries when lowercased
+        // to "yeti", but an exact hit must win outright.
+        assert_eq!(resolve("Yeti Nano").unwrap().name, "Yeti Nano");
+    }
+
+    #[test]
+    fn test_resolve_substring_is_case_insensitive() {
+        assert_eq!(resolve("built-in").unwrap().name, "Built-in Audio Analog Stereo");
+    }
+
+    #[test]
+    fn test_resolve_ambiguous_substring_is_an_error() {
+        // "yeti" matches both Yeti devices, so we refuse rather than guess.
+        assert!(resolve("yeti").is_err());
+    }
+
+    #[test]
+    fn test_resolve_unknown_name() {
+        assert!(resolve("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_preferences_round_trip() {
+        let mut prefs = DevicePreferences::default();
+        assert_eq!(prefs.get(DeviceKind::Microphone), None);
+
+        prefs.set(DeviceKind::Microphone, "Yeti Nano".to_string());
+        assert_eq!(prefs.get(DeviceKind::Microphone), Some("Yeti Nano"));
+        assert_eq!(prefs.get(DeviceKind::Speaker), None);
+
+        let json = serde_json::to_string(&prefs).unwrap();
+        assert_eq!(serde_json::from_str::<DevicePreferences>(&json).unwrap(), prefs);
+    }
+}

--- a/src/voip/devices.rs
+++ b/src/voip/devices.rs
@@ -8,7 +8,9 @@
 //! Only compiled when the `voip` feature is enabled.
 
 use anyhow::{Result, anyhow};
-use livekit::{PlatformAudio, PlayoutDeviceId, RecordingDeviceId};
+use livekit::PlatformAudio;
+use livekit::rtc_engine::lk_runtime::LkRuntime;
+use livekit::webrtc::peer_connection_factory::native::PeerConnectionFactoryExt;
 use serde::{Deserialize, Serialize};
 
 /// Which end of the call a device sits on.
@@ -77,16 +79,14 @@ impl DevicePreferences {
 /// One available audio device.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Device {
-    /// Position in the platform's device list.
+    /// Position in the platform's device list, and the only handle the audio
+    /// device module will actually act on. See [`switch`].
     index: usize,
 
     /// Human-readable name. Not necessarily unique: two identical USB
     /// microphones report the same name, so never use it to identify a device
     /// we have already picked out.
     name: String,
-
-    /// The platform's stable identifier for this device.
-    guid: String,
 }
 
 /// The devices of one kind.
@@ -95,25 +95,13 @@ fn enumerate(audio: &PlatformAudio, kind: DeviceKind) -> Vec<Device> {
         DeviceKind::Microphone => {
             audio
                 .recording_devices()
-                .map(|d| {
-                    Device {
-                        index: d.index,
-                        name: d.name,
-                        guid: d.id.as_str().to_string(),
-                    }
-                })
+                .map(|d| Device { index: d.index, name: d.name })
                 .collect()
         },
         DeviceKind::Speaker => {
             audio
                 .playout_devices()
-                .map(|d| {
-                    Device {
-                        index: d.index,
-                        name: d.name,
-                        guid: d.id.as_str().to_string(),
-                    }
-                })
+                .map(|d| Device { index: d.index, name: d.name })
                 .collect()
         },
     }
@@ -197,18 +185,60 @@ fn resolve_in(devices: &[Device], kind: DeviceKind, spec: &str) -> Result<Device
     Ok(device.clone())
 }
 
-/// Switch to a device by its platform identifier, hot-swapping it if a call is
-/// already running.
+/// Switch to a device by its position in the platform's device list,
+/// hot-swapping it if a call is already running.
 ///
-/// Identifiers rather than names, because two devices can share a name and
-/// picking the wrong one would silently change which microphone is live.
-fn switch(audio: &PlatformAudio, kind: DeviceKind, guid: &str) -> Result<()> {
+/// This goes to the audio device module directly rather than through
+/// [`PlatformAudio::switch_recording_device`], because that API takes a device
+/// GUID and on Linux the WebRTC ADM reports an *empty* GUID for every device.
+/// The lookup behind it walks the device list for the first equal GUID, so an
+/// empty one matches device 0 immediately, and it selects the default device and
+/// returns success.
+///
+/// Indices are what the ADM actually keys on, and the same `PeerConnectionFactory`
+/// exposes them. `audio` is not read, but holding it is what guarantees the
+/// platform ADM these calls reach is still acquired.
+fn switch(audio: &PlatformAudio, kind: DeviceKind, index: usize) -> Result<()> {
+    let _ = audio;
+
+    let index =
+        u16::try_from(index).map_err(|_| anyhow!("device index {index} is out of range"))?;
+
+    let runtime = LkRuntime::instance();
+    let factory = runtime.pc_factory();
+
+    // Capture and playback have to be stopped before the device underneath them
+    // can change.
     match kind {
         DeviceKind::Microphone => {
-            audio.switch_recording_device(&RecordingDeviceId::from_unchecked_guid(guid))?
+            let running = factory.recording_is_initialized();
+
+            if running && !factory.stop_recording() {
+                return Err(anyhow!("could not stop capturing to change the microphone"));
+            }
+
+            if !factory.set_recording_device(index) {
+                return Err(anyhow!("the audio device module rejected microphone {index}"));
+            }
+
+            if running && !(factory.init_recording() && factory.start_recording()) {
+                return Err(anyhow!("could not start capturing from the new microphone"));
+            }
         },
         DeviceKind::Speaker => {
-            audio.switch_playout_device(&PlayoutDeviceId::from_unchecked_guid(guid))?
+            let running = factory.playout_is_initialized();
+
+            if running && !factory.stop_playout() {
+                return Err(anyhow!("could not stop playback to change the speaker"));
+            }
+
+            if !factory.set_playout_device(index) {
+                return Err(anyhow!("the audio device module rejected speaker {index}"));
+            }
+
+            if running && !(factory.init_playout() && factory.start_playout()) {
+                return Err(anyhow!("could not start playback on the new speaker"));
+            }
         },
     }
 
@@ -219,7 +249,7 @@ fn switch(audio: &PlatformAudio, kind: DeviceKind, guid: &str) -> Result<()> {
 pub fn select(audio: &PlatformAudio, kind: DeviceKind, spec: &str) -> Result<String> {
     let device = resolve(audio, kind, spec)?;
 
-    switch(audio, kind, &device.guid)?;
+    switch(audio, kind, device.index)?;
 
     Ok(device.name)
 }
@@ -241,7 +271,7 @@ pub fn apply(audio: &PlatformAudio, prefs: &DevicePreferences) {
             continue;
         };
 
-        if let Err(e) = switch(audio, kind, &device.guid) {
+        if let Err(e) = switch(audio, kind, device.index) {
             tracing::warn!("could not select the remembered {}: {e:#}", kind.keyword());
         }
     }
@@ -251,19 +281,15 @@ pub fn apply(audio: &PlatformAudio, prefs: &DevicePreferences) {
 mod tests {
     use super::*;
 
-    fn device(index: usize, name: &str, guid: &str) -> Device {
-        Device {
-            index,
-            name: name.to_string(),
-            guid: guid.to_string(),
-        }
+    fn device(index: usize, name: &str) -> Device {
+        Device { index, name: name.to_string() }
     }
 
     fn devices() -> Vec<Device> {
         vec![
-            device(0, "Built-in Audio Analog Stereo", "guid-builtin"),
-            device(1, "Yeti Stereo Microphone", "guid-yeti"),
-            device(2, "Yeti Nano", "guid-nano"),
+            device(0, "Built-in Audio Analog Stereo"),
+            device(1, "Yeti Stereo Microphone"),
+            device(2, "Yeti Nano"),
         ]
     }
 
@@ -281,14 +307,11 @@ mod tests {
         // Two identical microphones report the same name, so an index must
         // resolve to the device at that index and not to whichever one a later
         // name lookup would have found first.
-        let devices = vec![
-            device(0, "USB Microphone", "guid-first"),
-            device(1, "USB Microphone", "guid-second"),
-        ];
+        let devices = vec![device(0, "USB Microphone"), device(1, "USB Microphone")];
 
         let picked = resolve_in(&devices, DeviceKind::Microphone, "1").unwrap();
 
-        assert_eq!(picked.guid, "guid-second");
+        assert_eq!(picked.index, 1);
     }
 
     #[test]

--- a/src/voip/devices.rs
+++ b/src/voip/devices.rs
@@ -195,9 +195,11 @@ fn resolve_in(devices: &[Device], kind: DeviceKind, spec: &str) -> Result<Device
 /// empty one matches device 0 immediately, and it selects the default device and
 /// returns success.
 ///
-/// Indices are what the ADM actually keys on, and the same `PeerConnectionFactory`
-/// exposes them. `audio` is not read, but holding it is what guarantees the
-/// platform ADM these calls reach is still acquired.
+/// Indices are what the ADM actually keys on, and the same
+/// [`PeerConnectionFactory`] exposes them. `audio` is not read, but holding it
+/// is what guarantees the platform ADM these calls reach is still acquired.
+///
+/// [`PeerConnectionFactory`]: livekit::webrtc::peer_connection_factory::PeerConnectionFactory
 fn switch(audio: &PlatformAudio, kind: DeviceKind, index: usize) -> Result<()> {
     let _ = audio;
 

--- a/src/voip/livekit_session.rs
+++ b/src/voip/livekit_session.rs
@@ -1,0 +1,320 @@
+//! LiveKit media session for VoIP calls.
+//!
+//! This owns the connection to a LiveKit room (the SFU) for a single call: the
+//! signalling connection, the end-to-end encryption key ring, and the microphone
+//! track we publish.
+//!
+//! Audio I/O is LiveKit's own platform audio device module rather than something
+//! we drive by hand. [`PlatformAudio`] captures the microphone and plays every
+//! subscribed remote track back through the system's output device, with echo
+//! cancellation, noise suppression, and automatic gain control applied by WebRTC.
+//! There is no capture loop or playback ring buffer in iamb at all: we hand
+//! LiveKit a `RtcAudioSource::Device` and it does the rest.
+//!
+//! The session runs on the dedicated `iamb-voip` thread (see
+//! [`crate::voip::CallSession`]) inside that thread's own tokio runtime, so
+//! nothing here ever runs on the runtime that serves the UI.
+//!
+//! Only compiled when the `voip` feature is enabled.
+
+use anyhow::{Context, Result};
+use livekit::PlatformAudio;
+use livekit::e2ee::key_provider::{KeyDerivationAlgorithm, KeyProvider, KeyProviderOptions};
+use livekit::e2ee::{E2eeOptions, EncryptionType};
+use livekit::options::TrackPublishOptions;
+use livekit::prelude::*;
+use matrix_sdk::ruma::OwnedRoomId;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use super::{KeyInbox, ReceivedCallKey};
+
+/// The key ring slot our own E2EE key starts in.
+///
+/// Rotation walks forward from here; other clients tell us which of *their*
+/// indices each key they send belongs to.
+pub const FIRST_KEY_INDEX: u8 = 0;
+
+/// How many slots the key ring has.
+///
+/// LiveKit's key provider keeps a fixed-size ring per participant, and Element
+/// Call's implementation uses 16 slots. Rotating past the end wraps around,
+/// which is safe because a call would have to survive sixteen departures before
+/// the oldest key is overwritten - long after any media encrypted under it has
+/// been played out.
+const KEY_RING_SIZE: u8 = 16;
+
+/// The slot a rotation moves to from `index`.
+pub fn next_key_index(index: u8) -> u8 {
+    (index + 1) % KEY_RING_SIZE
+}
+
+/// The name our published microphone track carries in the LiveKit room.
+const MIC_TRACK_NAME: &str = "microphone";
+
+/// Parameters needed to establish a LiveKit media session.
+///
+/// Filled in by the worker after it has discovered the SFU URL and obtained a
+/// LiveKit JWT via the `lk-jwt-service` `/sfu/get` exchange.
+pub struct SessionConfig {
+    /// The LiveKit SFU URL (`wss://…`) discovered from `m.call.member` state.
+    pub url: String,
+
+    /// The LiveKit access token (JWT) authorizing this participant.
+    pub token: String,
+
+    /// The raw E2EE key shared with other participants for this call.
+    pub e2ee_key: Vec<u8>,
+
+    /// Our LiveKit participant identity, `{user_id}:{device_id}`.
+    pub identity: String,
+
+    /// Keys received from other participants over Matrix to-device events.
+    pub inbox: KeyInbox,
+
+    /// The system audio devices, already set to the user's remembered choices.
+    pub audio: PlatformAudio,
+
+    /// The Matrix room this call belongs to.
+    ///
+    /// Senders address their keys to a room, so this is what tells apart a key
+    /// for our call from one for a call we are not in.
+    pub room_id: OwnedRoomId,
+
+    /// Whether to encrypt our media and decrypt everyone else's.
+    ///
+    /// Normally true. When false the room is joined with no E2EE options at
+    /// all, which is all or nothing: LiveKit installs no frame cryptor in
+    /// *either* direction, so an encrypted peer is inaudible rather than
+    /// merely unprotected.
+    pub encrypted: bool,
+}
+
+/// A running LiveKit media session for one call.
+///
+/// Dropping the session leaves the room, but [`LiveKitSession::disconnect`] does
+/// it deterministically and should be preferred.
+pub struct LiveKitSession {
+    room: Room,
+    key_provider: KeyProvider,
+    inbox: KeyInbox,
+    room_id: OwnedRoomId,
+
+    /// Our own participant identity, needed to register rotated keys under the
+    /// same identity our media is published with.
+    identity: ParticipantIdentity,
+
+    /// The platform audio device module.
+    ///
+    /// Held for the lifetime of the call: LiveKit reference-counts the ADM and
+    /// releases the microphone and speaker when the last handle drops.
+    _audio: PlatformAudio,
+
+    /// The microphone track we publish, kept so that it can be muted.
+    mic: LocalAudioTrack,
+}
+
+impl LiveKitSession {
+    /// Connect to the LiveKit room described by `config`.
+    ///
+    /// Returns the session along with the room's event stream, which the call
+    /// thread pumps for participant and track events.
+    pub async fn connect(config: SessionConfig) -> Result<(Self, UnboundedReceiver<RoomEvent>)> {
+        let audio = config.audio;
+
+        let options = KeyProviderOptions {
+            key_derivation_algorithm: KeyDerivationAlgorithm::HKDF,
+            ..Default::default()
+        };
+
+        let key_provider = KeyProvider::new(options);
+
+        // Per-participant mode: every participant's media is encrypted with
+        // their own key, so we register ours under our own identity and add
+        // everyone else's as their to-device events arrive.
+        //
+        // Registered against the identity we *expect* first so that there is no
+        // window in which we are connected without a key; the identity the SFU
+        // actually assigned is only readable once the connection is up, and is
+        // reconciled below.
+        let expected = ParticipantIdentity(config.identity.clone());
+        key_provider.set_key(&expected, FIRST_KEY_INDEX.into(), config.e2ee_key.clone());
+
+        let e2ee = E2eeOptions {
+            encryption_type: EncryptionType::Gcm,
+            key_provider: key_provider.clone(),
+        };
+
+        let mut options = RoomOptions::default();
+
+        // Leaving this `None` is what actually disables encryption: LiveKit
+        // decides per track whether to build a frame cryptor, and with no
+        // options it builds none, so our media goes out in the clear and
+        // everyone else's arrives undecrypted.
+        if config.encrypted {
+            options.encryption = Some(e2ee);
+        } else {
+            tracing::warn!("connecting to the SFU with media encryption disabled");
+        }
+
+        let (room, events) = Room::connect(&config.url, &config.token, options)
+            .await
+            .context("could not connect to the LiveKit SFU")?;
+
+        // The SFU, not us, decides what our participant identity is: it comes
+        // out of the JWT the focus's token service minted. We derive the same
+        // `{user_id}:{device_id}` that Element Call does, but a token service
+        // that disagrees would leave our outgoing media encrypted under an
+        // identity the frame cryptor never looks up - silence in both
+        // directions, with every key exchange apparently succeeding.
+        let identity = room.local_participant().identity();
+
+        if identity != expected {
+            tracing::warn!(
+                expected = %expected.0,
+                actual = %identity.0,
+                "the SFU assigned a different participant identity than we derived"
+            );
+
+            key_provider.set_key(&identity, FIRST_KEY_INDEX.into(), config.e2ee_key.clone());
+        }
+
+        let mic = LocalAudioTrack::create_audio_track(MIC_TRACK_NAME, audio.rtc_source());
+        let publish = TrackPublishOptions {
+            source: TrackSource::Microphone,
+            ..Default::default()
+        };
+
+        room.local_participant()
+            .publish_track(LocalTrack::Audio(mic.clone()), publish)
+            .await
+            .context("could not publish the microphone track")?;
+
+        let session = LiveKitSession {
+            room,
+            key_provider,
+            inbox: config.inbox,
+            room_id: config.room_id,
+            identity,
+            _audio: audio,
+            mic,
+        };
+
+        // Keys can arrive before the connection finishes, so apply whatever the
+        // sync handler buffered while we were connecting.
+        session.drain_inbox();
+
+        Ok((session, events))
+    }
+
+    /// Hand every key buffered by the Matrix sync handler to LiveKit.
+    ///
+    /// Called on a timer by the call thread; keys for participants that have not
+    /// joined the SFU yet are harmless, the key ring simply holds them until
+    /// their media shows up.
+    pub fn drain_inbox(&self) {
+        for key in self.inbox.drain() {
+            if key.room_id == self.room_id {
+                self.apply_key(&key);
+            }
+        }
+    }
+
+    /// Register one participant's key with the key provider.
+    fn apply_key(&self, key: &ReceivedCallKey) {
+        let identity = ParticipantIdentity(key.participant_identity());
+
+        if !self.key_provider.set_key(&identity, key.index.into(), key.key.clone()) {
+            tracing::warn!(identity = %identity.0, index = key.index, "LiveKit rejected a call key");
+            return;
+        }
+
+        // A key filed under an identity nobody in the room is using decrypts
+        // nothing, and is indistinguishable from having received no key at all
+        // unless it is said out loud.
+        let known = self
+            .room
+            .remote_participants()
+            .values()
+            .any(|participant| participant.identity() == identity);
+
+        if known {
+            tracing::debug!(identity = %identity.0, index = key.index, "applied a call key");
+        } else {
+            // Naming the identities actually on the SFU is what separates the
+            // two ways this happens: a key that simply arrived before its
+            // sender connected, which resolves itself, and a key filed under a
+            // name that peer never uses, which never decrypts anything. The
+            // second is invisible otherwise - the key exchange looks entirely
+            // successful and the participant is silent for the whole call.
+            let present = self
+                .room
+                .remote_participants()
+                .values()
+                .map(|participant| participant.identity().0)
+                .collect::<Vec<_>>();
+
+            tracing::info!(
+                identity = %identity.0,
+                index = key.index,
+                on_sfu = ?present,
+                "applied a call key for a participant not (yet) on the SFU"
+            );
+        }
+    }
+
+    /// Start encrypting our media with `key` at slot `index`.
+    ///
+    /// Registered under our own identity, which is what the E2EE frame
+    /// cryptor consults for outgoing media. Remote participants have already
+    /// been told about the new key by the time this arrives, so there is no
+    /// window in which we publish under a key nobody holds.
+    pub fn set_our_key(&self, index: u8, key: &[u8]) {
+        if !self.key_provider.set_key(&self.identity, index.into(), key.to_vec()) {
+            tracing::warn!(index, "LiveKit rejected our rotated call key");
+            return;
+        }
+
+        // Registering the key is only half of a rotation. livekit-rust builds
+        // the sending frame cryptor without ever calling `set_key_index`, so it
+        // stays on the slot it was created with - index 0 - no matter what the
+        // key provider is told. Without this the rotation is invisible to our
+        // own encoder: we keep publishing under the superseded key while every
+        // peer has moved on, and they stop hearing us.
+        for ((identity, _), cryptor) in self.room.e2ee_manager().frame_cryptors() {
+            if identity == self.identity {
+                cryptor.set_key_index(index.into());
+            }
+        }
+    }
+
+    /// Mute or unmute the local microphone.
+    ///
+    /// Muting the track rather than stopping capture keeps the publication alive
+    /// and tells the SFU, so other participants see us as muted instead of
+    /// simply going silent.
+    pub fn set_muted(&self, muted: bool) {
+        if muted {
+            self.mic.mute();
+        } else {
+            self.mic.unmute();
+        }
+    }
+
+    /// Leave the LiveKit room.
+    pub async fn disconnect(&self) -> Result<()> {
+        self.room
+            .close()
+            .await
+            .context("could not cleanly leave the LiveKit room")?;
+
+        Ok(())
+    }
+}
+
+/// Split a LiveKit participant identity back into its Matrix user and device.
+///
+/// Identities are `{user_id}:{device_id}` and user IDs themselves contain a
+/// colon, so the split has to happen at the last one.
+pub fn split_identity(identity: &str) -> Option<(&str, &str)> {
+    identity.rsplit_once(':')
+}

--- a/src/voip/livekit_session.rs
+++ b/src/voip/livekit_session.rs
@@ -9,7 +9,9 @@
 //! subscribed remote track back through the system's output device, with echo
 //! cancellation, noise suppression, and automatic gain control applied by WebRTC.
 //! There is no capture loop or playback ring buffer in iamb at all: we hand
-//! LiveKit a `RtcAudioSource::Device` and it does the rest.
+//! LiveKit a [`RtcAudioSource::Device`] and it does the rest.
+//!
+//! [`RtcAudioSource::Device`]: livekit::webrtc::audio_source::RtcAudioSource::Device
 //!
 //! The session runs on the dedicated `iamb-voip` thread (see
 //! [`crate::voip::CallSession`]) inside that thread's own tokio runtime, so

--- a/src/voip/matrix_rtc.rs
+++ b/src/voip/matrix_rtc.rs
@@ -1,0 +1,686 @@
+//! MatrixRTC signaling for VoIP calls.
+//!
+//! Everything in this module talks to the homeserver rather than to LiveKit: it
+//! discovers which SFU a room's call uses, trades a Matrix OpenID token for a
+//! LiveKit JWT, publishes and retracts our `m.call.member` state event, and
+//! distributes our end-to-end encryption key over to-device messages.
+//!
+//! Only compiled when the `voip` feature is enabled.
+
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result, anyhow};
+use matrix_sdk::encryption::identities::Device;
+// The SDK's own reqwest, not iamb's direct dependency: the graph carries two
+// majors, and this has to be the one the shared client was built with.
+use matrix_sdk::Client;
+use matrix_sdk::reqwest::{self, header::CONTENT_TYPE};
+use matrix_sdk::room::Room as MatrixRoom;
+use matrix_sdk::ruma::api::client::account::request_openid_token;
+use matrix_sdk::ruma::events::call::member::{
+    ActiveFocus,
+    ActiveLivekitFocus,
+    Application,
+    CallApplicationContent,
+    CallMemberEventContent,
+    CallMemberStateKey,
+    CallScope,
+    Focus,
+    LivekitFocus,
+};
+use matrix_sdk::ruma::events::relation::Reference;
+use matrix_sdk::ruma::events::rtc::decline::RtcDeclineEventContent;
+use matrix_sdk::ruma::events::rtc::notification::{
+    CallIntent,
+    NotificationType,
+    RtcNotificationEventContent,
+};
+use matrix_sdk::ruma::events::{AnyToDeviceEventContent, Mentions, StaticEventContent};
+use matrix_sdk::ruma::serde::Raw;
+use matrix_sdk::ruma::{
+    DeviceId,
+    EventId,
+    MilliSecondsSinceUnixEpoch,
+    OwnedEventId,
+    OwnedUserId,
+    UserId,
+};
+use matrix_sdk_crypto::CollectStrategy;
+use serde::{Deserialize, Serialize};
+use serde_json::value::to_raw_value;
+
+use super::{
+    CallEncryptionKey,
+    CallEncryptionKeysEventContent,
+    CallEncryptionKeysRoomEventContent,
+    CallKeyMember,
+    CallKeySession,
+};
+
+/// The `.well-known/matrix/client` key listing a homeserver's advertised
+/// MatrixRTC foci ([MSC4143]).
+///
+/// [MSC4143]: https://github.com/matrix-org/matrix-spec-proposals/pull/4143
+const WELL_KNOWN_FOCI: &str = "org.matrix.msc4143.rtc_foci";
+
+/// Everything needed to open the LiveKit connection for a call.
+#[derive(Clone, Debug)]
+pub struct SfuCredentials {
+    /// The SFU's WebSocket URL (`wss://…`), as returned by the JWT service.
+    pub url: String,
+
+    /// The LiveKit access token authorizing this participant.
+    pub jwt: String,
+}
+
+/// The response body of the `lk-jwt-service` `/sfu/get` endpoint.
+#[derive(Deserialize)]
+struct SfuGetResponse {
+    url: String,
+    jwt: String,
+}
+
+/// The OpenID token as `lk-jwt-service` expects to receive it.
+#[derive(Serialize)]
+struct OpenIdTokenBody {
+    access_token: String,
+    token_type: String,
+    matrix_server_name: String,
+}
+
+/// The request body of the `lk-jwt-service` `/sfu/get` endpoint.
+#[derive(Serialize)]
+struct SfuGetRequest {
+    room: String,
+    openid_token: OpenIdTokenBody,
+    device_id: String,
+}
+
+/// The state key our own `m.call.member` event is published under.
+///
+///
+/// MatrixRTC gives every device its own membership event, keyed by user and
+/// device, so several devices of the same user can be in a call at once.
+///
+/// The key takes the leading underscore form (`_{user_id}_{device_id}`,
+/// [MSC3757]) rather than the bare `{user_id}_{device_id}`. A state key that
+/// starts with `@` may only be set by the user it names, so the bare form
+/// which starts with `@` but has a device suffix, is rejected by the
+/// homeserver as an attempt to set another user's state, even in one's own
+/// room. The leading underscore sidesteps that auth rule while still letting
+/// each device own its own membership.
+///
+/// [MSC3757]: https://github.com/matrix-org/matrix-spec-proposals/pull/3757
+pub fn membership_state_key(user_id: &UserId, device_id: &DeviceId) -> CallMemberStateKey {
+    CallMemberStateKey::new(user_id.to_owned(), Some(device_id.to_string()), true)
+}
+
+/// The LiveKit participant identity we connect to the SFU with.
+///
+/// Must match what other clients derive for us, since E2EE keys are looked up
+/// per participant identity.
+pub fn participant_identity(user_id: &UserId, device_id: &DeviceId) -> String {
+    format!("{user_id}:{device_id}")
+}
+
+/// Find the LiveKit focus to use for the call in `room`.
+///
+/// Prefers a focus already advertised by a participant, so that a late joiner
+/// lands on the same SFU *and* the same LiveKit room as everyone else. The
+/// focus carries the LiveKit room alias, so adopting it wholesale is what keeps
+/// us in the same conversation. When nobody is in the call yet, falls back to
+/// the homeserver's advertised foci, naming the LiveKit room after the Matrix
+/// room as Element Call does.
+pub async fn discover_focus(
+    client: &Client,
+    http: &reqwest::Client,
+    room: &MatrixRoom,
+) -> Result<LivekitFocus> {
+    if let Some(focus) = focus_from_memberships(room).await {
+        return Ok(focus);
+    }
+
+    let service_url = service_url_from_well_known(client, http)
+        .await
+        .context("no LiveKit focus advertised by the room or the homeserver")?;
+
+    Ok(LivekitFocus::new(room.room_id().to_string(), service_url))
+}
+
+/// Pull the LiveKit focus of the *oldest* membership out of the room's existing
+/// `m.call.member` state events.
+///
+/// Which membership wins is not arbitrary. Every participant, ours included,
+/// advertises `focus_selection: "oldest_membership"` in its `ActiveFocus`, which
+/// is a promise about how the active focus is chosen. Taking whichever focus the
+/// state store happened to hand back first breaks that promise the moment two
+/// participants prefer different focus: a federated call where each side's
+/// homeserver advertises its own SFU is exactly that case, and lands us alone
+/// in a LiveKit room while everyone else talks in another.
+async fn focus_from_memberships(room: &MatrixRoom) -> Option<LivekitFocus> {
+    let events = room.get_state_events_static::<CallMemberEventContent>().await.ok()?;
+
+    let mut oldest: Option<(MilliSecondsSinceUnixEpoch, LivekitFocus)> = None;
+
+    for event in events {
+        let Ok(event) = event.deserialize() else {
+            continue;
+        };
+
+        let Some(event) = event.as_sync().and_then(|ev| ev.as_original()) else {
+            continue;
+        };
+
+        // A membership published by a spec-conforming client omits `created_ts`
+        // on its initial join and lets the server stamp it, so the fallback is
+        // load bearing: without it those memberships have no age to compare and
+        // `active_memberships` cannot tell whether they have expired.
+        let origin = Some(event.origin_server_ts);
+
+        for membership in event.content.active_memberships(origin) {
+            let Some(created_ts) = membership.created_ts().or(origin) else {
+                continue;
+            };
+
+            for focus in membership.foci_preferred() {
+                let Focus::Livekit(focus) = focus else {
+                    continue;
+                };
+
+                if oldest.as_ref().is_none_or(|(seen, _)| created_ts < *seen) {
+                    oldest = Some((created_ts, focus.clone()));
+                }
+            }
+        }
+    }
+
+    oldest.map(|(_, focus)| focus)
+}
+
+/// Read the homeserver's `.well-known/matrix/client` and return the first
+/// advertised LiveKit focus's JWT service URL.
+///
+/// The advertised entry carries only the service URL, not a `livekit_alias`:
+/// the LiveKit room is per-call and named by the client, so the caller supplies
+/// the alias itself. Deserializing into a full [`LivekitFocus`] would therefore
+/// always fail here, its `alias` field is required, which is why this pulls
+/// the URL out of the raw JSON instead.
+async fn service_url_from_well_known(client: &Client, http: &reqwest::Client) -> Result<String> {
+    // `.well-known/matrix/client` lives on the *server name* domain, not on the
+    // homeserver base URL, the whole point of the file is to point at the
+    // latter from the former. Asking the homeserver for it 404s on every
+    // deployment that uses delegation, which is most of the large ones
+    // (`matrix.org` delegates to `matrix-client.matrix.org`).
+    //
+    // `Client::server` is that domain when the client was built by discovery,
+    // and `None` when it was pointed straight at a homeserver URL, in which
+    // case the two are the same thing.
+    let base = client.server().cloned().unwrap_or_else(|| client.homeserver());
+    let url = base.join(".well-known/matrix/client")?;
+    // Decoded by hand rather than with `Response::json`: the SDK's reqwest is
+    // built without its `json` feature, and taking the body as text is all that
+    // convenience wraps anyway.
+    let body = http.get(url).send().await?.error_for_status()?.text().await?;
+    let body: serde_json::Value = serde_json::from_str(&body)?;
+
+    let foci = body
+        .get(WELL_KNOWN_FOCI)
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow!("homeserver advertises no {WELL_KNOWN_FOCI}"))?;
+
+    for focus in foci {
+        let is_livekit = focus.get("type").and_then(serde_json::Value::as_str) == Some("livekit");
+        let service_url = focus.get("livekit_service_url").and_then(serde_json::Value::as_str);
+
+        if let (true, Some(service_url)) = (is_livekit, service_url) {
+            return Ok(service_url.to_owned());
+        }
+    }
+
+    Err(anyhow!("homeserver advertises no LiveKit focus"))
+}
+
+/// Trade a Matrix OpenID token for a LiveKit JWT at the focus's JWT service.
+///
+/// The service (`lk-jwt-service`) verifies the OpenID token against our
+/// homeserver and answers with the SFU URL and an access token scoped to the
+/// LiveKit room.
+pub async fn request_sfu_credentials(
+    client: &Client,
+    http: &reqwest::Client,
+    focus: &LivekitFocus,
+    device_id: &DeviceId,
+) -> Result<SfuCredentials> {
+    let user_id = client.user_id().ok_or_else(|| anyhow!("not logged in"))?;
+    let token = client
+        .send(request_openid_token::v3::Request::new(user_id.to_owned()))
+        .await?;
+
+    let request = SfuGetRequest {
+        // The focus's own alias names the LiveKit room. Deriving it ourselves
+        // would put us in a different room from anyone who joined via a focus
+        // that names it differently.
+        room: focus.alias.clone(),
+        openid_token: OpenIdTokenBody {
+            access_token: token.access_token,
+            token_type: token.token_type.to_string(),
+            matrix_server_name: token.matrix_server_name.to_string(),
+        },
+        device_id: device_id.to_string(),
+    };
+
+    let endpoint = format!("{}/sfu/get", focus.service_url.trim_end_matches('/'));
+    let response = http
+        .post(&endpoint)
+        .header(CONTENT_TYPE, "application/json")
+        .body(serde_json::to_vec(&request)?)
+        .send()
+        .await
+        .with_context(|| format!("could not reach the LiveKit JWT service at {endpoint}"))?;
+
+    // Keep the response body: on a rejection it carries the reason (e.g. why the
+    // OpenID token or room was refused), which `error_for_status` would discard.
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if !status.is_success() {
+        let reason = body.trim();
+        let reason = if reason.is_empty() {
+            "(no details)"
+        } else {
+            reason
+        };
+
+        return Err(anyhow!(
+            "the LiveKit JWT service at {endpoint} rejected our request ({status}): {reason}"
+        ));
+    }
+
+    let response: SfuGetResponse =
+        serde_json::from_str(&body).context("malformed response from the LiveKit JWT service")?;
+
+    Ok(SfuCredentials { url: response.url, jwt: response.jwt })
+}
+
+/// How far ahead of *now* a published membership's expiry is set.
+///
+/// A membership outlives the client that published it: if we die without
+/// retracting, this is how long we haunt the room's participant list. Shorter is
+/// tidier, but a call whose refreshes are all failing drops out of everyone
+/// else's view once it elapses, so it also has to be comfortably longer than
+/// [`MEMBERSHIP_REFRESH_INTERVAL`] - here, four missed refreshes.
+pub const MEMBERSHIP_LIFETIME: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// How often a running call republishes its membership to push the expiry out.
+pub const MEMBERSHIP_REFRESH_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// The `expires` value a membership created at `created_ts` needs in order to
+/// stay valid for [`MEMBERSHIP_LIFETIME`] from now.
+///
+/// MatrixRTC expiry is `created_ts + expires`, **not** `origin_server_ts +
+/// expires`. Resending a membership that copies its original `created_ts`
+/// forward therefore does not extend anything. The refresh has to grow
+/// `expires` by however long the call has been running.
+fn membership_expires(created_ts: MilliSecondsSinceUnixEpoch) -> Duration {
+    let elapsed = created_ts
+        .to_system_time()
+        .and_then(|created| SystemTime::now().duration_since(created).ok())
+        .unwrap_or_default();
+
+    elapsed + MEMBERSHIP_LIFETIME
+}
+
+/// Announce that this device is in the room's call.
+///
+/// Used both to join and to refresh. `created_ts` names the instant the
+/// membership chain began: `None` on the initial join, which is what MSC3401
+/// requires - the server then stamps the event and `origin_server_ts` becomes
+/// the creation time. A refresh passes the value read back by
+/// [`our_membership_created_ts`] so the session keeps its original start while
+/// its expiry moves forward.
+///
+/// Stamping `created_ts` ourselves on the initial join would put our own clock
+/// in charge of when every other participant thinks we joined. A clock running
+/// fast keeps us in the participant list past our welcome; one running slow
+/// publishes a membership that everybody else considers already expired, so we
+/// are connected to the SFU and invisible in the room.
+///
+/// Returns the event ID of the published membership, which the call notification
+/// ([`send_call_notification`]) references so that receivers can tie the ring
+/// back to the session it announces.
+pub async fn publish_membership(
+    room: &MatrixRoom,
+    user_id: &UserId,
+    device_id: &DeviceId,
+    focus: &LivekitFocus,
+    created_ts: Option<MilliSecondsSinceUnixEpoch>,
+) -> Result<OwnedEventId> {
+    let application =
+        Application::Call(CallApplicationContent::new(String::new(), CallScope::Room));
+
+    // Expiry runs from `created_ts`, so a refresh has to grow `expires` by
+    // however long the call has already been running; merely resending the same
+    // value renews nothing. A fresh chain starts the clock now.
+    let expires = match created_ts {
+        Some(created_ts) => membership_expires(created_ts),
+        None => MEMBERSHIP_LIFETIME,
+    };
+
+    let content = CallMemberEventContent::new(
+        application,
+        device_id.to_owned(),
+        ActiveFocus::Livekit(ActiveLivekitFocus::new()),
+        vec![Focus::Livekit(focus.clone())],
+        created_ts,
+        Some(expires),
+    );
+
+    let response = room
+        .send_state_event_for_key(&membership_state_key(user_id, device_id), content)
+        .await?;
+
+    Ok(response.event_id)
+}
+
+/// When our own membership chain for this room's call began.
+///
+/// Read back from room state rather than remembered from the join, because the
+/// initial join deliberately leaves `created_ts` unset for the server to stamp
+/// (see [`publish_membership`]). Falls back to `origin_server_ts`, which is
+/// exactly what the server stamped it with.
+///
+/// `None` means our membership has not synced back yet, in which case the caller
+/// should start a fresh chain rather than guess.
+pub async fn our_membership_created_ts(
+    room: &MatrixRoom,
+    user_id: &UserId,
+    device_id: &DeviceId,
+) -> Option<MilliSecondsSinceUnixEpoch> {
+    let event = room
+        .get_state_event_static_for_key::<CallMemberEventContent, _>(&membership_state_key(
+            user_id, device_id,
+        ))
+        .await
+        .ok()??;
+
+    let event = event.deserialize().ok()?;
+    let event = event.as_sync()?.as_original()?;
+    let origin = Some(event.origin_server_ts);
+
+    event
+        .content
+        .active_memberships(origin)
+        .first()
+        .and_then(|membership| membership.created_ts())
+        .or(origin)
+}
+
+/// Announce that this device has left the room's call.
+///
+/// MatrixRTC signals a departure with an empty membership rather than a
+/// redaction, so the event stays in the room state as a tombstone.
+pub async fn retract_membership(
+    room: &MatrixRoom,
+    user_id: &UserId,
+    device_id: &DeviceId,
+) -> Result<()> {
+    let content = CallMemberEventContent::new_empty(None);
+
+    room.send_state_event_for_key(&membership_state_key(user_id, device_id), content)
+        .await?;
+
+    Ok(())
+}
+
+/// Send our E2EE key to every device of every user in `recipients`.
+///
+/// Called once after joining to seed the participants already in the call, and
+/// again whenever a late joiner appears, since LiveKit's per-participant key
+/// provider needs our key before it can decrypt anything we publish.
+///
+/// The key is Olm-encrypted to each recipient device rather than sent in the
+/// clear. Sending it unencrypted would hand the homeserver the key to every
+/// call it relays, which leaves the media end to end encrypted only against
+/// the SFU - the one party that was never going to have the key anyway.
+///
+/// Recipients that resolve to no devices at all, or that we could not establish
+/// an Olm session with, are logged and skipped: excluding one participant is
+/// better than aborting distribution for everybody. Failing to reach *every*
+/// device is an error, since that is indistinguishable from not having sent the
+/// key at all.
+pub async fn send_encryption_key(
+    client: &Client,
+    room: &MatrixRoom,
+    device_id: &DeviceId,
+    index: u8,
+    key: &[u8],
+    recipients: impl IntoIterator<Item = OwnedUserId>,
+) -> Result<()> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+
+    let user_id = client.user_id().context("not logged in")?;
+
+    let content = CallEncryptionKeysEventContent {
+        keys: CallEncryptionKey { index, key: STANDARD_NO_PAD.encode(key) },
+        member: CallKeyMember {
+            id: user_id.to_string(),
+            claimed_device_id: device_id.to_owned(),
+        },
+        room_id: room.room_id().to_string(),
+        session: CallKeySession::room_call(),
+        sent_ts: Some(MilliSecondsSinceUnixEpoch::now()),
+    };
+
+    let raw = Raw::<AnyToDeviceEventContent>::from_json(to_raw_value(&content)?);
+
+    let mut devices = Vec::new();
+
+    for recipient in recipients {
+        // Our own device is in the store too, and Olm has no session with
+        // itself; every *other* device of ours is a legitimate recipient, since
+        // we may well be in the call from two clients at once.
+        let ours = recipient == user_id;
+        let found = recipient_devices(client, &recipient).await?;
+
+        let before = devices.len();
+        devices.extend(
+            found
+                .into_iter()
+                .filter(|device| !(ours && device.device_id() == device_id)),
+        );
+
+        if devices.len() == before {
+            tracing::warn!(
+                user_id = %recipient,
+                "no devices to send our call encryption key to; they will not hear us"
+            );
+        }
+    }
+
+    if devices.is_empty() {
+        return Ok(());
+    }
+
+    let total = devices.len();
+    let failures = client
+        .encryption()
+        .encrypt_and_send_raw_to_device(
+            devices.iter().collect(),
+            CallEncryptionKeysEventContent::TYPE,
+            raw,
+            CollectStrategy::AllDevices,
+        )
+        .await
+        .context("could not encrypt the call encryption key")?;
+
+    if failures.len() == total {
+        return Err(anyhow!(
+            "could not deliver the call encryption key to any of the {total} devices in the call"
+        ));
+    }
+
+    for (user_id, device_id) in &failures {
+        tracing::warn!(%user_id, %device_id, "could not send our call encryption key to a device");
+    }
+
+    Ok(())
+}
+
+/// Send our E2EE key to the room as an `io.element.call.encryption_keys` room
+/// event.
+///
+/// The other half of [`send_encryption_key`], and the transport MatrixRTC used
+/// before to-device messages. Element Call builds from before the switch listen
+/// for nothing else, so a client that only speaks to-device is inaudible to
+/// them and cannot hear them either. A call in which the signalling all
+/// succeeds and no media is ever decrypted. Sending both is what matrix-js-sdk
+/// does while the migration is in flight.
+///
+/// This does not weaken the to-device path: in an encrypted room the event is
+/// megolm-encrypted like any other, and in an unencrypted room the key is no
+/// more exposed than the call itself already is. The to-device copy remains the
+/// one every current client actually uses.
+///
+/// Failure is logged by the caller rather than fatal: the to-device copy is the
+/// primary transport and has already gone out by the time this runs.
+pub async fn send_encryption_key_to_room(
+    room: &MatrixRoom,
+    device_id: &DeviceId,
+    index: u8,
+    key: &[u8],
+) -> Result<()> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+
+    let content = CallEncryptionKeysRoomEventContent {
+        keys: vec![CallEncryptionKey { index, key: STANDARD_NO_PAD.encode(key) }],
+        device_id: device_id.to_owned(),
+        call_id: String::new(),
+        sent_ts: Some(MilliSecondsSinceUnixEpoch::now()),
+    };
+
+    room.send(content).await?;
+
+    Ok(())
+}
+
+/// The devices of `user_id` that we can encrypt to.
+///
+/// Device lists are only tracked for users we share an *encrypted* room with,
+/// so in an unencrypted room the store can legitimately be empty on the first
+/// call. A `/keys/query` populates it; without this the key would silently go
+/// nowhere and the call would be audible to no one.
+async fn recipient_devices(client: &Client, user_id: &UserId) -> Result<Vec<Device>> {
+    let encryption = client.encryption();
+
+    let devices = encryption.get_user_devices(user_id).await?;
+    let devices = devices.devices().collect::<Vec<_>>();
+
+    if !devices.is_empty() {
+        return Ok(devices);
+    }
+
+    encryption
+        .request_user_identity(user_id)
+        .await
+        .with_context(|| format!("could not fetch the device list for {user_id}"))?;
+
+    Ok(encryption.get_user_devices(user_id).await?.devices().collect())
+}
+
+/// How long a call notification stays worth ringing for ([MSC4075]).
+///
+/// A notification is not a call invite that stands until answered: it is a ring
+/// with a deadline, and a receiver that comes online after the deadline must not
+/// start ringing for it. Thirty seconds matches Element Call, and doubles as the
+/// reason a client syncing days of backlog stays quiet
+///
+/// [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
+pub const NOTIFICATION_LIFETIME: Duration = Duration::from_secs(30);
+
+/// Whether a call in `room` should ring rather than notify quietly.
+///
+/// Ringing is for calls that are unambiguously *for you*: a direct chat, where
+/// there is one other person and they are calling you. In a group room the same
+/// treatment would have every member's client ring whenever anybody started a
+/// call, so those get a notification the user can ignore.
+pub async fn should_ring(room: &MatrixRoom) -> bool {
+    room.is_direct().await.unwrap_or(false)
+}
+
+/// Announce a newly started call to the room ([MSC4075]).
+///
+/// This is what makes other clients ring; it is separate from the `m.call.member`
+/// state event, which only says who is in the call. A client that publishes
+/// membership without this is joinable but silent - nobody is told to pick up.
+///
+/// Sent by whoever *starts* the call, not by everyone who joins it: a
+/// notification per join would ring the room again for every arrival, so the
+/// caller is responsible for checking that the call was empty first.
+///
+/// `membership` is the event ID returned by [`publish_membership`], referenced so
+/// that a receiver can tie the ring to the session it belongs to.
+///
+/// [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
+pub async fn send_call_notification(
+    room: &MatrixRoom,
+    membership: OwnedEventId,
+    ring: bool,
+) -> Result<()> {
+    let notification_type = if ring {
+        NotificationType::Ring
+    } else {
+        NotificationType::Notification
+    };
+
+    let mut content = RtcNotificationEventContent::new(
+        MilliSecondsSinceUnixEpoch::now(),
+        NOTIFICATION_LIFETIME,
+        notification_type,
+    );
+
+    // Everyone in the room is a candidate to answer, so the notification is
+    // addressed to the room rather than to named users. Without any mention the
+    // receiving side has no one to apply it to.
+    content.mentions = Some(Mentions::with_room_mention());
+    content.relates_to = Some(Reference::new(membership));
+
+    // We publish one microphone track and no camera, so anyone joining us can
+    // start with video off.
+    content.call_intent = Some(CallIntent::Audio);
+
+    room.send(content).await?;
+
+    Ok(())
+}
+
+/// Decline a call we were notified about ([MSC4310]).
+///
+/// Sent as a reference relation to the `m.rtc.notification` being declined, which
+/// is what lets other clients stop ringing on our behalf - in particular our own
+/// other devices, so answering or rejecting on one silences the rest.
+///
+/// [MSC4310]: https://github.com/matrix-org/matrix-spec-proposals/pull/4310
+pub async fn send_decline(room: &MatrixRoom, notification: &EventId) -> Result<()> {
+    room.send(RtcDeclineEventContent::new(notification.to_owned())).await?;
+
+    Ok(())
+}
+
+/// Whether the call in `room` already has participants.
+///
+/// Decides whether joining is *starting* a call, and so whether to ring the
+/// room, or merely joining one that is already ringing or under way.
+pub fn call_already_started(room: &MatrixRoom) -> bool {
+    room.has_active_room_call()
+}
+
+/// The users we distribute our E2EE key to: everyone joined to the room.
+///
+/// Our own user is included: another of our devices can be in the same call,
+/// and it needs our key like anyone else. [`send_encryption_key`] drops only
+/// *this* device from the resolved device list.
+pub async fn key_recipients(room: &MatrixRoom) -> Result<Vec<OwnedUserId>> {
+    Ok(room.joined_user_ids().await?)
+}

--- a/src/voip/matrix_rtc.rs
+++ b/src/voip/matrix_rtc.rs
@@ -151,12 +151,12 @@ pub async fn discover_focus(
 /// `m.call.member` state events.
 ///
 /// Which membership wins is not arbitrary. Every participant, ours included,
-/// advertises `focus_selection: "oldest_membership"` in its `ActiveFocus`, which
-/// is a promise about how the active focus is chosen. Taking whichever focus the
-/// state store happened to hand back first breaks that promise the moment two
-/// participants prefer different focus: a federated call where each side's
-/// homeserver advertises its own SFU is exactly that case, and lands us alone
-/// in a LiveKit room while everyone else talks in another.
+/// advertises `focus_selection: "oldest_membership"` in its [`ActiveFocus`],
+/// which is a promise about how the active focus is chosen. Taking whichever
+/// focus the state store happened to hand back first breaks that promise the
+/// moment two participants prefer different focus: a federated call where
+/// each side's homeserver advertises its own SFU is exactly that case, and
+/// lands us alone in a LiveKit room while everyone else talks in another.
 async fn focus_from_memberships(room: &MatrixRoom) -> Option<LivekitFocus> {
     let events = room.get_state_events_static::<CallMemberEventContent>().await.ok()?;
 
@@ -240,11 +240,14 @@ async fn service_url_from_well_known(client: &Client, http: &reqwest::Client) ->
     Err(anyhow!("homeserver advertises no LiveKit focus"))
 }
 
-/// Trade a Matrix OpenID token for a LiveKit JWT at the focus's JWT service.
+/// Trade a Matrix OpenID token for a LiveKit JWT at the focus's JWT service
+/// ([MSC4195]).
 ///
 /// The service (`lk-jwt-service`) verifies the OpenID token against our
 /// homeserver and answers with the SFU URL and an access token scoped to the
 /// LiveKit room.
+///
+/// [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
 pub async fn request_sfu_credentials(
     client: &Client,
     http: &reqwest::Client,
@@ -333,7 +336,7 @@ fn membership_expires(created_ts: MilliSecondsSinceUnixEpoch) -> Duration {
 /// Announce that this device is in the room's call.
 ///
 /// Used both to join and to refresh. `created_ts` names the instant the
-/// membership chain began: `None` on the initial join, which is what MSC3401
+/// membership chain began: `None` on the initial join, which is what [MSC3401]
 /// requires - the server then stamps the event and `origin_server_ts` becomes
 /// the creation time. A refresh passes the value read back by
 /// [`our_membership_created_ts`] so the session keeps its original start while
@@ -348,6 +351,8 @@ fn membership_expires(created_ts: MilliSecondsSinceUnixEpoch) -> Duration {
 /// Returns the event ID of the published membership, which the call notification
 /// ([`send_call_notification`]) references so that receivers can tie the ring
 /// back to the session it announces.
+///
+/// [MSC3401]: https://github.com/matrix-org/matrix-spec-proposals/pull/3401
 pub async fn publish_membership(
     room: &MatrixRoom,
     user_id: &UserId,

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -1,0 +1,1206 @@
+//! # Voice/Video calls (VoIP)
+//!
+//! This module implements voice calls for iamb using [LiveKit] for the media
+//! transport and the Matrix protocol (MatrixRTC) for signaling.
+//!
+//! It is only compiled when the `voip` feature is enabled.
+//!
+//! ## Layout
+//!
+//! - [`mod@self`] - call session state machine and the types exchanged over
+//!   Matrix signaling ([`CallManager`], [`CallSession`], [`CallStatus`]).
+//! - [`livekit_session`] - the LiveKit `Room` connection: audio capture,
+//!   playback, and end-to-end encryption key handling.
+//!
+//! ## Signaling overview
+//!
+//! Joining a call means:
+//! 1. Discover the LiveKit focus (SFU) URL from existing `m.call.member` state
+//!    events in the room.
+//! 2. Obtain an OpenID token and exchange it at the `lk-jwt-service` `/sfu/get`
+//!    endpoint for a LiveKit JWT.
+//! 3. Generate an E2EE key and connect to the LiveKit room.
+//! 4. Publish our own `m.call.member` state event (state key
+//!    `_{user_id}_{device_id}`) and share E2EE keys with other participants via
+//!    `io.element.call.encryption_keys` to-device events.
+//!
+
+pub mod devices;
+pub mod livekit_session;
+pub mod matrix_rtc;
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use matrix_sdk::ruma::{
+    MilliSecondsSinceUnixEpoch,
+    OwnedDeviceId,
+    OwnedEventId,
+    OwnedRoomId,
+    OwnedUserId,
+    UserId,
+    events::{Mentions, macros::EventContent},
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::UnboundedSender;
+
+use matrix_sdk::ruma::events::call::member::LivekitFocus;
+
+use self::livekit_session::{LiveKitSession, SessionConfig};
+use crate::worker::WorkerTask;
+
+/// A single E2EE key at a given index, as carried in an
+/// `io.element.call.encryption_keys` to-device event.
+///
+/// The key itself is unpadded base64 of the raw key material.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CallEncryptionKey {
+    /// The key index this key occupies in the sender's key ring.
+    pub index: u8,
+
+    /// The raw key material, unpadded base64.
+    pub key: String,
+}
+
+/// Who a key belongs to, as the sender identifies themselves.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CallKeyMember {
+    /// The user the key belongs to, as the sender wrote it.
+    ///
+    /// A plain [`String`] rather than an [`OwnedUserId`] on purpose. This field
+    /// is remote input, and ruma rejects the whole event if it does not
+    /// validate - taking the key down with it, which is silence for the rest of
+    /// the call. Nothing is lost by being lenient: the field is only ever
+    /// checked against the event's `sender`, which the homeserver vouches for,
+    /// and a value that does not parse cannot match a parsed sender anyway.
+    pub id: String,
+
+    /// The device the key belongs to.
+    ///
+    /// "Claimed" because nothing authenticates it: the homeserver vouches for
+    /// the event's `sender`, but the device named in the content is whatever the
+    /// sender chose to put there.
+    pub claimed_device_id: OwnedDeviceId,
+}
+
+/// The call session a key belongs to.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CallKeySession {
+    /// The kind of session; `m.call` for a voice or video call.
+    pub application: String,
+
+    /// Identifier of the call session; empty for the room-wide call.
+    pub call_id: String,
+
+    /// How widely the session is scoped; `m.room` for the room-wide call.
+    pub scope: String,
+}
+
+impl CallKeySession {
+    /// The session block describing a room's one and only call, matching the
+    /// `m.call.member` state published by `matrix_rtc::publish_membership`.
+    pub fn room_call() -> Self {
+        CallKeySession {
+            application: "m.call".to_owned(),
+            call_id: String::new(),
+            scope: "m.room".to_owned(),
+        }
+    }
+}
+
+/// The content of an `io.element.call.encryption_keys` to-device event.
+///
+/// Element Call participants send this to every other device in the call to
+/// distribute the key their media is encrypted with, and resend it whenever a
+/// late joiner appears.
+///
+/// This is *not* the shape of the identically named room event, which carries a
+/// `keys` array and names the device at the top level. The to-device event
+/// carries a single key and identifies the sender through `member`. Modelling it
+/// with the room event's shape is silently fatal: every incoming key fails to
+/// deserialize before it reaches a handler, and every key we send is dropped by
+/// the other end, leaving a call in which nobody can decrypt anybody.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "io.element.call.encryption_keys", kind = ToDevice)]
+pub struct CallEncryptionKeysEventContent {
+    /// The key this event distributes.
+    pub keys: CallEncryptionKey,
+
+    /// The participant the key belongs to.
+    pub member: CallKeyMember,
+
+    /// The room the call is taking place in, as the sender wrote it.
+    ///
+    /// Lenient for the same reason as [`CallKeyMember::id`]: a room id that
+    /// does not validate must not cost us the key it came with. It is only used
+    /// to tell a key for this call from one for a call we are not in, which is
+    /// a comparison that works just as well on the raw string.
+    pub room_id: String,
+
+    /// The call session the key is for.
+    pub session: CallKeySession,
+
+    /// When the sender sent this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_ts: Option<MilliSecondsSinceUnixEpoch>,
+}
+
+/// The content of an `io.element.call.encryption_keys` **room** event.
+///
+/// The older of MatrixRTC's two key transports, and still the only one some
+/// Element Call builds speak. It carries the same key material as
+/// [`CallEncryptionKeysEventContent`] in a different shape: a `keys` *array*,
+/// the device named at the top level, and no `room_id` or `session` block
+/// the event is already in the room, and `call_id` names the session.
+///
+/// A client that only sends and receives the to-device form interoperates with
+/// nothing but itself and current Element Call. Speaking both is what
+/// matrix-js-sdk does for the duration of the migration, and it costs one extra
+/// event per key.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "io.element.call.encryption_keys", kind = MessageLike)]
+pub struct CallEncryptionKeysRoomEventContent {
+    /// The keys this event distributes.
+    pub keys: Vec<CallEncryptionKey>,
+
+    /// The device the keys belong to.
+    ///
+    /// The user is the event's `sender`, which the homeserver vouches for.
+    pub device_id: OwnedDeviceId,
+
+    /// Identifier of the call session; empty for the room-wide call.
+    pub call_id: String,
+
+    /// When the sender sent this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_ts: Option<MilliSecondsSinceUnixEpoch>,
+}
+
+/// An E2EE key received from another participant, resolved to the participant
+/// it belongs to.
+#[derive(Clone, Debug)]
+pub struct ReceivedCallKey {
+    /// The room the call is taking place in.
+    pub room_id: OwnedRoomId,
+
+    /// The user that sent the key.
+    pub user_id: OwnedUserId,
+
+    /// The device that sent the key.
+    pub device_id: OwnedDeviceId,
+
+    /// The key index within that participant's key ring.
+    pub index: u8,
+
+    /// The decoded raw key material.
+    pub key: Vec<u8>,
+}
+
+impl ReceivedCallKey {
+    /// The LiveKit participant identity this key applies to.
+    ///
+    /// Element Call derives it as `{user_id}:{device_id}`, matching the identity
+    /// each participant connects to the SFU with.
+    pub fn participant_identity(&self) -> String {
+        format!("{}:{}", self.user_id, self.device_id)
+    }
+}
+
+/// How many inbound keys the inbox holds before it starts dropping the oldest.
+///
+/// The sync handler pushes every `io.element.call.encryption_keys` event it
+/// sees, but only a *running call* drains the inbox so outside a call, and for
+/// rooms whose calls we are not in, nothing ever takes these out again. Without
+/// a cap the inbox is an unbounded buffer fed by remote peers, growing for as
+/// long as the client stays open.
+///
+/// Dropping the oldest is the right end to lose: keys are cumulative per
+/// participant and each new key for a given index supersedes the last, so the
+/// newest entries are the ones that still describe the call.
+const KEY_INBOX_LIMIT: usize = 256;
+
+/// Keys received from other participants, waiting to be handed to LiveKit.
+///
+/// The Matrix sync handler and the call's LiveKit session live on different
+/// threads, so inbound keys are buffered here rather than applied directly. Keys
+/// can also arrive before we have finished joining, in which case the session
+/// drains whatever accumulated once it connects.
+///
+/// Bounded at [`KEY_INBOX_LIMIT`]; see there for why that matters.
+#[derive(Clone, Default)]
+pub struct KeyInbox(Arc<Mutex<VecDeque<ReceivedCallKey>>>);
+
+impl KeyInbox {
+    /// Buffer a newly received key, evicting the oldest if the inbox is full.
+    pub fn push(&self, key: ReceivedCallKey) {
+        if let Ok(mut keys) = self.0.lock() {
+            while keys.len() >= KEY_INBOX_LIMIT {
+                keys.pop_front();
+            }
+
+            keys.push_back(key);
+        }
+    }
+
+    /// Take everything buffered so far, leaving the inbox empty.
+    pub fn drain(&self) -> Vec<ReceivedCallKey> {
+        match self.0.lock() {
+            Ok(mut keys) => std::mem::take(&mut *keys).into(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// How many keys are currently buffered.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.lock().map(|keys| keys.len()).unwrap_or(0)
+    }
+}
+
+/// A call someone has rung us about and that we have neither joined nor
+/// declined ([MSC4075]).
+///
+/// Distinct from "a call is happening in this room", which is what
+/// `m.call.member` state says: this is somebody actively asking *us* to pick up,
+/// and it is the thing `:call decline` answers.
+///
+/// [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IncomingCall {
+    /// The `m.rtc.notification` event that rang us.
+    ///
+    /// Kept because declining is a reference relation to it, so a decline is
+    /// impossible without having held on to the event ID.
+    pub notification: OwnedEventId,
+
+    /// Who started the call.
+    pub from: OwnedUserId,
+
+    /// When this stops being worth ringing about.
+    ///
+    /// Computed by the SDK from the sender's timestamp and the server's, so a
+    /// caller with a badly set clock cannot ring us indefinitely.
+    pub expires_at: MilliSecondsSinceUnixEpoch,
+
+    /// Whether the caller asked for an audible ring rather than a quiet
+    /// notification.
+    pub ring: bool,
+}
+
+/// Whether a call notification's mentions address us.
+///
+/// Mentions are how MSC4075 says who should be rung, so this is what keeps a
+/// call aimed at two specific people in a large room from ringing everybody. A
+/// notification carrying no mentions at all addresses nobody and is ignored:
+/// treating it as room-wide would make the absence of a target mean the widest
+/// possible target.
+pub fn ring_is_for_us(mentions: Option<&Mentions>, user_id: &UserId) -> bool {
+    match mentions {
+        Some(mentions) => mentions.room || mentions.user_ids.contains(user_id),
+        None => false,
+    }
+}
+
+impl IncomingCall {
+    /// Whether this notification is still within its lifetime.
+    ///
+    /// Checked at every read rather than cleared on a timer: an expired ring
+    /// needs to stop being offered as answerable even if nothing has happened in
+    /// the room since, and nothing else would wake us to clear it.
+    pub fn is_live(&self) -> bool {
+        self.expires_at > MilliSecondsSinceUnixEpoch::now()
+    }
+}
+
+/// State for the call the local user is currently participating in.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveCall {
+    /// The room whose call we have joined.
+    pub room_id: OwnedRoomId,
+
+    /// Whether we have finished connecting to the SFU.
+    ///
+    /// Joining returns as soon as the signalling is done, but the SFU
+    /// connection is still being established on the call thread, so there is a
+    /// window where we are in the call without being able to hear anyone.
+    pub connected: bool,
+
+    /// Whether our microphone is currently muted.
+    pub muted: bool,
+
+    /// The participants LiveKit currently reports as speaking.
+    ///
+    /// Resolved back to Matrix users from the SFU participant identities, so the
+    /// UI can highlight them in the participant list without knowing anything
+    /// about LiveKit.
+    pub speakers: Vec<OwnedUserId>,
+}
+
+/// The call state the UI renders.
+///
+/// There is exactly one writer, the worker, which owns the call, and the UI
+/// only ever reads. That matters because the obvious alternative, letting the UI
+/// keep its own copy and update it from command results, gives two sources of
+/// truth for one fact and they drift apart the moment a call ends on its own.
+///
+/// This is deliberately *not* stored behind the [`AsyncProgramStore`] lock: the
+/// UI holds that lock while blocking on a worker reply, so the worker cannot
+/// take it without risking deadlock. A tiny `std` mutex, never held across an
+/// `await`, sidesteps that entirely.
+///
+/// [`AsyncProgramStore`]: crate::base::AsyncProgramStore
+#[derive(Clone, Default)]
+pub struct CallStatus(Arc<Mutex<Option<ActiveCall>>>);
+
+impl CallStatus {
+    /// The call currently in progress, if any.
+    pub fn get(&self) -> Option<ActiveCall> {
+        self.0.lock().ok().and_then(|call| call.clone())
+    }
+
+    /// Record that we have joined the call in `room_id` and are connecting.
+    pub fn joined(&self, room_id: OwnedRoomId) {
+        if let Ok(mut call) = self.0.lock() {
+            *call = Some(ActiveCall {
+                room_id,
+                connected: false,
+                muted: false,
+                speakers: Vec::new(),
+            });
+        }
+    }
+
+    /// Record that the SFU connection is up and media is flowing.
+    pub fn connected(&self) {
+        if let Ok(mut call) = self.0.lock() {
+            if let Some(call) = call.as_mut() {
+                call.connected = true;
+            }
+        }
+    }
+
+    /// Record that the call is over, however it ended.
+    pub fn left(&self) {
+        if let Ok(mut call) = self.0.lock() {
+            *call = None;
+        }
+    }
+
+    /// Record the microphone mute state of the call in progress.
+    pub fn set_muted(&self, muted: bool) {
+        if let Ok(mut call) = self.0.lock() {
+            if let Some(call) = call.as_mut() {
+                call.muted = muted;
+            }
+        }
+    }
+
+    /// Record who the SFU currently reports as speaking.
+    pub fn set_speakers(&self, speakers: Vec<OwnedUserId>) {
+        if let Ok(mut call) = self.0.lock() {
+            if let Some(call) = call.as_mut() {
+                call.speakers = speakers;
+            }
+        }
+    }
+}
+
+/// A control message sent from the worker to the call's dedicated thread.
+enum CallControl {
+    /// Mute (`true`) or unmute (`false`) the local microphone.
+    Mute(bool),
+
+    /// Start encrypting our media with a new key at the given index.
+    ///
+    /// Sent after the worker has rotated the key and told the remaining
+    /// participants about it.
+    SetKey(u8, Vec<u8>),
+
+    /// Tear the call down and let the thread exit.
+    Shutdown,
+}
+
+/// Something the call thread needs the worker to do on its behalf.
+///
+/// The call thread owns no Matrix state, so anything that has to talk to the
+/// homeserver sharing our E2EE key with a late joiner, reporting that the SFU
+/// dropped us goes back to the worker as one of these.
+#[derive(Debug)]
+pub enum CallNotice {
+    /// We are connected to the SFU and exchanging media.
+    Connected,
+
+    /// A participant joined the SFU and needs our E2EE key.
+    ShareKey(OwnedUserId),
+
+    /// Participants left the SFU, so our key should be rotated and reshared.
+    ///
+    /// Sent after a short debounce rather than per departure, so that everyone
+    /// leaving at the end of a call causes one rotation instead of one each.
+    RotateKey,
+
+    /// The set of participants the SFU reports as currently speaking.
+    Speakers(Vec<OwnedUserId>),
+
+    /// The LiveKit session ended without us asking it to.
+    Ended(String),
+}
+
+/// How often the call thread hands newly arrived E2EE keys to LiveKit.
+const KEY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// How long to wait for the SFU to acknowledge us leaving before giving up.
+///
+/// Hanging up joins this thread from the worker, which the UI is blocked on, so
+/// an unreachable SFU must not be able to freeze the application indefinitely.
+const DISCONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// How long to wait after a participant leaves before rotating our E2EE key.
+///
+/// Departures cluster: a call winding down empties the room in a burst, and
+/// rotating per departure would burn several key indices and send a to-device
+/// message for each. Waiting a beat collapses that into one rotation.
+const KEY_ROTATION_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// A single active call the user is participating in.
+///
+/// Owned by the worker thread and tracked by [`CallManager`].
+pub struct CallSession {
+    /// The room whose call this is.
+    pub room_id: OwnedRoomId,
+
+    /// The system audio devices this call is using.
+    ///
+    /// A second handle on the same reference-counted device module the call
+    /// thread holds, so that `:call device` can hot-swap devices mid-call
+    /// without going through the control channel.
+    pub audio: livekit::PlatformAudio,
+
+    /// The E2EE key our own media is encrypted with, kept so that it can be
+    /// resent to participants that join after us.
+    pub key: Vec<u8>,
+
+    /// The LiveKit focus this call is using.
+    ///
+    /// Kept so that a membership refresh republishes exactly what the original
+    /// join advertised a refresh that dropped or changed the focus would tell
+    /// late joiners to connect to a different SFU than the one we are on.
+    pub focus: LivekitFocus,
+
+    /// The key ring slot [`CallSession::key`] occupies.
+    ///
+    /// Advances on every rotation so that participants can tell a new key from
+    /// the one it replaces, and so that media still in flight under the old key
+    /// stays decryptable while the change propagates.
+    pub key_index: u8,
+
+    /// Whether the local microphone is currently muted.
+    pub muted: bool,
+
+    /// Sends control messages to the call's dedicated thread.
+    control: std::sync::mpsc::Sender<CallControl>,
+
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl CallSession {
+    /// Create a new session in the [`CallPhase::Connecting`] phase and spawn the
+    /// dedicated OS thread that drives the call's media work.
+    ///
+    /// `notices` carries work the call thread cannot do itself back to the
+    /// worker, which owns the Matrix client.
+    pub fn new(
+        config: SessionConfig,
+        room_id: OwnedRoomId,
+        focus: LivekitFocus,
+        notices: UnboundedSender<WorkerTask>,
+    ) -> std::io::Result<Self> {
+        let (control, rx) = std::sync::mpsc::channel();
+        let key = config.e2ee_key.clone();
+        let audio = config.audio.clone();
+
+        let thread = std::thread::Builder::new().name("iamb-voip".into()).spawn({
+            let room_id = room_id.clone();
+
+            move || call_thread(rx, config, room_id, notices)
+        })?;
+
+        Ok(CallSession {
+            room_id,
+            audio,
+            key,
+            focus,
+            key_index: livekit_session::FIRST_KEY_INDEX,
+            muted: false,
+            control,
+            thread: Some(thread),
+        })
+    }
+
+    /// Update the mute state and signal the call thread.
+    pub fn set_muted(&mut self, muted: bool) {
+        self.muted = muted;
+        let _ = self.control.send(CallControl::Mute(muted));
+    }
+
+    /// The slot the next rotation will move to.
+    ///
+    /// Distribution happens before the switch, so the caller needs the index
+    /// ahead of [`CallSession::adopt_key`] rather than as a result of it.
+    pub fn next_key_index(&self) -> u8 {
+        livekit_session::next_key_index(self.key_index)
+    }
+
+    /// Start encrypting our media with `key` at `index`.
+    ///
+    /// Only call this once the remaining participants have been told, or our
+    /// media becomes undecryptable to them.
+    pub fn adopt_key(&mut self, index: u8, key: Vec<u8>) {
+        self.key_index = index;
+        self.key = key.clone();
+
+        let _ = self.control.send(CallControl::SetKey(index, key));
+    }
+}
+
+/// Reports the call as finished however the call thread stops.
+///
+/// Without this, a thread that dies unexpectedly. A panic, or a failure before
+/// the control loop starts, leaves the worker holding a session for a call that
+/// is not happening, and the UI showing a banner for it forever.
+///
+/// Disarmed on the paths where the worker already knows: it asked us to shut
+/// down, or it dropped the session out from under us.
+struct EndGuard {
+    room_id: OwnedRoomId,
+    notices: UnboundedSender<WorkerTask>,
+    reason: Option<String>,
+}
+
+impl EndGuard {
+    fn new(room_id: OwnedRoomId, notices: UnboundedSender<WorkerTask>) -> Self {
+        let reason = Some("the call thread stopped unexpectedly".to_string());
+
+        EndGuard { room_id, notices, reason }
+    }
+
+    /// Report `reason` if the thread stops from here on.
+    fn failing(&mut self, reason: String) {
+        self.reason = Some(reason);
+    }
+
+    /// The worker already knows the call is over; stay quiet.
+    fn disarm(&mut self) {
+        self.reason = None;
+    }
+}
+
+impl Drop for EndGuard {
+    fn drop(&mut self) {
+        let Some(reason) = self.reason.take() else {
+            return;
+        };
+
+        let notice = CallNotice::Ended(reason);
+        let _ = self.notices.send(WorkerTask::CallNotice(self.room_id.clone(), notice));
+    }
+}
+
+/// Body of the dedicated VoIP thread.
+///
+/// The thread owns a private tokio runtime that exists only for the duration of
+/// the call: LiveKit's client is async, but running it here keeps every bit of
+/// media work off the runtime that serves the UI. The thread itself does the one
+/// thing it is best at, blocking on the control channel, while the runtime
+/// drives the SFU connection and the room event pump.
+fn call_thread(
+    rx: std::sync::mpsc::Receiver<CallControl>,
+    config: SessionConfig,
+    room_id: OwnedRoomId,
+    notices: UnboundedSender<WorkerTask>,
+) {
+    let mut guard = EndGuard::new(room_id.clone(), notices.clone());
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("iamb-voip-rt")
+        .enable_all()
+        .build();
+
+    let runtime = match runtime {
+        Ok(runtime) => runtime,
+        Err(e) => return guard.failing(format!("could not start the call runtime: {e}")),
+    };
+
+    let (session, events) = match runtime.block_on(LiveKitSession::connect(config)) {
+        Ok(connected) => connected,
+        Err(e) => return guard.failing(format!("{e:#}")),
+    };
+
+    let _ = notices.send(WorkerTask::CallNotice(room_id.clone(), CallNotice::Connected));
+
+    let session = Arc::new(session);
+    let pump = runtime.spawn(pump_room(session.clone(), events, room_id.clone(), notices.clone()));
+
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            CallControl::Mute(muted) => session.set_muted(muted),
+            CallControl::SetKey(index, key) => session.set_our_key(index, &key),
+            CallControl::Shutdown => break,
+        }
+    }
+
+    // Either the worker told us to stop or it dropped the session; both mean it
+    // already knows, so leaving here is not something to report back.
+    guard.disarm();
+
+    pump.abort();
+
+    let left = runtime
+        .block_on(async { tokio::time::timeout(DISCONNECT_TIMEOUT, session.disconnect()).await });
+
+    match left {
+        Ok(Ok(())) => {},
+        Ok(Err(e)) => tracing::warn!("failed to leave the LiveKit room cleanly: {e:#}"),
+        Err(_) => tracing::warn!("timed out leaving the LiveKit room"),
+    }
+}
+
+/// Pump the LiveKit room's event stream for the lifetime of the call.
+///
+/// Runs on the call thread's own runtime. Besides reacting to room events it
+/// periodically hands LiveKit the keys the Matrix sync handler has buffered,
+/// since those arrive on a completely different thread.
+async fn pump_room(
+    session: Arc<LiveKitSession>,
+    mut events: tokio::sync::mpsc::UnboundedReceiver<livekit::RoomEvent>,
+    room_id: OwnedRoomId,
+    notices: UnboundedSender<WorkerTask>,
+) {
+    use livekit::RoomEvent;
+
+    let mut keys = tokio::time::interval(KEY_POLL_INTERVAL);
+
+    // When the pending rotation, if any, becomes due. Departures are collapsed
+    // into one rotation by pushing this forward each time another one arrives.
+    let mut rotate_at: Option<tokio::time::Instant> = None;
+
+    loop {
+        tokio::select! {
+            _ = keys.tick() => {
+                session.drain_inbox();
+
+                // Piggy-backing the debounce on the key poll keeps the select
+                // arms fixed, which an optional timer would not.
+                if rotate_at.is_some_and(|at| at <= tokio::time::Instant::now()) {
+                    rotate_at = None;
+
+                    let notice = CallNotice::RotateKey;
+                    let _ = notices.send(WorkerTask::CallNotice(room_id.clone(), notice));
+                }
+            },
+            event = events.recv() => {
+                let Some(event) = event else {
+                    break;
+                };
+
+                match event {
+                    RoomEvent::ParticipantConnected(participant) => {
+                        // Logged verbatim because this is the string our keys
+                        // have to be filed under: a peer whose identity is not
+                        // the `{user_id}:{device_id}` we assume is one we can
+                        // neither encrypt to nor decrypt from.
+                        tracing::info!(
+                            identity = %participant.identity().0,
+                            "a participant joined the SFU"
+                        );
+
+                        // A late joiner cannot decrypt us until they have our
+                        // key, and only the worker can send Matrix events.
+                        let Some(user_id) = participant_user(&participant.identity().0) else {
+                            continue;
+                        };
+
+                        let notice = CallNotice::ShareKey(user_id);
+                        let _ = notices.send(WorkerTask::CallNotice(room_id.clone(), notice));
+                    },
+                    RoomEvent::TrackSubscribed { track, publication, participant } => {
+                        // Playback itself is LiveKit's: its platform audio
+                        // device module mixes every subscribed track into the
+                        // system's output device. What that leaves us without
+                        // is any way to tell a track we never received from one
+                        // that arrived and was played to nobody, so the arrival
+                        // is worth saying out loud.
+                        let livekit::prelude::RemoteTrack::Audio(audio) = &track else {
+                            continue;
+                        };
+
+                        // A disabled track is dropped from the mixer before it
+                        // ever reaches the speaker. Nothing here disables one,
+                        // but the cost of making sure is a single call and the
+                        // symptom is indistinguishable from silence.
+                        audio.enable();
+
+                        // `encryption` is the field that decides whether this
+                        // track is decrypted at all: LiveKit only installs a
+                        // frame cryptor when the publication advertises one, so
+                        // a remote that reports `None` while sending encrypted
+                        // media is played straight into the decoder and comes
+                        // out as nothing. That failure is invisible everywhere
+                        // else - with no cryptor there is no `E2eeStateChanged`
+                        // to warn from either.
+                        tracing::info!(
+                            identity = %participant.identity().0,
+                            sid = %audio.sid(),
+                            encryption = ?publication.encryption_type(),
+                            muted = audio.is_muted(),
+                            enabled = audio.is_enabled(),
+                            "subscribed to a remote audio track"
+                        );
+                    },
+                    RoomEvent::TrackSubscriptionFailed { participant, error, track_sid } => {
+                        // A track we never subscribed to is silence that looks
+                        // exactly like a participant who is not talking.
+                        tracing::warn!(
+                            identity = %participant.identity().0,
+                            sid = %track_sid,
+                            "could not subscribe to a remote track: {error}"
+                        );
+                    },
+                    RoomEvent::ParticipantDisconnected(_) => {
+                        // Whoever left keeps the key they were given, so our
+                        // media stays readable to them until we rotate onto a
+                        // new one they never receive. Their own key staying in
+                        // our ring is harmless it only decrypts media they
+                        // are no longer sending.
+                        rotate_at = Some(tokio::time::Instant::now() + KEY_ROTATION_DEBOUNCE);
+                    },
+                    RoomEvent::ActiveSpeakersChanged { speakers } => {
+                        let speakers = speakers
+                            .iter()
+                            .filter_map(|speaker| participant_user(&speaker.identity().0))
+                            .collect();
+
+                        let notice = CallNotice::Speakers(speakers);
+                        let _ = notices.send(WorkerTask::CallNotice(room_id.clone(), notice));
+                    },
+                    RoomEvent::E2eeStateChanged { participant, state } => {
+                        // The one place LiveKit says out loud whether the key
+                        // exchange actually worked. A call that connects and
+                        // stays silent looks identical from every other angle,
+                        // so swallowing this leaves nothing to debug with.
+                        use livekit::webrtc::native::frame_cryptor::EncryptionState;
+
+                        let identity = participant.identity();
+
+                        match state {
+                            EncryptionState::New | EncryptionState::Ok => {
+                                tracing::debug!(identity = %identity.0, ?state, "call media encryption is healthy");
+                            },
+                            _ => {
+                                tracing::warn!(
+                                    identity = %identity.0,
+                                    ?state,
+                                    "call media encryption failed; this participant will not be audible"
+                                );
+                            },
+                        }
+                    },
+                    RoomEvent::Disconnected { reason } => {
+                        let notice = CallNotice::Ended(format!("disconnected from the SFU: {reason:?}"));
+                        let _ = notices.send(WorkerTask::CallNotice(room_id.clone(), notice));
+                        break;
+                    },
+                    _ => {},
+                }
+            },
+        }
+    }
+}
+
+/// The Matrix user behind a LiveKit participant identity, if it parses.
+///
+/// Identities are made by whichever client the participant is running, so a
+/// malformed one is a remote input rather than a bug on our side: log it and
+/// carry on rather than treating the call as broken.
+fn participant_user(identity: &str) -> Option<OwnedUserId> {
+    let Some((user_id, _)) = livekit_session::split_identity(identity) else {
+        tracing::warn!(%identity, "call participant has a malformed identity");
+        return None;
+    };
+
+    match <OwnedUserId as std::str::FromStr>::from_str(user_id) {
+        Ok(user_id) => Some(user_id),
+        Err(_) => {
+            tracing::warn!(%identity, "call participant has a malformed user id");
+            None
+        },
+    }
+}
+
+impl Drop for CallSession {
+    fn drop(&mut self) {
+        // Signal the thread to exit, then wait for it to finish. The thread
+        // stops as soon as it observes the message, so this does not block.
+        let _ = self.control.send(CallControl::Shutdown);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Tracks the currently active call, if any.
+///
+/// Stored on the worker so that call commands (`:call`, `:call hangup`,
+/// `:call mute`) and inbound signaling events operate on shared state.
+#[derive(Default)]
+pub struct CallManager {
+    /// The active call session, or `None` when not in a call.
+    pub session: Option<CallSession>,
+
+    /// E2EE keys received from other participants over to-device events.
+    ///
+    /// Shared with the sync event handler, which pushes keys in as they arrive.
+    pub inbox: KeyInbox,
+}
+
+impl CallManager {
+    /// Create an empty [`CallManager`] with no active call.
+    pub fn new() -> Self {
+        CallManager::default()
+    }
+
+    /// Whether the user is currently in a call.
+    pub fn is_active(&self) -> bool {
+        self.session.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_sdk::ruma::room_id;
+
+    #[test]
+    fn test_encryption_keys_to_device_shape_matches_element_call() {
+        // Verbatim from matrix-js-sdk's `EncryptionKeysToDeviceEventContent`.
+        // The room event of the same type carries a `keys` *array* and names the
+        // device at the top level; modelling the to-device event that way parses
+        // nothing and produces a call in which nobody can decrypt anybody.
+        let json = serde_json::json!({
+            "keys": { "index": 3, "key": "YWJjZGVmZ2hpamtsbW5vcA" },
+            "member": { "id": "@alice:example.org", "claimed_device_id": "ABCDEFGH" },
+            "room_id": "!room:example.org",
+            "session": { "application": "m.call", "call_id": "", "scope": "m.room" },
+            "sent_ts": 1_700_000_000_000_i64,
+        });
+
+        let content: CallEncryptionKeysEventContent = serde_json::from_value(json).unwrap();
+
+        assert_eq!(content.keys.index, 3);
+        assert_eq!(content.keys.key, "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(content.member.id, "@alice:example.org");
+        assert_eq!(content.member.claimed_device_id, "ABCDEFGH");
+        assert_eq!(content.session.application, "m.call");
+        assert_eq!(content.session.scope, "m.room");
+    }
+
+    #[test]
+    fn test_redacting_a_logged_key_keeps_the_shape_and_drops_the_secret() {
+        // The payload is logged to diagnose a sender's field layout, so the
+        // layout has to survive and the key material must not: a call key
+        // written to a file on disk undoes the encryption it exists for.
+        let json = r#"{"type":"io.element.call.encryption_keys","content":{
+            "keys":{"index":3,"key":"c3VwZXJzZWNyZXQ"},
+            "member":{"id":"@a:b.org","claimed_device_id":"DEV"},
+            "room_id":"!r:b.org"}}"#;
+
+        let redacted = crate::worker::redact_call_key(json);
+
+        assert!(!redacted.contains("c3VwZXJzZWNyZXQ"), "the key material must not survive");
+        assert!(redacted.contains("<redacted>"));
+        assert!(redacted.contains("claimed_device_id"), "the shape must survive");
+        assert!(redacted.contains(r#""index":3"#), "the index is not secret and locates the key");
+    }
+
+    #[test]
+    fn test_redacting_a_key_array_covers_every_entry() {
+        // The room transport carries an array, so a redactor that only knows
+        // the to-device shape would leak every key it was meant to protect.
+        let json = r#"{"content":{"keys":[
+            {"index":0,"key":"Zmlyc3RzZWNyZXQ"},
+            {"index":1,"key":"c2Vjb25kc2VjcmV0"}]}}"#;
+
+        let redacted = crate::worker::redact_call_key(json);
+
+        assert!(!redacted.contains("Zmlyc3RzZWNyZXQ"));
+        assert!(!redacted.contains("c2Vjb25kc2VjcmV0"));
+    }
+
+    #[test]
+    fn test_redacting_something_that_is_not_json() {
+        // Non-JSON cannot be redacted, so it must not be passed through: that
+        // is precisely the input whose contents are unknown.
+        assert_eq!(crate::worker::redact_call_key("not json at all"), "<unparseable>");
+    }
+
+    #[test]
+    fn test_encryption_keys_survive_an_unparseable_identifier() {
+        // A peer that writes an identifier ruma will not accept must not cost
+        // us the key that came with it. Typing these fields as `OwnedUserId`
+        // and `OwnedRoomId` made the whole event fail to deserialize, so the
+        // SDK dropped it before any handler ran and the participant stayed
+        // silent for the entire call with `MissingKey` as the only clue.
+        let json = serde_json::json!({
+            "keys": { "index": 0, "key": "YWJjZGVmZ2hpamtsbW5vcA" },
+            "member": { "id": "alice:example.org", "claimed_device_id": "ABCDEFGH" },
+            "room_id": "room:example.org",
+            "session": { "application": "m.call", "call_id": "", "scope": "m.room" },
+        });
+
+        let content: CallEncryptionKeysEventContent = serde_json::from_value(json).unwrap();
+
+        assert_eq!(content.member.id, "alice:example.org");
+        assert_eq!(content.room_id, "room:example.org");
+        assert_eq!(content.keys.key, "YWJjZGVmZ2hpamtsbW5vcA");
+    }
+
+    #[test]
+    fn test_encryption_keys_round_trip_to_the_same_shape() {
+        // What we send has to be what the other end parses, so serializing must
+        // land back on the same field layout we accept.
+        let content = CallEncryptionKeysEventContent {
+            keys: CallEncryptionKey { index: 0, key: "AAAA".to_owned() },
+            member: CallKeyMember {
+                id: "@bob:example.org".to_owned(),
+                claimed_device_id: matrix_sdk::ruma::device_id!("DEVICE").to_owned(),
+            },
+            room_id: "!room:example.org".to_owned(),
+            session: CallKeySession::room_call(),
+            sent_ts: None,
+        };
+
+        let json = serde_json::to_value(&content).unwrap();
+
+        assert!(json["keys"].is_object(), "keys must be one object, not an array");
+        assert_eq!(json["member"]["claimed_device_id"], "DEVICE");
+        assert_eq!(json["session"]["call_id"], "");
+        assert!(json.get("sent_ts").is_none(), "an absent timestamp must be omitted");
+
+        serde_json::from_value::<CallEncryptionKeysEventContent>(json).unwrap();
+    }
+
+    /// The room transport's shape is *not* the to-device one, and a client that
+    /// confuses them exchanges keys that never parse.
+    #[test]
+    fn test_encryption_keys_room_event_shape_matches_element_call() {
+        // Verbatim from matrix-js-sdk's `EncryptionKeysEventContent`: a `keys`
+        // array, the device at the top level, no `room_id`, no `session`.
+        let json = serde_json::json!({
+            "keys": [{ "index": 1, "key": "YWJjZGVmZ2hpamtsbW5vcA" }],
+            "device_id": "ABCDEFGH",
+            "call_id": "",
+            "sent_ts": 1_700_000_000_000_i64,
+        });
+
+        let content: CallEncryptionKeysRoomEventContent = serde_json::from_value(json).unwrap();
+
+        assert_eq!(content.keys.len(), 1);
+        assert_eq!(content.keys[0].index, 1);
+        assert_eq!(content.keys[0].key, "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(content.device_id, "ABCDEFGH");
+        assert_eq!(content.call_id, "");
+    }
+
+    #[test]
+    fn test_encryption_keys_room_event_round_trips_to_the_same_shape() {
+        let content = CallEncryptionKeysRoomEventContent {
+            keys: vec![CallEncryptionKey { index: 0, key: "AAAA".to_owned() }],
+            device_id: matrix_sdk::ruma::device_id!("DEVICE").to_owned(),
+            call_id: String::new(),
+            sent_ts: None,
+        };
+
+        let json = serde_json::to_value(&content).unwrap();
+
+        assert!(json["keys"].is_array(), "keys must be an array, not one object");
+        assert_eq!(json["device_id"], "DEVICE");
+        assert!(json.get("sent_ts").is_none(), "an absent timestamp must be omitted");
+        assert!(json.get("member").is_none(), "the room event names no member");
+
+        serde_json::from_value::<CallEncryptionKeysRoomEventContent>(json).unwrap();
+    }
+
+    /// Both transports carry the same `io.element.call.encryption_keys` type and
+    /// differ only in kind, so the two content types must stay distinguishable
+    /// by shape alone.
+    #[test]
+    fn test_the_two_key_transports_do_not_parse_each_other() {
+        let to_device = serde_json::json!({
+            "keys": { "index": 0, "key": "AAAA" },
+            "member": { "id": "@alice:example.org", "claimed_device_id": "DEVICE" },
+            "room_id": "!room:example.org",
+            "session": { "application": "m.call", "call_id": "", "scope": "m.room" },
+        });
+
+        let room = serde_json::json!({
+            "keys": [{ "index": 0, "key": "AAAA" }],
+            "device_id": "DEVICE",
+            "call_id": "",
+        });
+
+        assert!(serde_json::from_value::<CallEncryptionKeysRoomEventContent>(to_device).is_err());
+        assert!(serde_json::from_value::<CallEncryptionKeysEventContent>(room).is_err());
+    }
+
+    #[test]
+    fn test_call_status_is_shared_between_clones() {
+        // The UI's handle and the worker's handle must be the same state, or the
+        // two drift apart the moment a call ends without the UI asking it to.
+        let worker = CallStatus::default();
+        let ui = worker.clone();
+
+        assert_eq!(ui.get(), None);
+
+        worker.joined(room_id!("!room:example.com").to_owned());
+        assert_eq!(ui.get().unwrap().room_id, room_id!("!room:example.com"));
+        assert!(!ui.get().unwrap().muted);
+
+        // Joining is not the same as being connected: the SFU handshake is
+        // still in flight on the call thread.
+        assert!(!ui.get().unwrap().connected);
+        worker.connected();
+        assert!(ui.get().unwrap().connected);
+
+        worker.set_muted(true);
+        assert!(ui.get().unwrap().muted);
+
+        worker.left();
+        assert_eq!(ui.get(), None);
+    }
+
+    #[test]
+    fn test_muting_without_a_call_does_nothing() {
+        let status = CallStatus::default();
+
+        status.set_muted(true);
+
+        assert_eq!(status.get(), None);
+    }
+
+    #[test]
+    fn test_call_status_tracks_speakers() {
+        let status = CallStatus::default();
+        let alice = matrix_sdk::ruma::user_id!("@alice:example.com").to_owned();
+
+        status.joined(room_id!("!room:example.com").to_owned());
+        assert!(status.get().unwrap().speakers.is_empty());
+
+        status.set_speakers(vec![alice.clone()]);
+        assert_eq!(status.get().unwrap().speakers, vec![alice]);
+
+        // Speakers belong to the call, not the client, so they go with it.
+        status.left();
+        status.joined(room_id!("!room:example.com").to_owned());
+        assert!(status.get().unwrap().speakers.is_empty());
+    }
+
+    /// The inbox is fed by remote peers and only drained by a running call, so
+    /// without a cap it grows for as long as the client is open.
+    #[test]
+    fn test_key_inbox_is_bounded() {
+        let inbox = KeyInbox::default();
+
+        let key = |index: u8| {
+            ReceivedCallKey {
+                room_id: room_id!("!room:example.com").to_owned(),
+                user_id: matrix_sdk::ruma::user_id!("@alice:example.com").to_owned(),
+                device_id: matrix_sdk::ruma::device_id!("DEVICE").to_owned(),
+                index,
+                key: vec![index],
+            }
+        };
+
+        for i in 0..(KEY_INBOX_LIMIT + 50) {
+            inbox.push(key((i % 256) as u8));
+        }
+
+        assert_eq!(inbox.len(), KEY_INBOX_LIMIT);
+
+        // The oldest are the ones dropped: a newer key for a given slot
+        // supersedes the one it replaces, so the tail is what still matters.
+        let drained = inbox.drain();
+        assert_eq!(drained.len(), KEY_INBOX_LIMIT);
+        assert_eq!(drained.last().unwrap().index, ((KEY_INBOX_LIMIT + 49) % 256) as u8);
+        assert_eq!(inbox.len(), 0);
+    }
+
+    #[test]
+    fn test_key_index_wraps_around_the_ring() {
+        use livekit_session::{FIRST_KEY_INDEX, next_key_index};
+
+        let mut index = FIRST_KEY_INDEX;
+        let mut seen = vec![index];
+
+        for _ in 0..15 {
+            index = next_key_index(index);
+            seen.push(index);
+        }
+
+        // Sixteen distinct slots, then back to the start.
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), 16);
+        assert_eq!(next_key_index(index), FIRST_KEY_INDEX);
+    }
+
+    /// A ring is a request with a deadline, not an invite that stands until
+    /// answered: a client syncing a backlog must not ring for calls that are
+    /// long over.
+    #[test]
+    fn test_incoming_call_expires() {
+        use std::time::{Duration, SystemTime};
+
+        let call = |at: SystemTime| {
+            IncomingCall {
+                notification: matrix_sdk::ruma::owned_event_id!("$ring:example.org"),
+                from: matrix_sdk::ruma::user_id!("@alice:example.org").to_owned(),
+                expires_at: MilliSecondsSinceUnixEpoch::from_system_time(at).unwrap(),
+                ring: true,
+            }
+        };
+
+        assert!(call(SystemTime::now() + Duration::from_secs(30)).is_live());
+        assert!(!call(SystemTime::now() - Duration::from_secs(1)).is_live());
+    }
+
+    /// Mentions decide who a ring is aimed at. Getting this wrong either rings a
+    /// whole room for a two-person call or silences a call meant for us.
+    #[test]
+    fn test_ring_targeting_follows_mentions() {
+        let us = matrix_sdk::ruma::user_id!("@us:example.org");
+        let them = matrix_sdk::ruma::user_id!("@them:example.org").to_owned();
+
+        assert!(ring_is_for_us(Some(&Mentions::with_room_mention()), us));
+        assert!(ring_is_for_us(Some(&Mentions::with_user_ids([us.to_owned()])), us));
+
+        // Aimed at somebody else in a room we happen to be in.
+        assert!(!ring_is_for_us(Some(&Mentions::with_user_ids([them])), us));
+
+        // Addressed to nobody at all: the absence of a target must not read as
+        // the widest possible target.
+        assert!(!ring_is_for_us(Some(&Mentions::new()), us));
+        assert!(!ring_is_for_us(None, us));
+    }
+
+    #[test]
+    fn test_leaving_twice_is_harmless() {
+        let status = CallStatus::default();
+
+        status.joined(room_id!("!room:example.com").to_owned());
+        status.left();
+        status.left();
+
+        assert_eq!(status.get(), None);
+    }
+}

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -5,11 +5,31 @@
 //!
 //! It is only compiled when the `voip` feature is enabled.
 //!
+//! [LiveKit]: https://livekit.io/
+//! [`Room`]: livekit::Room
+//!
+//! ## Specifications
+//!
+//! - [MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143) -
+//!   MatrixRTC: sessions, memberships, and focus discovery.
+//! - [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195) -
+//!   the LiveKit transport for MatrixRTC.
+//! - [MSC4196](https://github.com/matrix-org/matrix-spec-proposals/pull/4196) -
+//!   the `m.call` voice and video application.
+//! - [MSC3401](https://github.com/matrix-org/matrix-spec-proposals/pull/3401) -
+//!   native group VoIP, where `m.call.member` comes from.
+//! - [MSC4075](https://github.com/matrix-org/matrix-spec-proposals/pull/4075) -
+//!   ringing with `m.rtc.notification`.
+//! - [MSC3757](https://github.com/matrix-org/matrix-spec-proposals/pull/3757) -
+//!   the `_{user_id}_{device_id}` membership state key.
+//! - [MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310) -
+//!   declining with `m.rtc.decline`.
+//!
 //! ## Layout
 //!
 //! - [`mod@self`] - call session state machine and the types exchanged over
 //!   Matrix signaling ([`CallManager`], [`CallSession`], [`CallStatus`]).
-//! - [`livekit_session`] - the LiveKit `Room` connection: audio capture,
+//! - [`livekit_session`] - the LiveKit [`Room`] connection: audio capture,
 //!   playback, and end-to-end encryption key handling.
 //!
 //! ## Signaling overview
@@ -98,7 +118,7 @@ pub struct CallKeySession {
 
 impl CallKeySession {
     /// The session block describing a room's one and only call, matching the
-    /// `m.call.member` state published by `matrix_rtc::publish_membership`.
+    /// `m.call.member` state published by [`matrix_rtc::publish_membership`].
     pub fn room_call() -> Self {
         CallKeySession {
             application: "m.call".to_owned(),
@@ -289,11 +309,13 @@ pub struct IncomingCall {
 
 /// Whether a call notification's mentions address us.
 ///
-/// Mentions are how MSC4075 says who should be rung, so this is what keeps a
+/// Mentions are how [MSC4075] says who should be rung, so this is what keeps a
 /// call aimed at two specific people in a large room from ringing everybody. A
 /// notification carrying no mentions at all addresses nobody and is ignored:
 /// treating it as room-wide would make the absence of a target mean the widest
 /// possible target.
+///
+/// [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
 pub fn ring_is_for_us(mentions: Option<&Mentions>, user_id: &UserId) -> bool {
     match mentions {
         Some(mentions) => mentions.room || mentions.user_ids.contains(user_id),
@@ -504,8 +526,8 @@ pub struct CallSession {
 }
 
 impl CallSession {
-    /// Create a new session in the [`CallPhase::Connecting`] phase and spawn the
-    /// dedicated OS thread that drives the call's media work.
+    /// Create a new session and spawn the dedicated OS thread that drives the
+    /// call's media work.
     ///
     /// `notices` carries work the call thread cannot do itself back to the
     /// worker, which owns the Matrix client.

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -372,10 +372,10 @@ impl CallStatus {
 
     /// Record that the SFU connection is up and media is flowing.
     pub fn connected(&self) {
-        if let Ok(mut call) = self.0.lock() {
-            if let Some(call) = call.as_mut() {
-                call.connected = true;
-            }
+        if let Ok(mut call) = self.0.lock() &&
+            let Some(call) = call.as_mut()
+        {
+            call.connected = true;
         }
     }
 
@@ -388,19 +388,19 @@ impl CallStatus {
 
     /// Record the microphone mute state of the call in progress.
     pub fn set_muted(&self, muted: bool) {
-        if let Ok(mut call) = self.0.lock() {
-            if let Some(call) = call.as_mut() {
-                call.muted = muted;
-            }
+        if let Ok(mut call) = self.0.lock() &&
+            let Some(call) = call.as_mut()
+        {
+            call.muted = muted;
         }
     }
 
     /// Record who the SFU currently reports as speaking.
     pub fn set_speakers(&self, speakers: Vec<OwnedUserId>) {
-        if let Ok(mut call) = self.0.lock() {
-            if let Some(call) = call.as_mut() {
-                call.speakers = speakers;
-            }
+        if let Ok(mut call) = self.0.lock() &&
+            let Some(call) = call.as_mut()
+        {
+            call.speakers = speakers;
         }
     }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -85,9 +85,6 @@ use self::welcome::WelcomeState;
 use crate::message::MessageTimeStamp;
 use feruca::Collator;
 
-#[cfg(feature = "voip")]
-use crate::base::CallAction;
-
 pub mod room;
 pub mod verify;
 pub mod welcome;
@@ -314,7 +311,7 @@ fn tag_to_span(tag: &TagName, style: Style) -> Vec<Span<'_>> {
 /// several clients; this collapses them, because the banner and the room list
 /// both count people rather than sessions.
 ///
-/// [`active_room_call_participants`]: matrix_sdk::Room::active_room_call_participants
+/// [`active_room_call_participants`]: matrix_sdk::BaseRoom::active_room_call_participants
 #[cfg(feature = "voip")]
 pub fn call_participants(
     room_id: &RoomId,
@@ -327,7 +324,11 @@ pub fn call_participants(
     // Our retraction is only reflected here once the homeserver echoes it back,
     // which is a full round trip of being drawn in a call we have demonstrably
     // left. `CallStatus` knows immediately, so let it overrule the state event.
-    let joined = store.call_status.get().is_some_and(|call| *call.room_id == *room_id);
+    let joined = store
+        .worker
+        .call_status
+        .get()
+        .is_some_and(|call| *call.room_id == *room_id);
     let us = (!joined)
         .then(|| store.worker.client.user_id().map(ToOwned::to_owned))
         .flatten();
@@ -513,17 +514,17 @@ impl IambWindow {
     #[cfg(feature = "voip")]
     pub async fn call_command(
         &mut self,
-        act: CallAction,
+        act: crate::base::CallAction,
         _ctx: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
         // Audio devices are a property of the machine, not of a room, so these
         // work anywhere - including outside a call.
         match act {
-            CallAction::Devices => {
+            crate::base::CallAction::Devices => {
                 return store.application.worker.call_devices();
             },
-            CallAction::SetDevice(kind, spec) => {
+            crate::base::CallAction::SetDevice(kind, spec) => {
                 return store.application.worker.call_set_device(kind, spec);
             },
             _ => {},
@@ -543,7 +544,7 @@ impl IambWindow {
         // the store has - the worker cannot read it, since the UI holds the store
         // lock while blocking on the worker's reply.
         let pending = match act {
-            CallAction::Join | CallAction::Decline => {
+            crate::base::CallAction::Join | crate::base::CallAction::Decline => {
                 store
                     .application
                     .rooms
@@ -558,16 +559,16 @@ impl IambWindow {
         match act {
             // The worker owns the call and publishes its state, so none of these
             // touch the store: mirroring it here is what let the two drift apart.
-            CallAction::Join => store.application.worker.call_join(room_id),
-            CallAction::Hangup => store.application.worker.call_hangup(room_id),
-            CallAction::Decline => {
+            crate::base::CallAction::Join => store.application.worker.call_join(room_id),
+            crate::base::CallAction::Hangup => store.application.worker.call_hangup(room_id),
+            crate::base::CallAction::Decline => {
                 let Some(call) = pending else {
                     return Ok(Some(InfoMessage::from("No incoming call to decline")));
                 };
 
                 store.application.worker.call_decline(room_id, call.notification)
             },
-            CallAction::Mute(muted) => {
+            crate::base::CallAction::Mute(muted) => {
                 store.application.worker.call_mute(muted);
 
                 let msg = if muted {
@@ -578,7 +579,9 @@ impl IambWindow {
 
                 Ok(Some(InfoMessage::from(msg)))
             },
-            CallAction::Devices | CallAction::SetDevice(..) => unreachable!("handled above"),
+            crate::base::CallAction::Devices | crate::base::CallAction::SetDevice(..) => {
+                unreachable!("handled above")
+            },
         }
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -12,10 +12,6 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "voip")]
-use crate::base::CallAction;
-#[cfg(feature = "voip")]
-use matrix_sdk::ruma::OwnedUserId;
 use matrix_sdk::{
     RoomState as MatrixRoomState,
     room::{Room as MatrixRoom, RoomMember},
@@ -28,8 +24,6 @@ use matrix_sdk::{
         events::tag::{TagName, Tags},
     },
 };
-#[cfg(feature = "voip")]
-use std::collections::HashSet;
 
 use ratatui::{
     buffer::Buffer,
@@ -90,6 +84,9 @@ use self::verify::VerifyItem;
 use self::welcome::WelcomeState;
 use crate::message::MessageTimeStamp;
 use feruca::Collator;
+
+#[cfg(feature = "voip")]
+use crate::base::CallAction;
 
 pub mod room;
 pub mod verify;
@@ -319,7 +316,10 @@ fn tag_to_span(tag: &TagName, style: Style) -> Vec<Span<'_>> {
 ///
 /// [`active_room_call_participants`]: matrix_sdk::Room::active_room_call_participants
 #[cfg(feature = "voip")]
-pub fn call_participants(room_id: &RoomId, store: &ChatStore) -> Vec<OwnedUserId> {
+pub fn call_participants(
+    room_id: &RoomId,
+    store: &ChatStore,
+) -> Vec<matrix_sdk::ruma::OwnedUserId> {
     let Some(room) = store.worker.client.get_room(room_id) else {
         return Vec::new();
     };
@@ -332,7 +332,7 @@ pub fn call_participants(room_id: &RoomId, store: &ChatStore) -> Vec<OwnedUserId
         .then(|| store.worker.client.user_id().map(ToOwned::to_owned))
         .flatten();
 
-    let mut seen = HashSet::new();
+    let mut seen = std::collections::HashSet::new();
 
     room.active_room_call_participants()
         .into_iter()

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -12,6 +12,10 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "voip")]
+use crate::base::CallAction;
+#[cfg(feature = "voip")]
+use matrix_sdk::ruma::OwnedUserId;
 use matrix_sdk::{
     RoomState as MatrixRoomState,
     room::{Room as MatrixRoom, RoomMember},
@@ -24,6 +28,8 @@ use matrix_sdk::{
         events::tag::{TagName, Tags},
     },
 };
+#[cfg(feature = "voip")]
+use std::collections::HashSet;
 
 use ratatui::{
     buffer::Buffer,
@@ -299,6 +305,57 @@ fn tag_to_span(tag: &TagName, style: Style) -> Vec<Span<'_>> {
     }
 }
 
+/// The users currently in `room_id`'s MatrixRTC call, oldest joiner first.
+///
+/// Read straight out of the SDK rather than tracked alongside it.
+/// [`active_room_call_participants`] already drops expired memberships, keeps
+/// only sessions whose application is `m.call` and whose scope is `m.room`, and
+/// orders by join time - all of which a parallel copy has to reimplement and
+/// can only get wrong.
+///
+/// The SDK yields one entry per *device*, since one user can be in a call from
+/// several clients; this collapses them, because the banner and the room list
+/// both count people rather than sessions.
+///
+/// [`active_room_call_participants`]: matrix_sdk::Room::active_room_call_participants
+#[cfg(feature = "voip")]
+pub fn call_participants(room_id: &RoomId, store: &ChatStore) -> Vec<OwnedUserId> {
+    let Some(room) = store.worker.client.get_room(room_id) else {
+        return Vec::new();
+    };
+
+    // Our retraction is only reflected here once the homeserver echoes it back,
+    // which is a full round trip of being drawn in a call we have demonstrably
+    // left. `CallStatus` knows immediately, so let it overrule the state event.
+    let joined = store.call_status.get().is_some_and(|call| *call.room_id == *room_id);
+    let us = (!joined)
+        .then(|| store.worker.client.user_id().map(ToOwned::to_owned))
+        .flatten();
+
+    let mut seen = HashSet::new();
+
+    room.active_room_call_participants()
+        .into_iter()
+        .filter(|user_id| Some(user_id) != us.as_ref())
+        .filter(|user_id| seen.insert(user_id.clone()))
+        .collect()
+}
+
+/// A room-list label for a room with a MatrixRTC call in progress.
+///
+/// Without this a call is only visible from inside the room it is happening in,
+/// so there is no way to notice one starting anywhere else.
+#[cfg(feature = "voip")]
+fn call_label(room_id: &RoomId, store: &ProgramStore, style: Style) -> Option<Vec<Span<'static>>> {
+    let participants = call_participants(room_id, &store.application).len();
+
+    if participants == 0 {
+        return None;
+    }
+
+    Some(vec![Span::styled(format!("📞 {participants}"), style)])
+}
+
 fn append_tags<'a>(tags: Vec<Vec<Span<'a>>>, spans: &mut Vec<Span<'a>>, style: Style) {
     if tags.is_empty() {
         return;
@@ -427,7 +484,18 @@ impl IambWindow {
         ctx: ProgramContext,
         store: &mut ProgramStore,
     ) -> IambResult<Vec<(Action<IambInfo>, ProgramContext)>> {
-        let id = match self {
+        if let Some(id) = self.selected_room_id() {
+            let id = id.to_owned();
+            room_command(&id, act, ctx, store).await
+        } else {
+            return Err(IambError::NoSelectedRoomOrSpace.into());
+        }
+    }
+
+    /// The room a room-scoped command should act on: the open room, or the
+    /// entry highlighted in a room, DM, space, member, or chat list.
+    fn selected_room_id(&self) -> Option<&RoomId> {
+        match self {
             IambWindow::Room(state) => Some(state.id()),
             IambWindow::MemberList(_, room_id, _) => Some(&**room_id),
 
@@ -439,12 +507,78 @@ impl IambWindow {
             },
 
             _ => None,
+        }
+    }
+
+    #[cfg(feature = "voip")]
+    pub async fn call_command(
+        &mut self,
+        act: CallAction,
+        _ctx: ProgramContext,
+        store: &mut ProgramStore,
+    ) -> IambResult<EditInfo> {
+        // Audio devices are a property of the machine, not of a room, so these
+        // work anywhere - including outside a call.
+        match act {
+            CallAction::Devices => {
+                return store.application.worker.call_devices();
+            },
+            CallAction::SetDevice(kind, spec) => {
+                return store.application.worker.call_set_device(kind, spec);
+            },
+            _ => {},
+        }
+
+        // Works from an open room or from a room/DM/space list with an entry
+        // highlighted, so a call can be started without first entering the room.
+        let Some(room_id) = self.selected_room_id() else {
+            return Err(IambError::NoSelectedRoom.into());
         };
 
-        if let Some(id) = id {
-            room_command(id, act, ctx, store).await
-        } else {
-            return Err(IambError::NoSelectedRoomOrSpace.into());
+        let room_id = room_id.to_owned();
+
+        // Answering or rejecting settles the ring either way, so it stops being
+        // offered here rather than waiting for the state event to come back
+        // round. Declining needs the notification it is a reply to, which only
+        // the store has - the worker cannot read it, since the UI holds the store
+        // lock while blocking on the worker's reply.
+        let pending = match act {
+            CallAction::Join | CallAction::Decline => {
+                store
+                    .application
+                    .rooms
+                    .get_or_default(room_id.clone())
+                    .incoming_call
+                    .take()
+                    .filter(|call| call.is_live())
+            },
+            _ => None,
+        };
+
+        match act {
+            // The worker owns the call and publishes its state, so none of these
+            // touch the store: mirroring it here is what let the two drift apart.
+            CallAction::Join => store.application.worker.call_join(room_id),
+            CallAction::Hangup => store.application.worker.call_hangup(room_id),
+            CallAction::Decline => {
+                let Some(call) = pending else {
+                    return Ok(Some(InfoMessage::from("No incoming call to decline")));
+                };
+
+                store.application.worker.call_decline(room_id, call.notification)
+            },
+            CallAction::Mute(muted) => {
+                store.application.worker.call_mute(muted);
+
+                let msg = if muted {
+                    "Muted microphone"
+                } else {
+                    "Unmuted microphone"
+                };
+
+                Ok(Some(InfoMessage::from(msg)))
+            },
+            CallAction::Devices | CallAction::SetDevice(..) => unreachable!("handled above"),
         }
     }
 
@@ -1085,8 +1219,11 @@ impl ListItem<IambInfo> for GenericChatItem {
         &self,
         selected: bool,
         _: &ViewportContext<ListCursor>,
-        _: &mut ProgramStore,
+        store: &mut ProgramStore,
     ) -> Text<'_> {
+        #[cfg(not(feature = "voip"))]
+        let _ = store;
+
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
@@ -1096,6 +1233,9 @@ impl ListItem<IambInfo> for GenericChatItem {
         } else {
             vec![Span::styled("Room", style)]
         });
+
+        #[cfg(feature = "voip")]
+        labels.extend(call_label(self.room_id(), store, style));
 
         if let Some(tags) = &self.tags() {
             labels.extend(tags.keys().map(|t| tag_to_span(t, style)));
@@ -1203,11 +1343,17 @@ impl ListItem<IambInfo> for RoomItem {
         &self,
         selected: bool,
         _: &ViewportContext<ListCursor>,
-        _: &mut ProgramStore,
+        store: &mut ProgramStore,
     ) -> Text<'_> {
+        #[cfg(not(feature = "voip"))]
+        let _ = store;
+
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
+
+        #[cfg(feature = "voip")]
+        labels.extend(call_label(self.room_id(), store, style));
 
         if let Some(tags) = &self.tags() {
             labels.extend(tags.keys().map(|t| tag_to_span(t, style)));
@@ -1312,11 +1458,17 @@ impl ListItem<IambInfo> for DirectItem {
         &self,
         selected: bool,
         _: &ViewportContext<ListCursor>,
-        _: &mut ProgramStore,
+        store: &mut ProgramStore,
     ) -> Text<'_> {
+        #[cfg(not(feature = "voip"))]
+        let _ = store;
+
         let style = selected_style(selected);
         let (name, mut labels) = name_and_labels(&self.name, &self.unread, self.room(), style);
         let mut spans = vec![name];
+
+        #[cfg(feature = "voip")]
+        labels.extend(call_label(self.room_id(), store, style));
 
         if let Some(tags) = &self.tags() {
             labels.extend(tags.keys().map(|t| tag_to_span(t, style)));

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -37,6 +37,8 @@ use matrix_sdk::{
     send_queue::RoomSendQueueError,
 };
 
+#[cfg(feature = "voip")]
+use ratatui::style::{Color, Style};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -101,6 +103,13 @@ use crate::message::{
 use crate::worker::Requester;
 
 use super::scrollback::{Scrollback, ScrollbackState};
+
+/// How many call participants the banner names before summarising the rest.
+///
+/// The banner is a single line, so a busy call has to be truncated somewhere;
+/// the remainder is reported as a count.
+#[cfg(feature = "voip")]
+const CALL_BANNER_NAMES: usize = 5;
 
 /// State needed for rendering [Chat].
 pub struct ChatState {
@@ -1154,6 +1163,106 @@ impl StatefulWidget for Chat<'_> {
             },
         };
 
+        // Determine whether to show a banner for an ongoing call in this room.
+        #[cfg(feature = "voip")]
+        let call_line: Option<Line> = {
+            // Whether we ourselves have joined this room's call, and our mute state.
+            let ours = self
+                .store
+                .application
+                .call_status
+                .get()
+                .filter(|call| *call.room_id == *state.id());
+
+            let settings = &self.store.application.settings;
+            let info = self.store.application.rooms.get(state.id());
+
+            // Expired memberships are already filtered out, so a peer whose
+            // client died without retracting drops off the banner by itself.
+            let participants =
+                crate::windows::call_participants(state.id(), &self.store.application);
+
+            // Somebody is waiting for us to pick up. That outranks the roster of
+            // who is already talking: it is the only part of a call banner the
+            // user has to act on, and it goes stale on its own once the ring
+            // times out.
+            let incoming = info
+                .and_then(|info| info.incoming_call.as_ref())
+                .filter(|call| call.is_live() && ours.is_none());
+
+            if let Some(incoming) = incoming {
+                let base = Style::default().fg(Color::LightYellow);
+
+                let caller = info.map(|info| settings.get_user_span(&incoming.from, info));
+                let caller = match caller {
+                    Some(span) => span.content.into_owned(),
+                    None => incoming.from.to_string(),
+                };
+
+                Some(Line::from(vec![
+                    Span::styled(format!("📞 {caller} is calling"), base),
+                    Span::styled(" · :call to answer · :call decline to reject", base),
+                ]))
+            } else if participants.is_empty() && ours.is_none() {
+                None
+            } else {
+                let base = Style::default().fg(Color::Green);
+                let speakers =
+                    ours.as_ref().map(|call| call.speakers.as_slice()).unwrap_or_default();
+
+                // Our own membership can lag the join by a sync, so the list is
+                // briefly empty for a call we are demonstrably in.
+                let header = if participants.is_empty() {
+                    "📞 in call".to_string()
+                } else {
+                    format!("📞 {} in call: ", participants.len())
+                };
+
+                let mut spans = vec![Span::styled(header, base)];
+
+                for (i, user_id) in participants.iter().take(CALL_BANNER_NAMES).enumerate() {
+                    if i > 0 {
+                        spans.push(Span::styled(", ", base));
+                    }
+
+                    // Reuse the room's own naming rules so a participant reads
+                    // the same here as on their messages.
+                    let name = info.map(|info| settings.get_user_span(user_id, info));
+                    let name = match name {
+                        Some(span) => span.content.into_owned(),
+                        None => user_id.to_string(),
+                    };
+
+                    if speakers.contains(user_id) {
+                        spans.push(Span::styled(format!("▸{name}"), base.fg(Color::LightGreen)));
+                    } else {
+                        spans.push(Span::styled(name, base));
+                    }
+                }
+
+                if let Some(extra) =
+                    participants.len().checked_sub(CALL_BANNER_NAMES).filter(|n| *n > 0)
+                {
+                    spans.push(Span::styled(format!(" +{extra} more"), base));
+                }
+
+                if let Some(call) = ours {
+                    spans.push(Span::styled(
+                        match call {
+                            c if !c.connected => " · you: connecting…",
+                            c if c.muted => " · you: muted",
+                            _ => " · you: joined",
+                        },
+                        base,
+                    ));
+                }
+
+                Some(Line::from(spans))
+            }
+        };
+        #[cfg(not(feature = "voip"))]
+        let call_line: Option<Line> = None;
+
         // Determine the region to show each UI element.
         let lines = state.tbox.has_lines(5).max(1) as u16;
         let drawh = area.height;
@@ -1163,11 +1272,22 @@ impl StatefulWidget for Chat<'_> {
         } else {
             0
         };
-        let scrollh = drawh.saturating_sub(texth).saturating_sub(desch);
+        let callh = if call_line.is_some() {
+            drawh.saturating_sub(texth).saturating_sub(desch).min(1)
+        } else {
+            0
+        };
+        let scrollh = drawh.saturating_sub(texth).saturating_sub(desch).saturating_sub(callh);
 
-        let scrollarea = Rect::new(area.x, area.y, area.width, scrollh);
+        let callarea = Rect::new(area.x, area.y, area.width, callh);
+        let scrollarea = Rect::new(area.x, callarea.y + callh, area.width, scrollh);
         let descarea = Rect::new(area.x, scrollarea.y + scrollh, area.width, desch);
         let textarea = Rect::new(area.x, descarea.y + desch, area.width, texth);
+
+        // Render the call banner, if any.
+        if let Some(call_line) = call_line {
+            Paragraph::new(call_line).render(callarea, buf);
+        }
 
         // Render the message bar and any description for it.
         if let Some(desc_spans) = desc_spans {

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -1171,6 +1171,7 @@ impl StatefulWidget for Chat<'_> {
             let ours = self
                 .store
                 .application
+                .worker
                 .call_status
                 .get()
                 .filter(|call| *call.room_id == *state.id());

--- a/src/windows/room/chat.rs
+++ b/src/windows/room/chat.rs
@@ -37,8 +37,6 @@ use matrix_sdk::{
     send_queue::RoomSendQueueError,
 };
 
-#[cfg(feature = "voip")]
-use ratatui::style::{Color, Style};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -103,6 +101,9 @@ use crate::message::{
 use crate::worker::Requester;
 
 use super::scrollback::{Scrollback, ScrollbackState};
+
+#[cfg(feature = "voip")]
+use ratatui::style::{Color, Style};
 
 /// How many call participants the banner names before summarising the rest.
 ///

--- a/src/windows/welcome-call.md
+++ b/src/windows/welcome-call.md
@@ -1,0 +1,26 @@
+## Call Commands
+
+The `:call` command joins the voice call in the currently focused room. It also
+works on the room highlighted in a room, DM, space, member, or chat list, so you
+can call a room without entering it first.
+
+The different subcommands are:
+
+- `:call` will join the call in the focused room
+- `:call hangup` will leave the call
+- `:call mute` and `:call unmute` will toggle your microphone
+- `:call devices` will list the available microphones and speakers
+- `:call device mic NAME|INDEX` will choose the microphone
+- `:call device speaker NAME|INDEX` will choose the speaker
+
+A device can be named by its index from `:call devices`, by its exact name, or
+by any unambiguous part of one, so `:call device mic yeti` will work. Names do
+not need quoting, and your choice is remembered between restarts.
+
+The device subcommands work whether or not you are in a call, so you can set
+things up before dialling.
+
+While a call is running, the room shows a green banner listing who is in it,
+with `▸` marking whoever is speaking. Rooms with a call in progress are also
+marked with `📞` in the room lists.
+

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -859,7 +859,8 @@ fn generate_call_key() -> Vec<u8> {
 #[cfg(feature = "voip")]
 async fn call_media_encrypted(room: &MatrixRoom) -> bool {
     match room.latest_encryption_state().await {
-        Ok(state) => !matches!(state, EncryptionState::NotEncrypted),
+        Ok(EncryptionState::NotEncrypted) => false,
+        Ok(_) => true,
         Err(e) => {
             warn!(
                 room_id = %room.room_id(),
@@ -1616,6 +1617,7 @@ impl ClientWorker {
         // Someone ringing the room (MSC4075). This is the explicit "pick up"
         // signal, as opposed to the `m.call.member` state above, which only says
         // a call exists.
+        // https://github.com/matrix-org/matrix-spec-proposals/pull/4075
         #[cfg(feature = "voip")]
         let _ = self.client.add_event_handler(
             move |ev: OriginalSyncRtcNotificationEvent,
@@ -1664,6 +1666,7 @@ impl ClientWorker {
                     // call. Skip a notification
                     let joined = locked
                         .application
+                        .worker
                         .call_status
                         .get()
                         .is_some_and(|call| *call.room_id == *room_id);
@@ -2371,10 +2374,6 @@ impl ClientWorker {
 
         let encrypted = call_media_encrypted(&room).await;
 
-        if !encrypted {
-            tracing::warn!(%room_id, "the room is unencrypted, so our media is too");
-        }
-
         let user_id = self
             .client
             .user_id()
@@ -2406,7 +2405,7 @@ impl ClientWorker {
             "opened the audio device module for a call"
         );
 
-        devices::apply(&audio, &self.settings.read_voip_devices());
+        devices::apply(&audio, &self.settings.voip_devices);
 
         let key = generate_call_key();
         let config = SessionConfig {
@@ -2428,6 +2427,7 @@ impl ClientWorker {
         //
         // `None` leaves `created_ts` for the server to stamp, which is what
         // MSC3401 asks of an initial join; refreshes read it back.
+        // https://github.com/matrix-org/matrix-spec-proposals/pull/3401
         let membership = matrix_rtc::publish_membership(&room, &user_id, &device_id, &focus, None)
             .await
             .map_err(call_error)?;
@@ -2605,20 +2605,18 @@ impl ClientWorker {
     #[cfg(feature = "voip")]
     fn call_devices(&self) -> IambResult<EditInfo> {
         let audio = self.audio_handle()?;
-        let prefs = self.settings.read_voip_devices();
+        let listing = devices::format_listing(&audio, &self.settings.voip_devices);
 
-        Ok(Some(InfoMessage::Pager(devices::format_listing(&audio, &prefs))))
+        Ok(Some(InfoMessage::Pager(listing)))
     }
 
     /// Choose an audio device, applying it now and remembering it for later.
     #[cfg(feature = "voip")]
-    fn call_set_device(&self, kind: DeviceKind, spec: String) -> IambResult<EditInfo> {
+    fn call_set_device(&mut self, kind: DeviceKind, spec: String) -> IambResult<EditInfo> {
         let audio = self.audio_handle()?;
         let name = devices::select(&audio, kind, &spec).map_err(call_error)?;
 
-        let mut prefs = self.settings.read_voip_devices();
-        prefs.set(kind, name.clone());
-        self.settings.write_voip_devices(&prefs).map_err(call_error)?;
+        self.settings.set_voip_device(kind, name.clone()).map_err(call_error)?;
 
         Ok(Some(InfoMessage::from(format!("Using {name:?} as the {}", kind.keyword()))))
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -10,12 +10,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::time::{Duration, Instant};
-#[cfg(feature = "voip")]
-use {
-    matrix_sdk::deserialized_responses::EncryptionInfo,
-    matrix_sdk::ruma::MilliSecondsSinceUnixEpoch,
-    std::time::SystemTime,
-};
 
 use futures::{StreamExt, stream::FuturesUnordered};
 use gethostname::gethostname;
@@ -31,37 +25,6 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 use tracing::{Instrument as _, error, warn};
 use url::Url;
-
-#[cfg(feature = "voip")]
-use crate::voip::devices::{self, DeviceKind};
-#[cfg(feature = "voip")]
-use crate::voip::livekit_session::{FIRST_KEY_INDEX, SessionConfig};
-#[cfg(feature = "voip")]
-use crate::voip::{
-    CallEncryptionKeysEvent,
-    CallManager,
-    CallNotice,
-    CallSession,
-    CallStatus,
-    IncomingCall,
-    KeyInbox,
-    OriginalSyncCallEncryptionKeysRoomEvent,
-    ReceivedCallKey,
-    matrix_rtc,
-};
-#[cfg(feature = "voip")]
-use livekit::PlatformAudio;
-#[cfg(feature = "voip")]
-use matrix_sdk::EncryptionState;
-#[cfg(feature = "voip")]
-use matrix_sdk::ruma::events::call::member::CallMemberEventContent;
-#[cfg(feature = "voip")]
-use matrix_sdk::ruma::events::rtc::decline::OriginalSyncRtcDeclineEvent;
-#[cfg(feature = "voip")]
-use matrix_sdk::ruma::events::rtc::notification::{
-    NotificationType,
-    OriginalSyncRtcNotificationEvent,
-};
 
 use matrix_sdk::{
     Client,
@@ -148,6 +111,35 @@ use crate::{
         RoomFetchStatus,
         RoomInfo,
     },
+};
+
+#[cfg(feature = "voip")]
+use {
+    crate::voip::devices::{self, DeviceKind},
+    crate::voip::livekit_session::{FIRST_KEY_INDEX, SessionConfig},
+    crate::voip::{
+        CallEncryptionKeysEvent,
+        CallManager,
+        CallNotice,
+        CallSession,
+        CallStatus,
+        IncomingCall,
+        KeyInbox,
+        OriginalSyncCallEncryptionKeysRoomEvent,
+        ReceivedCallKey,
+        matrix_rtc,
+    },
+    livekit::PlatformAudio,
+    matrix_sdk::EncryptionState,
+    matrix_sdk::deserialized_responses::EncryptionInfo,
+    matrix_sdk::ruma::MilliSecondsSinceUnixEpoch,
+    matrix_sdk::ruma::events::call::member::CallMemberEventContent,
+    matrix_sdk::ruma::events::rtc::decline::OriginalSyncRtcDeclineEvent,
+    matrix_sdk::ruma::events::rtc::notification::{
+        NotificationType,
+        OriginalSyncRtcNotificationEvent,
+    },
+    std::time::SystemTime,
 };
 
 const DEFAULT_ENCRYPTION_SETTINGS: EncryptionSettings = EncryptionSettings {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -10,6 +10,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::time::{Duration, Instant};
+#[cfg(feature = "voip")]
+use {
+    matrix_sdk::deserialized_responses::EncryptionInfo,
+    matrix_sdk::ruma::MilliSecondsSinceUnixEpoch,
+    std::time::SystemTime,
+};
 
 use futures::{StreamExt, stream::FuturesUnordered};
 use gethostname::gethostname;
@@ -25,6 +31,37 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 use tracing::{Instrument as _, error, warn};
 use url::Url;
+
+#[cfg(feature = "voip")]
+use crate::voip::devices::{self, DeviceKind};
+#[cfg(feature = "voip")]
+use crate::voip::livekit_session::{FIRST_KEY_INDEX, SessionConfig};
+#[cfg(feature = "voip")]
+use crate::voip::{
+    CallEncryptionKeysEvent,
+    CallManager,
+    CallNotice,
+    CallSession,
+    CallStatus,
+    IncomingCall,
+    KeyInbox,
+    OriginalSyncCallEncryptionKeysRoomEvent,
+    ReceivedCallKey,
+    matrix_rtc,
+};
+#[cfg(feature = "voip")]
+use livekit::PlatformAudio;
+#[cfg(feature = "voip")]
+use matrix_sdk::EncryptionState;
+#[cfg(feature = "voip")]
+use matrix_sdk::ruma::events::call::member::CallMemberEventContent;
+#[cfg(feature = "voip")]
+use matrix_sdk::ruma::events::rtc::decline::OriginalSyncRtcDeclineEvent;
+#[cfg(feature = "voip")]
+use matrix_sdk::ruma::events::rtc::notification::{
+    NotificationType,
+    OriginalSyncRtcNotificationEvent,
+};
 
 use matrix_sdk::{
     Client,
@@ -587,6 +624,37 @@ fn insert_local_echo(
     Ok(())
 }
 
+/// How long shutdown waits for the call to be left before giving up on it.
+///
+/// Retracting the membership means a round trip to the homeserver, and the user
+/// has already asked to quit; past this point the membership expiry is a good
+/// enough backstop.
+#[cfg(feature = "voip")]
+const HANGUP_ON_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Ask the worker to refresh the active call's membership, forever.
+///
+/// This only nudges: the worker owns the call session, so it decides whether
+/// there is anything to refresh. Going through the task queue rather than
+/// touching the session from here keeps the session single-threaded and avoids
+/// taking any lock on a timer.
+#[cfg(feature = "voip")]
+async fn refresh_call_membership_forever(tx: UnboundedSender<WorkerTask>) {
+    let mut interval = tokio::time::interval(matrix_rtc::MEMBERSHIP_REFRESH_INTERVAL);
+
+    // The first tick completes immediately, and a refresh the instant we start
+    // up would be pointless - nothing has had time to expire.
+    interval.tick().await;
+
+    loop {
+        interval.tick().await;
+
+        if tx.send(WorkerTask::CallRefresh).is_err() {
+            break;
+        }
+    }
+}
+
 async fn subscribe_sendqueue_forever(client: &Client, store: &AsyncProgramStore) {
     let own_user_id = client.user_id().unwrap();
     let mut receiver = client.send_queue().subscribe();
@@ -709,12 +777,112 @@ impl<T> ClientResponse<T> {
     fn recv(self) -> T {
         self.0.recv().expect("failed to receive response from client thread")
     }
+
+    /// Wait up to `timeout` for a response, tolerating never getting one.
+    ///
+    /// For shutdown paths, where the worker having already gone away is a
+    /// normal race rather than a bug, and where blocking indefinitely on an
+    /// unreachable server would mean the application never exits.
+    #[cfg(feature = "voip")]
+    fn recv_before(self, timeout: Duration) -> Option<T> {
+        self.0.recv_timeout(timeout).ok()
+    }
 }
 
 impl<T> ClientReply<T> {
     fn send(self, t: T) {
         self.0.send(t).unwrap();
     }
+}
+
+/// Decode the base64 key material from an `io.element.call.encryption_keys` event.
+///
+/// Element Call sends the key unpadded, but padded input is accepted too so that
+/// a stricter sender still interoperates.
+#[cfg(feature = "voip")]
+fn decode_call_key(encoded: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    use base64::engine::general_purpose::{STANDARD, STANDARD_NO_PAD};
+
+    STANDARD_NO_PAD.decode(encoded).or_else(|_| STANDARD.decode(encoded)).ok()
+}
+
+/// Render a call key event for the log with the key material taken out.
+///
+/// The whole point of logging the payload is to see the shape a sender used,
+/// and the one field that never helps with that is the only one worth keeping
+/// secret. Writing raw call keys into a file on disk would undo the encryption
+/// they exist to provide.
+///
+/// Input that is not JSON at all is reported as such rather than passed
+/// through, since that is exactly the case where it cannot be redacted.
+#[cfg(feature = "voip")]
+pub fn redact_call_key(json: &str) -> String {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return "<unparseable>".to_owned();
+    };
+
+    // Both transports, since either shape may be what failed: the to-device
+    // event carries one key object, the room event an array of them.
+    if let Some(key) = value.pointer_mut("/content/keys/key") {
+        *key = serde_json::Value::from("<redacted>");
+    }
+
+    if let Some(serde_json::Value::Array(keys)) = value.pointer_mut("/content/keys") {
+        for entry in keys {
+            if let Some(key) = entry.pointer_mut("/key") {
+                *key = serde_json::Value::from("<redacted>");
+            }
+        }
+    }
+
+    value.to_string()
+}
+
+/// Generate the E2EE key our media is encrypted with for one call.
+///
+/// 16 bytes, matching what Element Call generates, so that the key we hand out
+/// slots straight into other clients' key rings.
+#[cfg(feature = "voip")]
+fn generate_call_key() -> Vec<u8> {
+    use rand::Rng as _;
+
+    let mut key = vec![0u8; 16];
+    rand::rng().fill_bytes(&mut key);
+
+    key
+}
+
+/// Whether a call in this room should encrypt its media.
+///
+/// The room decides, the same way Element Call decides it, because LiveKit only
+/// installs a frame decryptor when encryption is on: a peer that disagrees with
+/// us is inaudible in both directions, not merely unencrypted.
+///
+/// `latest_encryption_state` fetches `m.room.encryption` when the state never
+/// reached us, which matters because `:call` works from the room list, on rooms
+/// we may never have opened. If even that fails we assume encryption: guessing
+/// wrong that way costs audio, while guessing wrong the other way puts our
+/// media on the wire in the clear.
+#[cfg(feature = "voip")]
+async fn call_media_encrypted(room: &MatrixRoom) -> bool {
+    match room.latest_encryption_state().await {
+        Ok(state) => !matches!(state, EncryptionState::NotEncrypted),
+        Err(e) => {
+            warn!(
+                room_id = %room.room_id(),
+                "could not read the room's encryption state, assuming encrypted: {e}"
+            );
+
+            true
+        },
+    }
+}
+
+/// Wrap a call setup failure as something the UI can show.
+#[cfg(feature = "voip")]
+fn call_error(e: impl std::fmt::Display) -> UIError<crate::base::IambInfo> {
+    IambError::Call(format!("{e:#}")).into()
 }
 
 fn oneshot<T>() -> (ClientReply<T>, ClientResponse<T>) {
@@ -738,6 +906,26 @@ pub enum WorkerTask {
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
     TypingNotice(OwnedRoomId),
     LoadImage(MediaSource, PreviewKind, Size, Arc<Picker>, Arc<Semaphore>),
+    Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
+    VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
+    LoadImage(MediaSource, PreviewKind, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
+
+    #[cfg(feature = "voip")]
+    CallJoin(OwnedRoomId, ClientReply<IambResult<EditInfo>>),
+    #[cfg(feature = "voip")]
+    CallHangup(OwnedRoomId, ClientReply<IambResult<EditInfo>>),
+    #[cfg(feature = "voip")]
+    CallDecline(OwnedRoomId, OwnedEventId, ClientReply<IambResult<EditInfo>>),
+    #[cfg(feature = "voip")]
+    CallMute(bool),
+    #[cfg(feature = "voip")]
+    CallNotice(OwnedRoomId, CallNotice),
+    #[cfg(feature = "voip")]
+    CallRefresh,
+    #[cfg(feature = "voip")]
+    CallDevices(ClientReply<IambResult<EditInfo>>),
+    #[cfg(feature = "voip")]
+    CallSetDevice(DeviceKind, String, ClientReply<IambResult<EditInfo>>),
 }
 
 impl Debug for WorkerTask {
@@ -797,8 +985,85 @@ impl Debug for WorkerTask {
                     .field(&format_args!("_"))
                     .finish()
             },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallJoin(room_id, _) => {
+                f.debug_tuple("WorkerTask::CallJoin").field(room_id).finish()
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallHangup(room_id, _) => {
+                f.debug_tuple("WorkerTask::CallHangup").field(room_id).finish()
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallDecline(room_id, event_id, _) => {
+                f.debug_tuple("WorkerTask::CallDecline")
+                    .field(room_id)
+                    .field(event_id)
+                    .finish()
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallMute(muted) => {
+                f.debug_tuple("WorkerTask::CallMute").field(muted).finish()
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallNotice(room_id, notice) => {
+                f.debug_tuple("WorkerTask::CallNotice")
+                    .field(room_id)
+                    .field(notice)
+                    .finish()
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallRefresh => f.debug_tuple("WorkerTask::CallRefresh").finish(),
+            #[cfg(feature = "voip")]
+            WorkerTask::CallDevices(_) => f.debug_tuple("WorkerTask::CallDevices").finish(),
+            #[cfg(feature = "voip")]
+            WorkerTask::CallSetDevice(kind, spec, _) => {
+                f.debug_tuple("WorkerTask::CallSetDevice").field(kind).field(spec).finish()
+            },
         }
     }
+}
+
+/// Build the HTTP client that all of iamb's outbound requests go through.
+///
+/// Shared rather than inlined because the Matrix client is not the only thing
+/// that talks HTTP: the VoIP feature fetches `.well-known` and the LiveKit JWT
+/// service directly. Those requests have to honour the same proxy, user agent
+/// and timeout, or signalling works while call setup fails for anyone behind a
+/// proxy.
+/// Build an HTTP client for talking to the LiveKit JWT service.
+///
+/// This mirrors the proxy and TLS settings used for the homeserver connection,
+/// so a user behind a proxy can still reach the SFU's token endpoint.
+#[cfg(feature = "voip")]
+fn build_http_client(settings: &ApplicationSettings) -> reqwest::Client {
+    let req_timeout = Duration::from_secs(settings.tunables.request_timeout);
+
+    let mut builder = reqwest::Client::builder()
+        .user_agent(IAMB_USER_AGENT)
+        .timeout(req_timeout)
+        .danger_accept_invalid_certs(!settings.tunables.ssl_verify);
+
+    let proxy_config = &settings.tunables.proxy;
+
+    match &proxy_config.url {
+        ProxyUrl::Disabled => builder = builder.no_proxy(),
+        ProxyUrl::Endpoint(url) => {
+            if let Ok(mut proxy) = reqwest::Proxy::all(url.clone()) {
+                if !proxy_config.headers.is_empty() {
+                    proxy = proxy.headers(proxy_config.headers.clone());
+                }
+
+                if let Some(auth) = proxy_config.auth.clone() {
+                    proxy = proxy.custom_http_auth(auth);
+                }
+
+                builder = builder.proxy(proxy);
+            }
+        },
+        ProxyUrl::System => {},
+    }
+
+    builder.build().unwrap_or_default()
 }
 
 async fn create_client_inner(
@@ -896,6 +1161,10 @@ pub async fn create_client(settings: &ApplicationSettings) -> Client {
 pub struct Requester {
     pub client: Client,
     pub tx: UnboundedSender<WorkerTask>,
+
+    /// The call state the worker publishes for the UI to render.
+    #[cfg(feature = "voip")]
+    pub call_status: CallStatus,
 }
 
 impl Requester {
@@ -979,6 +1248,95 @@ impl Requester {
             .send(WorkerTask::LoadImage(source, kind, size, picker, permits))
             .unwrap();
     }
+
+    /// Join the call in the given room, connecting to the LiveKit focus.
+    #[cfg(feature = "voip")]
+    pub fn call_join(&self, room_id: OwnedRoomId) -> IambResult<EditInfo> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::CallJoin(room_id, reply)).unwrap();
+
+        return response.recv();
+    }
+
+    /// Leave the call in the given room and tear down the LiveKit session.
+    #[cfg(feature = "voip")]
+    pub fn call_hangup(&self, room_id: OwnedRoomId) -> IambResult<EditInfo> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::CallHangup(room_id, reply)).unwrap();
+
+        return response.recv();
+    }
+
+    /// Leave the active call as part of shutting the application down.
+    ///
+    /// Unlike [`Requester::call_hangup`], this neither panics nor blocks
+    /// forever: at exit the worker may already be gone, and an unreachable
+    /// homeserver must not keep the process from quitting. If the retraction
+    /// does not get through, the membership expiry cleans up instead.
+    #[cfg(feature = "voip")]
+    pub fn call_hangup_on_exit(&self, room_id: OwnedRoomId) {
+        let (reply, response) = oneshot();
+
+        if self.tx.send(WorkerTask::CallHangup(room_id, reply)).is_err() {
+            return;
+        }
+
+        if response.recv_before(HANGUP_ON_EXIT_TIMEOUT).is_none() {
+            tracing::warn!("timed out leaving the call while shutting down");
+        }
+    }
+
+    /// Reject an incoming call without joining it.
+    ///
+    /// `notification` is the `m.rtc.notification` event that rang us, which the
+    /// decline is sent as a reply to - so declining is only possible for a call
+    /// someone explicitly rang, not for any call happening in the room.
+    ///
+    /// This does not end the call or leave one (see [`Requester::call_hangup`]
+    /// for that); the others carry on without us. Its real purpose is to stop
+    /// *our own other devices* ringing, since they watch for our declines.
+    #[cfg(feature = "voip")]
+    pub fn call_decline(
+        &self,
+        room_id: OwnedRoomId,
+        notification: OwnedEventId,
+    ) -> IambResult<EditInfo> {
+        let (reply, response) = oneshot();
+
+        self.tx
+            .send(WorkerTask::CallDecline(room_id, notification, reply))
+            .unwrap();
+
+        return response.recv();
+    }
+
+    /// Mute or unmute the local microphone in the active call.
+    #[cfg(feature = "voip")]
+    pub fn call_mute(&self, muted: bool) {
+        self.tx.send(WorkerTask::CallMute(muted)).unwrap();
+    }
+
+    /// List the audio devices available for calls.
+    #[cfg(feature = "voip")]
+    pub fn call_devices(&self) -> IambResult<EditInfo> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::CallDevices(reply)).unwrap();
+
+        return response.recv();
+    }
+
+    /// Choose the audio device to use for calls.
+    #[cfg(feature = "voip")]
+    pub fn call_set_device(&self, kind: DeviceKind, spec: String) -> IambResult<EditInfo> {
+        let (reply, response) = oneshot();
+
+        self.tx.send(WorkerTask::CallSetDevice(kind, spec, reply)).unwrap();
+
+        return response.recv();
+    }
 }
 
 pub struct ClientWorker {
@@ -988,13 +1346,36 @@ pub struct ClientWorker {
     load_handle: Option<JoinHandle<()>>,
     sync_handle: Option<JoinHandle<()>>,
 
+    /// Tracks the active call session, if any.
+    #[cfg(feature = "voip")]
+    call_manager: CallManager,
+
+    /// Lets the call thread queue work that needs the Matrix client.
+    #[cfg(feature = "voip")]
+    tx: UnboundedSender<WorkerTask>,
+
+    /// For the call setup requests that do not go through the Matrix client:
+    /// `.well-known` discovery and the LiveKit JWT service. Built from the same
+    /// settings as the Matrix client's, so both honour the configured proxy.
+    #[cfg(feature = "voip")]
+    http: reqwest::Client,
+
+    /// The call state published to the UI. The worker is its only writer.
+    #[cfg(feature = "voip")]
+    call_status: CallStatus,
+
     /// Take care when locking since worker commands are sent with the lock already hold
     store: Option<AsyncProgramStore>,
 }
-
 impl ClientWorker {
     pub async fn spawn(client: Client, settings: ApplicationSettings) -> Requester {
         let (tx, rx) = unbounded_channel();
+
+        #[cfg(feature = "voip")]
+        let call_status = CallStatus::default();
+
+        #[cfg(feature = "voip")]
+        let http = build_http_client(&settings);
 
         let mut worker = ClientWorker {
             initialized: false,
@@ -1002,6 +1383,14 @@ impl ClientWorker {
             client: client.clone(),
             load_handle: None,
             sync_handle: None,
+            #[cfg(feature = "voip")]
+            call_manager: CallManager::new(),
+            #[cfg(feature = "voip")]
+            tx: tx.clone(),
+            #[cfg(feature = "voip")]
+            http,
+            #[cfg(feature = "voip")]
+            call_status: call_status.clone(),
             store: None,
         };
 
@@ -1009,7 +1398,12 @@ impl ClientWorker {
             worker.work(rx).await;
         });
 
-        return Requester { client, tx };
+        return Requester {
+            client,
+            tx,
+            #[cfg(feature = "voip")]
+            call_status,
+        };
     }
 
     async fn work(&mut self, mut rx: UnboundedReceiver<WorkerTask>) {
@@ -1080,6 +1474,46 @@ impl ClientWorker {
                     size,
                 ));
             },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallJoin(room_id, reply) => {
+                assert!(self.initialized);
+                reply.send(self.call_join(room_id).await);
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallHangup(room_id, reply) => {
+                assert!(self.initialized);
+                reply.send(self.call_hangup(room_id).await);
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallDecline(room_id, notification, reply) => {
+                assert!(self.initialized);
+                reply.send(self.call_decline(room_id, notification).await);
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallMute(muted) => {
+                assert!(self.initialized);
+                self.call_mute(muted).await;
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallNotice(room_id, notice) => {
+                assert!(self.initialized);
+                self.call_notice(room_id, notice).await;
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallRefresh => {
+                assert!(self.initialized);
+                self.call_refresh().await;
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallDevices(reply) => {
+                assert!(self.initialized);
+                reply.send(self.call_devices());
+            },
+            #[cfg(feature = "voip")]
+            WorkerTask::CallSetDevice(kind, spec, reply) => {
+                assert!(self.initialized);
+                reply.send(self.call_set_device(kind, spec));
+            },
         }
     }
 
@@ -1128,6 +1562,362 @@ impl ClientWorker {
                 }
             },
         );
+
+        // Calls already in progress arrive as room state during the first sync.
+        // Announcing those would greet every startup with a burst of "call in
+        // …" for calls that may have started hours ago, so memberships older
+        // than this are tracked but not announced.
+        #[cfg(feature = "voip")]
+        let startup_ts = MilliSecondsSinceUnixEpoch::from_system_time(SystemTime::now());
+
+        #[cfg(feature = "voip")]
+        let _ = self.client.add_event_handler(
+            move |ev: SyncStateEvent<CallMemberEventContent>,
+                  room: MatrixRoom,
+                  client: Client,
+                  store: Ctx<AsyncProgramStore>| {
+                async move {
+                    let room_id = room.room_id().to_owned();
+                    let sender = ev.sender().to_owned();
+
+                    let ours = client.user_id() == Some(&sender);
+                    let fresh = startup_ts.is_some_and(|start| ev.origin_server_ts() >= start);
+
+                    // Handlers run after the sync response has been folded into
+                    // the store, so the SDK's MatrixRTC state already accounts
+                    // for this event - including empty content, redactions, and
+                    // memberships whose expiry has already elapsed.
+                    let active = room.has_active_room_call();
+
+                    let mut locked = store.lock().await;
+                    let info = locked.application.rooms.get_or_default(room_id.clone());
+
+                    // A call "starts" the moment the room goes from nobody in it
+                    // to somebody, which is the only transition worth announcing.
+                    let started = active && !info.had_active_call;
+                    info.had_active_call = active;
+
+                    // The call this ring belonged to is over, so stop offering
+                    // it as answerable and let the next call announce itself.
+                    if !active {
+                        info.incoming_call = None;
+                        info.call_announced = false;
+                    }
+
+                    // An `m.rtc.notification` for the same call says everything
+                    // Whichever arrives first announces; the other stays quiet.
+                    let announce = started && fresh && !ours && !info.call_announced;
+
+                    if announce {
+                        info.call_announced = true;
+                    }
+
+                    let name = info.name.clone();
+
+                    if announce {
+                        let name = name.unwrap_or_else(|| room_id.to_string());
+
+                        crate::notifications::notify_call_started(&name, room_id, &mut locked)
+                            .await;
+                    }
+                }
+            },
+        );
+
+        // Someone ringing the room (MSC4075). This is the explicit "pick up"
+        // signal, as opposed to the `m.call.member` state above, which only says
+        // a call exists.
+        #[cfg(feature = "voip")]
+        let _ = self.client.add_event_handler(
+            move |ev: OriginalSyncRtcNotificationEvent,
+                  room: MatrixRoom,
+                  client: Client,
+                  store: Ctx<AsyncProgramStore>| {
+                async move {
+                    let room_id = room.room_id().to_owned();
+                    let sender = ev.sender.clone();
+
+                    // Check if we are the sender
+                    if client.user_id() == Some(&sender) {
+                        return;
+                    }
+
+                    // Call experation timer
+                    let expires_at = ev.content.expiration_ts(ev.origin_server_ts, None);
+
+                    if expires_at <= MilliSecondsSinceUnixEpoch::now() {
+                        return;
+                    }
+
+                    // Mentions say who the ring is for, so a call aimed at two
+                    // people in a large room does not ring everybody.
+                    let mentioned = client.user_id().is_some_and(|us| {
+                        crate::voip::ring_is_for_us(ev.content.mentions.as_ref(), us)
+                    });
+
+                    if !mentioned {
+                        return;
+                    }
+
+                    let ring = ev.content.notification_type == NotificationType::Ring;
+
+                    let caller = room
+                        .get_member_no_sync(&sender)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|member| member.display_name().map(ToOwned::to_owned))
+                        .unwrap_or_else(|| sender.localpart().to_owned());
+
+                    let mut locked = store.lock().await;
+
+                    // If the ring is aimed at us, and we have already joined the
+                    // call. Skip a notification
+                    let joined = locked
+                        .application
+                        .call_status
+                        .get()
+                        .is_some_and(|call| *call.room_id == *room_id);
+
+                    if joined {
+                        return;
+                    }
+
+                    let info = locked.application.rooms.get_or_default(room_id.clone());
+
+                    info.incoming_call = Some(IncomingCall {
+                        notification: ev.event_id.clone(),
+                        from: sender,
+                        expires_at,
+                        ring,
+                    });
+
+                    // The `m.call.member` handler may have announced this call
+                    // already; one call is worth one notification.
+                    if info.call_announced {
+                        return;
+                    }
+
+                    info.call_announced = true;
+
+                    let name = info.name.clone().unwrap_or_else(|| room_id.to_string());
+
+                    crate::notifications::notify_incoming_call(
+                        &name,
+                        &caller,
+                        room_id,
+                        ring,
+                        &mut locked,
+                    )
+                    .await;
+                }
+            },
+        );
+
+        // Someone declining a call they were rung about, including our own other
+        // devices - answering or rejecting on one device silences the rest.
+        #[cfg(feature = "voip")]
+        let _ = self.client.add_event_handler(
+            move |ev: OriginalSyncRtcDeclineEvent,
+                  room: MatrixRoom,
+                  client: Client,
+                  store: Ctx<AsyncProgramStore>| {
+                async move {
+                    //Check if the device user that declined is our own
+                    if client.user_id() != Some(&ev.sender) {
+                        return;
+                    }
+
+                    let room_id = room.room_id().to_owned();
+                    let declined = &ev.content.relates_to.event_id;
+
+                    let mut locked = store.lock().await;
+                    let info = locked.application.rooms.get_or_default(room_id);
+
+                    if info
+                        .incoming_call
+                        .as_ref()
+                        .is_some_and(|call| call.notification == *declined)
+                    {
+                        info.incoming_call = None;
+                    }
+                }
+            },
+        );
+
+        #[cfg(feature = "voip")]
+        {
+            self.client.add_event_handler_context(self.call_manager.inbox.clone());
+
+            // Taken raw so that a shape we do not recognise is something we can
+            // read rather than something the SDK silently drops. Every client
+            // writes this event slightly differently, and a typed handler that
+            // fails to parse takes the key down with it: the participant is
+            // then inaudible for the whole call, with `MissingKey` in the log
+            // and no way to tell which field was to blame.
+            let _ = self.client.add_event_handler(
+                |ev: Raw<CallEncryptionKeysEvent>,
+                 encryption: Option<EncryptionInfo>,
+                 inbox: Ctx<KeyInbox>| {
+                    async move {
+                        let ev = match ev.deserialize() {
+                            Ok(ev) => ev,
+                            Err(e) => {
+                                tracing::warn!(
+                                    payload = %redact_call_key(ev.json().get()),
+                                    "could not parse an incoming call encryption key: {e}"
+                                );
+
+                                return;
+                            },
+                        };
+
+                        let content = ev.content;
+
+                        // `member.id` is not necessarily a user id. Element X
+                        // puts a per-session MatrixRTC member identifier there
+                        // - a fresh UUID for every call - so requiring it to
+                        // equal the sender rejected every key it ever sent.
+                        //
+                        // Nothing is lost by not insisting: the field is never
+                        // read again. The key is filed under `ev.sender`, which
+                        // the homeserver vouches for, so a sender cannot claim
+                        // another user's slot no matter what it writes here.
+                        if content.member.id != ev.sender.as_str() {
+                            tracing::debug!(
+                                sender = %ev.sender,
+                                member_id = %content.member.id,
+                                "call encryption key names its member by something other than the sender"
+                            );
+                        }
+
+                        // The device named in the content picks which LiveKit
+                        // participant the key is filed under, so a wrong one
+                        // silences that participant. Olm authenticates the
+                        // sending device, so encrypted keys can be checked;
+                        // ones sent in the clear cannot, but older Element Call
+                        // still sends those, so they are accepted unverified.
+                        let sender_device =
+                            encryption.as_ref().and_then(|info| info.sender_device.as_ref());
+
+                        // Olm's device is preferred over the claimed one rather
+                        // than merely checked against it. Both name the same
+                        // thing, but only Olm's is authenticated, and taking it
+                        // means a sender that writes something unexpected in
+                        // the content still gets its key filed correctly - the
+                        // same class of mistake that `member.id` turned out to
+                        // be. Unencrypted senders have no Olm device, so the
+                        // claim is all there is.
+                        let device_id = match sender_device {
+                            Some(device) => {
+                                if *device != content.member.claimed_device_id {
+                                    tracing::warn!(
+                                        sender = %ev.sender,
+                                        claimed = %content.member.claimed_device_id,
+                                        authenticated = %device,
+                                        "call encryption key claims a device other than the one that sent it"
+                                    );
+                                }
+
+                                device.to_owned()
+                            },
+                            None => content.member.claimed_device_id.clone(),
+                        };
+
+                        let Some(material) = decode_call_key(&content.keys.key) else {
+                            tracing::warn!(
+                                sender = %ev.sender,
+                                "ignoring call encryption key with invalid base64"
+                            );
+
+                            return;
+                        };
+
+                        // Only now, once the key itself is known to be usable,
+                        // is the room id worth insisting on. Parsing it earlier
+                        // as part of the event is what cost us every key a peer
+                        // ever sent: one field ruma dislikes and the whole
+                        // event is dropped before any of this runs.
+                        let room_id = match OwnedRoomId::try_from(content.room_id.clone()) {
+                            Ok(room_id) => room_id,
+                            Err(e) => {
+                                tracing::warn!(
+                                    sender = %ev.sender,
+                                    room_id = %content.room_id,
+                                    "ignoring call encryption key for an unparseable room: {e}"
+                                );
+
+                                return;
+                            },
+                        };
+
+                        // The counterpart of the room transport's own line
+                        // below. Both are needed to tell "their key never
+                        // arrived" from "their key arrived and did not work":
+                        // a key lost to a broken Olm session is dropped by the
+                        // SDK before it ever reaches this handler, and from
+                        // here looks exactly like a peer that sent nothing.
+                        tracing::debug!(
+                            sender = %ev.sender,
+                            %device_id,
+                            index = content.keys.index,
+                            encrypted = encryption.is_some(),
+                            "received a call encryption key over the to-device transport"
+                        );
+
+                        inbox.push(ReceivedCallKey {
+                            room_id,
+                            user_id: ev.sender,
+                            device_id,
+                            index: content.keys.index,
+                            key: material,
+                        });
+                    }
+                },
+            );
+
+            // The older key transport, still the only one some Element Call
+            // builds speak. Nothing here authenticates the device beyond what
+            // the room's own encryption provides, which is exactly the trust
+            // model the senders using this transport already have.
+            let _ = self.client.add_event_handler(
+                |ev: OriginalSyncCallEncryptionKeysRoomEvent,
+                 room: MatrixRoom,
+                 inbox: Ctx<KeyInbox>| {
+                    async move {
+                        let room_id = room.room_id().to_owned();
+                        let sender = ev.sender;
+                        let device_id = ev.content.device_id;
+
+                        for key in ev.content.keys {
+                            let Some(material) = decode_call_key(&key.key) else {
+                                tracing::warn!(
+                                    %sender,
+                                    "ignoring call encryption key with invalid base64"
+                                );
+
+                                continue;
+                            };
+
+                            tracing::debug!(
+                                %sender,
+                                %device_id,
+                                index = key.index,
+                                "received a call encryption key over the room transport"
+                            );
+
+                            inbox.push(ReceivedCallKey {
+                                room_id: room_id.clone(),
+                                user_id: sender.clone(),
+                                device_id: device_id.clone(),
+                                index: key.index,
+                                key: material,
+                            });
+                        }
+                    }
+                },
+            );
+        }
 
         let _ = self.client.add_event_handler(
             |ev: SyncMessageLikeEvent<RoomMessageEventContent>,
@@ -1383,6 +2173,8 @@ impl ClientWorker {
         self.load_handle = tokio::spawn({
             let client = self.client.clone();
             let settings = self.settings.clone();
+            #[cfg(feature = "voip")]
+            let tx = self.tx.clone();
 
             async move {
                 while !client.is_active() {
@@ -1394,7 +2186,14 @@ impl ClientWorker {
                 let room = refresh_rooms_forever(&client, &store);
                 let notifications = register_notifications(&client, &settings, &store);
                 let sendqueue = subscribe_sendqueue_forever(&client, &store);
-                let ((), (), (), (), ()) = tokio::join!(load, rcpt, room, notifications, sendqueue);
+
+                #[cfg(feature = "voip")]
+                let call = refresh_call_membership_forever(tx);
+                #[cfg(not(feature = "voip"))]
+                let call = std::future::pending::<()>();
+
+                let ((), (), (), (), (), ()) =
+                    tokio::join!(load, rcpt, room, notifications, sendqueue, call);
             }
         })
         .into();
@@ -1566,6 +2365,461 @@ impl ClientWorker {
     async fn typing_notice(&mut self, room_id: OwnedRoomId) {
         if let Some(room) = self.client.get_room(room_id.as_ref()) {
             let _ = room.typing_notice(true).await;
+        }
+    }
+
+    async fn verify(&self, action: VerifyAction, sas: SasVerification) -> IambResult<EditInfo> {
+        match action {
+            VerifyAction::Accept => {
+                sas.accept().await.map_err(IambError::from)?;
+
+                Ok(Some(InfoMessage::from("Accepted verification request")))
+            },
+            VerifyAction::Confirm => {
+                if sas.is_done() || sas.is_cancelled() {
+                    let msg = "Can only confirm in-progress verifications!";
+                    let err = UIError::Failure(msg.into());
+
+                    return Err(err);
+                }
+
+                sas.confirm().await.map_err(IambError::from)?;
+
+                Ok(Some(InfoMessage::from("Confirmed verification")))
+            },
+            VerifyAction::Cancel => {
+                if sas.is_done() || sas.is_cancelled() {
+                    let msg = "Can only cancel in-progress verifications!";
+                    let err = UIError::Failure(msg.into());
+
+                    return Err(err);
+                }
+
+                sas.cancel().await.map_err(IambError::from)?;
+
+                Ok(Some(InfoMessage::from("Cancelled verification")))
+            },
+            VerifyAction::Mismatch => {
+                if sas.is_done() || sas.is_cancelled() {
+                    let msg = "Can only cancel in-progress verifications!";
+                    let err = UIError::Failure(msg.into());
+
+                    return Err(err);
+                }
+
+                sas.mismatch().await.map_err(IambError::from)?;
+
+                Ok(Some(InfoMessage::from("Cancelled verification")))
+            },
+        }
+    }
+
+    async fn verify_request(&self, user_id: OwnedUserId) -> IambResult<EditInfo> {
+        let enc = self.client.encryption();
+
+        match enc.get_user_identity(user_id.as_ref()).await.map_err(IambError::from)? {
+            Some(identity) => {
+                let methods = vec![VerificationMethod::SasV1];
+                let request = identity.request_verification_with_methods(methods);
+                let _req = request.await.map_err(IambError::from)?;
+                let info = format!("Sent verification request to {user_id}");
+
+                Ok(Some(InfoMessage::from(info)))
+            },
+            None => {
+                let msg = format!("Could not find identity information for {user_id}");
+                let err = UIError::Failure(msg);
+
+                Err(err)
+            },
+        }
+    }
+
+    /// Join the call in `room_id`: discover the LiveKit focus, obtain a token,
+    /// connect, and publish our `m.call.member` state event.
+    #[cfg(feature = "voip")]
+    async fn call_join(&mut self, room_id: OwnedRoomId) -> IambResult<EditInfo> {
+        if self.call_manager.is_active() {
+            return Ok(Some(InfoMessage::from("Already in a call")));
+        }
+
+        let Some(room) = self.client.get_room(&room_id) else {
+            return Err(IambError::UnknownRoom(room_id).into());
+        };
+
+        let encrypted = call_media_encrypted(&room).await;
+
+        if !encrypted {
+            tracing::warn!(%room_id, "the room is unencrypted, so our media is too");
+        }
+
+        let user_id = self
+            .client
+            .user_id()
+            .ok_or_else(|| call_error("not logged in"))?
+            .to_owned();
+        let device_id = self
+            .client
+            .device_id()
+            .ok_or_else(|| call_error("no device id"))?
+            .to_owned();
+
+        let focus = matrix_rtc::discover_focus(&self.client, &self.http, &room)
+            .await
+            .map_err(call_error)?;
+        let credentials =
+            matrix_rtc::request_sfu_credentials(&self.client, &self.http, &focus, &device_id)
+                .await
+                .map_err(call_error)?;
+
+        let audio = PlatformAudio::new().map_err(call_error)?;
+
+        // Playback is LiveKit's, inside libwebrtc, and reports nothing back:
+        // there is no way to ask whether playout ever started. The device
+        // counts are the one thing we can see, and an output count of zero
+        // turns "the call is silent" from a mystery into a fact.
+        tracing::info!(
+            microphones = audio.recording_devices().count(),
+            speakers = audio.playout_devices().count(),
+            "opened the audio device module for a call"
+        );
+
+        devices::apply(&audio, &self.settings.read_voip_devices());
+
+        let key = generate_call_key();
+        let config = SessionConfig {
+            audio,
+            url: credentials.url,
+            token: credentials.jwt,
+            e2ee_key: key.clone(),
+            identity: matrix_rtc::participant_identity(&user_id, &device_id),
+            inbox: self.call_manager.inbox.clone(),
+            room_id: room_id.clone(),
+            encrypted,
+        };
+
+        // If we start the call we claim ownership
+        let starting = !matrix_rtc::call_already_started(&room);
+
+        // Announce ourselves before connecting so that anyone already in the
+        // call sees us arrive and starts sending us their keys.
+        //
+        // `None` leaves `created_ts` for the server to stamp, which is what
+        // MSC3401 asks of an initial join; refreshes read it back.
+        let membership = matrix_rtc::publish_membership(&room, &user_id, &device_id, &focus, None)
+            .await
+            .map_err(call_error)?;
+
+        let session = match CallSession::new(config, room_id.clone(), focus, self.tx.clone()) {
+            Ok(session) => session,
+            Err(e) => {
+                // We already told the room we were joining, so take that back
+                // rather than leaving a membership for a call we are not in.
+                if let Err(e) = self.retract_our_membership(&room_id).await {
+                    tracing::warn!("could not retract our call membership: {e:#}");
+                }
+
+                return Err(call_error(format!("could not start the call thread: {e}")));
+            },
+        };
+
+        self.call_manager.session = Some(session);
+        self.call_status.joined(room_id.clone());
+
+        // Ring the room, if we are the one starting the call.
+        if starting {
+            let ring = matrix_rtc::should_ring(&room).await;
+
+            if let Err(e) = matrix_rtc::send_call_notification(&room, membership, ring).await {
+                tracing::warn!("could not announce the call to the room: {e:#}");
+            }
+        }
+
+        // We are in the call from here on, so key distribution failing is worth
+        // a warning but must not report the join as failed which would leave
+        // the worker in a call the UI does not know about.
+        match matrix_rtc::key_recipients(&room).await {
+            Err(e) => tracing::warn!("could not list call key recipients: {e:#}"),
+            Ok(recipients) => {
+                if let Err(e) = self
+                    .share_call_key(&room, &device_id, FIRST_KEY_INDEX, &key, recipients)
+                    .await
+                {
+                    tracing::warn!("could not share our call encryption key: {e:#}");
+                }
+            },
+        }
+
+        Ok(Some(InfoMessage::from("Joined the call")))
+    }
+
+    /// Leave the call in `room_id`, tearing down the LiveKit session and
+    /// retracting our `m.call.member` state event.
+    #[cfg(feature = "voip")]
+    async fn call_hangup(&mut self, room_id: OwnedRoomId) -> IambResult<EditInfo> {
+        if !self.call_manager.is_active() {
+            self.call_status.left();
+
+            return Ok(Some(InfoMessage::from("Not in a call")));
+        }
+
+        // Dropping the session shuts the call thread down and leaves the SFU.
+        //
+        // Clearing `call_status` is also what drops us from the participant
+        // list right away: the state event we are about to retract only stops
+        // counting once the homeserver echoes it back, and until then
+        // `call_participants` uses this to overrule it.
+        self.call_manager.session = None;
+        self.call_status.left();
+
+        match self.retract_our_membership(&room_id).await {
+            Ok(()) => Ok(Some(InfoMessage::from("Left the call"))),
+            Err(e) => {
+                tracing::warn!("could not retract our call membership: {e:#}");
+
+                Ok(Some(InfoMessage::from("Left the call (membership not retracted)")))
+            },
+        }
+    }
+
+    /// Decline a call we were rung about, without joining it.
+    /// Also tells other devices we declined
+    #[cfg(feature = "voip")]
+    async fn call_decline(
+        &mut self,
+        room_id: OwnedRoomId,
+        notification: OwnedEventId,
+    ) -> IambResult<EditInfo> {
+        let Some(room) = self.client.get_room(&room_id) else {
+            return Err(IambError::UnknownRoom(room_id).into());
+        };
+
+        matrix_rtc::send_decline(&room, &notification).await.map_err(call_error)?;
+
+        Ok(Some(InfoMessage::from("Declined the call")))
+    }
+
+    /// Push the expiry of our `m.call.member` membership further out.
+    ///
+    /// A membership is only valid for [`matrix_rtc::MEMBERSHIP_LIFETIME`] past
+    /// its creation, so a call that outlives that would silently vanish from
+    /// every other participant's view while still running. Re-publishing on a
+    /// timer keeps it alive; the same expiry is what eventually clears our
+    /// membership if we die without retracting it.
+    #[cfg(feature = "voip")]
+    async fn call_refresh(&mut self) {
+        let Some(session) = &self.call_manager.session else {
+            return;
+        };
+
+        let (Some(room), Some(device_id), Some(user_id)) = (
+            self.client.get_room(&session.room_id),
+            self.client.device_id().map(|id| id.to_owned()),
+            self.client.user_id().map(|id| id.to_owned()),
+        ) else {
+            return;
+        };
+
+        // The server stamped `created_ts` when we joined, so read it back rather
+        // than trusting our own clock for when the session began. `None` here
+        // means our membership has not synced back, in which case starting a
+        // fresh chain is safer than guessing at a start time.
+        let created_ts = matrix_rtc::our_membership_created_ts(&room, &user_id, &device_id).await;
+
+        // If failed to refresh, the call doesn't drop. The call can be refreshed later
+        if let Err(e) =
+            matrix_rtc::publish_membership(&room, &user_id, &device_id, &session.focus, created_ts)
+                .await
+        {
+            tracing::warn!("could not refresh our call membership: {e:#}");
+        }
+    }
+
+    /// Announce that this device has left the call in `room_id`.
+    #[cfg(feature = "voip")]
+    async fn retract_our_membership(&self, room_id: &OwnedRoomId) -> anyhow::Result<()> {
+        let room = self
+            .client
+            .get_room(room_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown room {room_id}"))?;
+        let user_id = self
+            .client
+            .user_id()
+            .ok_or_else(|| anyhow::anyhow!("not logged in"))?
+            .to_owned();
+        let device_id = self
+            .client
+            .device_id()
+            .ok_or_else(|| anyhow::anyhow!("no device id"))?
+            .to_owned();
+
+        matrix_rtc::retract_membership(&room, &user_id, &device_id).await
+    }
+
+    /// Mute or unmute the local microphone in the active call.
+    #[cfg(feature = "voip")]
+    async fn call_mute(&mut self, muted: bool) {
+        if let Some(session) = &mut self.call_manager.session {
+            session.set_muted(muted);
+            self.call_status.set_muted(muted);
+        }
+    }
+
+    /// A handle on the system audio devices.
+    ///
+    /// During a call this is the session's own handle, so changes take effect on
+    /// the live call. Outside a call it is a temporary one, which acquires the
+    /// audio device module just long enough to answer and releases it on drop.
+    #[cfg(feature = "voip")]
+    fn audio_handle(&self) -> IambResult<PlatformAudio> {
+        if let Some(session) = &self.call_manager.session {
+            return Ok(session.audio.clone());
+        }
+
+        PlatformAudio::new().map_err(call_error)
+    }
+
+    /// Show the audio devices available for calls.
+    #[cfg(feature = "voip")]
+    fn call_devices(&self) -> IambResult<EditInfo> {
+        let audio = self.audio_handle()?;
+        let prefs = self.settings.read_voip_devices();
+
+        Ok(Some(InfoMessage::Pager(devices::format_listing(&audio, &prefs))))
+    }
+
+    /// Choose an audio device, applying it now and remembering it for later.
+    #[cfg(feature = "voip")]
+    fn call_set_device(&self, kind: DeviceKind, spec: String) -> IambResult<EditInfo> {
+        let audio = self.audio_handle()?;
+        let name = devices::select(&audio, kind, &spec).map_err(call_error)?;
+
+        let mut prefs = self.settings.read_voip_devices();
+        prefs.set(kind, name.clone());
+        self.settings.write_voip_devices(&prefs).map_err(call_error)?;
+
+        Ok(Some(InfoMessage::from(format!("Using {name:?} as the {}", kind.keyword()))))
+    }
+
+    /// Act on something the call thread asked us to do.
+    #[cfg(feature = "voip")]
+    async fn call_notice(&mut self, room_id: OwnedRoomId, notice: CallNotice) {
+        let Some(session) = &self.call_manager.session else {
+            return;
+        };
+
+        if session.room_id != room_id {
+            return;
+        }
+
+        match notice {
+            CallNotice::Connected => {
+                self.call_status.connected();
+            },
+            CallNotice::Speakers(speakers) => {
+                self.call_status.set_speakers(speakers);
+            },
+            CallNotice::ShareKey(user_id) => {
+                let (Some(room), Some(device_id)) =
+                    (self.client.get_room(&room_id), self.client.device_id())
+                else {
+                    return;
+                };
+
+                // Whatever key we are on *now* a late joiner arriving after a
+                // rotation must be told the current one, not the original.
+                let key = session.key.clone();
+                let index = session.key_index;
+                let device_id = device_id.to_owned();
+
+                if let Err(e) =
+                    self.share_call_key(&room, &device_id, index, &key, vec![user_id]).await
+                {
+                    tracing::warn!("could not share our call encryption key: {e:#}");
+                }
+            },
+            CallNotice::RotateKey => {
+                self.rotate_call_key(&room_id).await;
+            },
+            CallNotice::Ended(reason) => {
+                tracing::warn!("call ended: {reason}");
+                self.call_manager.session = None;
+
+                if let Err(e) = self.retract_our_membership(&room_id).await {
+                    tracing::warn!("could not retract our call membership: {e:#}");
+                }
+
+                self.call_status.left();
+            },
+        }
+    }
+
+    /// Distribute our call E2EE key over both MatrixRTC key transports.
+    ///
+    /// To-device is the primary one and the only one that encrypts the key to
+    /// the participants rather than to the room, so it is the one whose failure
+    /// is reported back. The room event exists for Element Call builds from
+    /// before the to-device transport landed, which listen for nothing else;
+    /// against those, sending only to-device produces a call where both sides
+    /// join, see each other, and hear nothing.
+    #[cfg(feature = "voip")]
+    async fn share_call_key(
+        &self,
+        room: &MatrixRoom,
+        device_id: &matrix_sdk::ruma::DeviceId,
+        index: u8,
+        key: &[u8],
+        recipients: Vec<OwnedUserId>,
+    ) -> anyhow::Result<()> {
+        let sent =
+            matrix_rtc::send_encryption_key(&self.client, room, device_id, index, key, recipients)
+                .await;
+
+        if let Err(e) = matrix_rtc::send_encryption_key_to_room(room, device_id, index, key).await {
+            tracing::warn!("could not send our call encryption key as a room event: {e:#}");
+        }
+
+        sent
+    }
+
+    /// Re-key the call in `room_id` after someone left it.
+    /// Avoids people being able to read call data from outside the call
+    #[cfg(feature = "voip")]
+    async fn rotate_call_key(&mut self, room_id: &OwnedRoomId) {
+        let (Some(room), Some(device_id)) =
+            (self.client.get_room(room_id), self.client.device_id().map(|id| id.to_owned()))
+        else {
+            return;
+        };
+
+        let Some(session) = &self.call_manager.session else {
+            return;
+        };
+
+        let key = generate_call_key();
+        let index = session.next_key_index();
+
+        let recipients = match matrix_rtc::key_recipients(&room).await {
+            Ok(recipients) => recipients,
+            Err(e) => {
+                tracing::warn!("could not list call key recipients for rotation: {e:#}");
+                return;
+            },
+        };
+
+        if let Err(e) = self.share_call_key(&room, &device_id, index, &key, recipients).await {
+            // Switching anyway would encrypt under a key nobody has, silently
+            // cutting our audio for the rest of the call. Staying on the old key
+            // only means the departed participant can still follow along.
+            tracing::warn!(
+                "could not distribute the rotated call key, staying on the old one: {e:#}"
+            );
+            return;
+        }
+
+        if let Some(session) = &mut self.call_manager.session {
+            session.adopt_key(index, key);
+            tracing::info!(index, "rotated the call encryption key");
         }
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -898,9 +898,6 @@ pub enum WorkerTask {
     SpaceMembers(OwnedRoomId, ClientReply<IambResult<Vec<OwnedRoomId>>>),
     TypingNotice(OwnedRoomId),
     LoadImage(MediaSource, PreviewKind, Size, Arc<Picker>, Arc<Semaphore>),
-    Verify(VerifyAction, SasVerification, ClientReply<IambResult<EditInfo>>),
-    VerifyRequest(OwnedUserId, ClientReply<IambResult<EditInfo>>),
-    LoadImage(MediaSource, PreviewKind, ImagePreviewSize, Arc<Picker>, Arc<Semaphore>),
 
     #[cfg(feature = "voip")]
     CallJoin(OwnedRoomId, ClientReply<IambResult<EditInfo>>),
@@ -2357,73 +2354,6 @@ impl ClientWorker {
     async fn typing_notice(&mut self, room_id: OwnedRoomId) {
         if let Some(room) = self.client.get_room(room_id.as_ref()) {
             let _ = room.typing_notice(true).await;
-        }
-    }
-
-    async fn verify(&self, action: VerifyAction, sas: SasVerification) -> IambResult<EditInfo> {
-        match action {
-            VerifyAction::Accept => {
-                sas.accept().await.map_err(IambError::from)?;
-
-                Ok(Some(InfoMessage::from("Accepted verification request")))
-            },
-            VerifyAction::Confirm => {
-                if sas.is_done() || sas.is_cancelled() {
-                    let msg = "Can only confirm in-progress verifications!";
-                    let err = UIError::Failure(msg.into());
-
-                    return Err(err);
-                }
-
-                sas.confirm().await.map_err(IambError::from)?;
-
-                Ok(Some(InfoMessage::from("Confirmed verification")))
-            },
-            VerifyAction::Cancel => {
-                if sas.is_done() || sas.is_cancelled() {
-                    let msg = "Can only cancel in-progress verifications!";
-                    let err = UIError::Failure(msg.into());
-
-                    return Err(err);
-                }
-
-                sas.cancel().await.map_err(IambError::from)?;
-
-                Ok(Some(InfoMessage::from("Cancelled verification")))
-            },
-            VerifyAction::Mismatch => {
-                if sas.is_done() || sas.is_cancelled() {
-                    let msg = "Can only cancel in-progress verifications!";
-                    let err = UIError::Failure(msg.into());
-
-                    return Err(err);
-                }
-
-                sas.mismatch().await.map_err(IambError::from)?;
-
-                Ok(Some(InfoMessage::from("Cancelled verification")))
-            },
-        }
-    }
-
-    async fn verify_request(&self, user_id: OwnedUserId) -> IambResult<EditInfo> {
-        let enc = self.client.encryption();
-
-        match enc.get_user_identity(user_id.as_ref()).await.map_err(IambError::from)? {
-            Some(identity) => {
-                let methods = vec![VerificationMethod::SasV1];
-                let request = identity.request_verification_with_methods(methods);
-                let _req = request.await.map_err(IambError::from)?;
-                let info = format!("Sent verification request to {user_id}");
-
-                Ok(Some(InfoMessage::from(info)))
-            },
-            None => {
-                let msg = format!("Could not find identity information for {user_id}");
-                let err = UIError::Failure(msg);
-
-                Err(err)
-            },
         }
     }
 


### PR DESCRIPTION
Adds an optional `voip` feature providing voice calls over MatrixRTC, using LiveKit as the SFU.

The new `src/voip` module contains:

  - `matrix_rtc.rs`: homeserver-facing signalling. Discovers the LiveKit focus from `m.call.member` state, exchanges an OpenID token for an SFU JWT via lk-jwt-service, and publishes our own membership.
  - `livekit_session.rs`: the LiveKit room connection, the E2EE key ring, and the published microphone track.
  - `devices.rs`: audio device enumeration, matching, and remembered choices.
  - `mod.rs`: `CallManager`/`CallSession` state machine and the key exchange event types.

Calls in encrypted rooms are end-to-end encrypted. Per-participant keys are distributed over Olm-encrypted to-device messages (`io.element.call.encryption_keys`), and re-sent to late joiners. In unencrypted rooms audio is sent in the clear, matching the room.

Audio capture and playback are both handled by LiveKit's platform audio device module, so no additional audio dependency is needed.

User-facing surface is the `:call` command (`join`, `hangup`, `decline`, `mute`, `unmute`, `devices`, `device mic|speaker <name>`), a participant banner in the room view, and a room-list indicator for rooms with an active call.

The feature is off by default; without `--features voip` the build is unchanged.

Claude-Session: https://claude.ai/code/session_01MNTPSETtCAzUuLbn4fzG9a