### PR TITLE
Document `:room history` commands in iamb(1)

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -219,6 +219,22 @@ Set the room's canonical alias to the one provided, and make the previous one an
 Delete the room's canonical alias.
 .It Sy ":room canon show"
 Show the room's canonical alias, if any is set.
+.It Sy ":room history show"
+Show the history visibility setting for the current room.
+.It Sy ":room history set [mode]" .\" TODO: get options
+Set the history visibility for the current room.
+Valid modes are
+.Dq invited
+(new events after invitation),
+.Dq joined
+(new events after join),
+.Dq shared
+(whole history after join),
+.Dq world_readable
+(whole history for unjoined users).
+.It Sy ":room history unset"
+Reset the room visibility setting to
+.Dq joined .
 .It Sy ":room ban [user] [reason]"
 Ban a user from this room with an optional reason.
 .It Sy ":room unban [user] [reason]"


### PR DESCRIPTION
This change is by @VAWVAW and was originally part of #520 and adds documentation to `iamb(1)` for the `:room history` commands. I'm splitting it out so that it will get its own changelog entry in the release notes.