### PR TITLE
Support using room aliases and DMs with `:space child set`

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -250,7 +250,7 @@ Show the display name you currently have in this room.
 .El
 .Sh "SPACE COMMANDS"
 .Bl -tag -width Ds
-.It Sy ":space child set [room_id] [arguments]"
+.It Sy ":space child set [room] [arguments]"
 Add a room to the currently focused space.
 .Dq ++suggested
 marks the room as a suggested child.

--- a/src/base.rs
+++ b/src/base.rs
@@ -195,9 +195,14 @@ pub enum MessageAction {
 pub enum SpaceAction {
     /// Add a room or update metadata.
     ///
-    /// The [`Option<String>`] argument is the order parameter.
-    /// The [`bool`] argument indicates whether the room is suggested.
-    SetChild(OwnedRoomId, Option<String>, bool),
+    SetChild {
+        /// The room ID, alias, or a user whose DM room should be added to the space.
+        child: String,
+        /// The order parameter to use when sorting children in the space.
+        order: Option<String>,
+        /// Whether the room is suggested.
+        suggested: bool,
+    },
 
     /// Remove the selected room.
     RemoveChild,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,6 @@ use std::{convert::TryFrom, str::FromStr as _};
 
 use matrix_sdk::ruma::{
     OwnedMxcUri,
-    OwnedRoomId,
     OwnedRoomOrAliasId,
     OwnedUserId,
     RoomVersionId,
@@ -732,15 +731,15 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         },
         ("version", "upgrade", None) => return Result::Err(CommandError::InvalidArgument),
 
-        // :room aliases show
+        // :room alias show
         ("alias", "show", None) => RoomAction::Show(RoomField::Aliases).into(),
         ("alias", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
 
-        // :room aliases unset <alias>
+        // :room alias unset <alias>
         ("alias", "unset", Some(s)) => RoomAction::Unset(RoomField::Alias(s)).into(),
         ("alias", "unset", None) => return Result::Err(CommandError::InvalidArgument),
 
-        // :room aliases set <alias>
+        // :room alias set <alias>
         ("alias", "set", Some(s)) => RoomAction::Set(RoomField::Alias(s), "".into()).into(),
         ("alias", "set", None) => return Result::Err(CommandError::InvalidArgument),
 
@@ -882,15 +881,12 @@ fn iamb_space(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
                 }
             }
 
-            let child = if let Some(child) = raw_child {
-                OwnedRoomId::from_str(&child)
-                    .map_err(|_| CommandError::Error("Invalid room id specified".into()))?
-            } else {
+            let Some(child) = raw_child else {
                 let msg = "Must specify a room to add";
                 return Err(CommandError::Error(msg.into()));
             };
 
-            SpaceAction::SetChild(child, order, suggested).into()
+            SpaceAction::SetChild { child, order, suggested }.into()
         },
         _ => return Result::Err(CommandError::InvalidArgument),
     };
@@ -1113,7 +1109,7 @@ pub fn setup_commands() -> ProgramCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use matrix_sdk::ruma::{room_id, user_id};
+    use matrix_sdk::ruma::user_id;
     use modalkit::actions::WindowAction;
     use modalkit::editing::context::EditContext;
 
@@ -1493,16 +1489,20 @@ mod tests {
 
         let cmd = "space child set !roomid:example.org";
         let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
-        let act = SpaceAction::SetChild(room_id!("!roomid:example.org").to_owned(), None, false);
+        let act = SpaceAction::SetChild {
+            child: "!roomid:example.org".to_owned(),
+            order: None,
+            suggested: false,
+        };
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
         let cmd = "space child set ++order=abcd ++suggested !roomid:example.org";
         let res = cmds.input_cmd(cmd, ctx.clone()).unwrap();
-        let act = SpaceAction::SetChild(
-            room_id!("!roomid:example.org").to_owned(),
-            Some("abcd".into()),
-            true,
-        );
+        let act = SpaceAction::SetChild {
+            child: "!roomid:example.org".to_owned(),
+            order: Some("abcd".into()),
+            suggested: true,
+        };
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
         let cmd = "space child set ++order=abcd ++order=1234 !roomid:example.org";
@@ -1527,10 +1527,6 @@ mod tests {
         let cmd = "space child ++order=abcd ++suggested set !roomid:example.org";
         let res = cmds.input_cmd(cmd, ctx.clone());
         assert_eq!(res, Err(CommandError::InvalidArgument));
-
-        let cmd = "space child set foo";
-        let res = cmds.input_cmd(cmd, ctx.clone());
-        assert_eq!(res, Err(CommandError::Error("Invalid room id specified".into())));
 
         let cmd = "space child set";
         let res = cmds.input_cmd(cmd, ctx.clone());

--- a/src/windows/room/space.rs
+++ b/src/windows/room/space.rs
@@ -90,7 +90,7 @@ impl SpaceState {
         store: &mut ProgramStore,
     ) -> IambResult<EditInfo> {
         match act {
-            SpaceAction::SetChild(child_id, order, suggested) => {
+            SpaceAction::SetChild { child, order, suggested } => {
                 if !self
                     .room
                     .power_levels()
@@ -104,6 +104,8 @@ impl SpaceState {
                 {
                     return Err(IambError::InsufficientPermission.into());
                 }
+
+                let child_id = store.application.worker.join_room(child)?;
 
                 let via = self.room.route().await.map_err(IambError::from)?;
                 let mut ev = SpaceChildEventContent::new(via);


### PR DESCRIPTION
This change is by @VAWVAW and was originally part of #520. It relaxes the constraints on using `:space child set` so that it no longer requires an actual room identifier, but will instead use `Requester::join_room` to resolve aliases or user identifiers for DM rooms into their room identifiers. I've split this out so that it can be called out separately in the release notes.