### PR TITLE
Add a `:room access` command for managing join rules

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -156,14 +156,36 @@ Send an invitation to a user to join the currently focused room with an optional
 Leave the currently focused room.
 .It Sy ":members"
 View a list of members of the currently focused room.
-.It Sy ":room name set [name]"
-Set the name of the currently focused room.
-.It Sy ":room name unset"
-Unset the name of the currently focused room.
+.It Sy ":room access set [rule]"
+Set the join rules for the room to control who can access it.
+Possible values for the
+.Sy rule
+argument are
+.Dq invite ,
+.Dq knock ,
+.Dq knock-restricted ,
+.Dq public ,
+and
+.Dq restricted .
+The
+.Dq knock-restricted
+and
+.Dq restricted
+values allow additional
+.Sy ++members=!room:example.org
+arguments to specify rooms (and spaces) whose members are allowed to join without an invite or knocking.
+.It Sy ":room access unset"
+Set the room to being invite-only so that those not already members cannot join.
+.It Sy ":room access show"
+Show the current join rules for the room.
 .It Sy ":room dm set"
 Mark the currently focused room as a direct message.
 .It Sy ":room dm unset"
 Mark the currently focused room as a normal room.
+.It Sy ":room name set [name]"
+Set the name of the currently focused room.
+.It Sy ":room name unset"
+Unset the name of the currently focused room.
 .It Sy ":room unread set"
 Mark the currently focused room as unread.
 .It Sy ":room unread unset"

--- a/src/base.rs
+++ b/src/base.rs
@@ -37,6 +37,7 @@ use matrix_sdk::{
         EventId,
         OwnedEventId,
         OwnedMxcUri,
+        OwnedRoomAliasId,
         OwnedRoomId,
         OwnedRoomOrAliasId,
         OwnedTransactionId,
@@ -67,6 +68,7 @@ use matrix_sdk::{
         },
         presence::PresenceState,
         profile::{ProfileFieldName, ProfileFieldValue},
+        room::JoinRule,
     },
 };
 
@@ -409,6 +411,9 @@ impl Visitor<'_> for SortUserVisitor {
 /// A room property.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RoomField {
+    /// The room's join rules, aka who can access this room.
+    Access,
+
     /// The room's history visibility.
     History,
 
@@ -497,6 +502,9 @@ pub enum RoomAction {
 
     /// Set whether a room is a direct message.
     SetDirect(bool),
+
+    /// Set the join rules for a room to control who can access it and how.
+    SetAccess(JoinRule),
 
     /// Set a room property.
     Set(RoomField, String),
@@ -1907,6 +1915,11 @@ impl ChatStore {
         } else {
             None
         }
+    }
+
+    /// Get the alias for a room if it has one (and the client knows it).
+    pub fn get_joined_room_alias(&self, room_id: &RoomId) -> Option<OwnedRoomAliasId> {
+        self.worker.client.get_room(room_id).and_then(|r| r.canonical_alias())
     }
 
     /// Get the title for a room.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,11 +6,13 @@ use std::{convert::TryFrom, str::FromStr as _};
 
 use matrix_sdk::ruma::{
     OwnedMxcUri,
+    OwnedRoomId,
     OwnedRoomOrAliasId,
     OwnedUserId,
     RoomVersionId,
     events::tag::TagName,
     profile::{ProfileFieldName, ProfileFieldValue},
+    room::{AllowRule, JoinRule, Restricted as JoinRestrictions},
 };
 
 use modalkit::{
@@ -628,16 +630,63 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     let arg = iter.next();
     let trailing = iter.collect::<Vec<_>>();
 
-    match (field.as_str(), action.as_str()) {
+    match (field.as_str(), action.as_str(), arg.as_deref()) {
         // Skip check for commands that takes a variable number of arguments:
-        ("version", "upgrade") => (),
+        ("access", "set", Some("restricted" | "knock-restricted")) => (),
+        ("version", "upgrade", _) => (),
 
         // Reject if we have any trailing arguments:
-        (_, _) if !trailing.is_empty() => return Result::Err(CommandError::InvalidArgument),
-        (_, _) => (),
+        (_, _, _) if !trailing.is_empty() => return Result::Err(CommandError::InvalidArgument),
+        (_, _, _) => (),
     }
 
     let act: IambAction = match (field.as_str(), action.as_str(), arg) {
+        // :room access set
+        ("access", "set", Some(rule)) => {
+            let allow = trailing
+                .iter()
+                .map(|a| {
+                    let (flag, v) = match OptionType::from_str(a)? {
+                        OptionType::Positional(_) => return Err(CommandError::InvalidArgument),
+                        OptionType::Flag(_, None) => return Err(CommandError::InvalidArgument),
+                        OptionType::Flag(f, Some(v)) => (f, v),
+                    };
+
+                    match flag.as_str() {
+                        "members" => {
+                            let room_id = OwnedRoomId::from_str(&v).map_err(|e| {
+                                CommandError::Error(format!(
+                                    "{v:?} is not a valid room identifier: {e}"
+                                ))
+                            })?;
+                            Ok(AllowRule::room_membership(room_id))
+                        },
+                        _ => Err(CommandError::Error(format!("unknown flag {flag:?}"))),
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let restrictions = JoinRestrictions::new(allow);
+
+            let rule = match rule.as_str() {
+                "invite" => JoinRule::Invite,
+                "knock" => JoinRule::Knock,
+                "knock-restricted" => JoinRule::KnockRestricted(restrictions),
+                "public" => JoinRule::Public,
+                "restricted" => JoinRule::Restricted(restrictions),
+                _ => return Err(CommandError::InvalidArgument),
+            };
+            RoomAction::SetAccess(rule).into()
+        },
+        ("access", "set", None) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room access unset
+        ("access", "unset", None) => RoomAction::SetAccess(JoinRule::Invite).into(),
+        ("access", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
+        // :room access unset
+        ("access", "show", None) => RoomAction::Show(RoomField::Access).into(),
+        ("access", "show", Some(_)) => return Result::Err(CommandError::InvalidArgument),
+
         // :room dm set
         ("dm", "set", None) => RoomAction::SetDirect(true).into(),
         ("dm", "set", Some(_)) => return Result::Err(CommandError::InvalidArgument),
@@ -1109,7 +1158,7 @@ pub fn setup_commands() -> ProgramCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use matrix_sdk::ruma::user_id;
+    use matrix_sdk::ruma::{owned_room_id, user_id};
     use modalkit::actions::WindowAction;
     use modalkit::editing::context::EditContext;
 
@@ -1742,5 +1791,27 @@ mod tests {
         let res = cmds.input_cmd("room version upgrade", ctx.clone()).unwrap_err();
         let err = CommandError::InvalidArgument;
         assert_eq!(res, err);
+    }
+
+    #[test]
+    fn test_cmd_room_access() {
+        let mut cmds = setup_commands();
+        let ctx = EditContext::default();
+
+        let res = cmds.input_cmd("room access set knock", ctx.clone()).unwrap();
+        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::Knock));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds
+            .input_cmd("room access set knock-restricted ++members=!abcde:example.org", ctx.clone())
+            .unwrap();
+        let allow = AllowRule::room_membership(owned_room_id!("!abcde:example.org"));
+        let restrictions = JoinRestrictions::new(vec![allow]);
+        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::KnockRestricted(restrictions)));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
+
+        let res = cmds.input_cmd("room access unset", ctx.clone()).unwrap();
+        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::Invite));
+        assert_eq!(res, vec![(act.into(), ctx.clone())]);
     }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -413,6 +413,7 @@ fn complete_iamb_create(args: Vec<String>) -> Vec<String> {
 // "kick","ban","unban", ".. unset" and "dm/tag set/unset"
 fn complete_iamb_room(args: Vec<String>, store: &ChatStore) -> Vec<String> {
     let subcmds = [
+        "access",
         "dm",
         "kick",
         "ban",
@@ -437,7 +438,7 @@ fn complete_iamb_room(args: Vec<String>, store: &ChatStore) -> Vec<String> {
             "id" => complete_choices(input, &["show"]),
             "dm" | "name" | "tag" => complete_choices(input, &["set", "unset"]),
 
-            "history" | "topic" | "notify" | "alias" | "canonicalalias" | "canon" => {
+            "access" | "history" | "topic" | "notify" | "alias" | "canonicalalias" | "canon" => {
                 complete_choices(input, &["show", "set", "unset"])
             },
 
@@ -449,6 +450,15 @@ fn complete_iamb_room(args: Vec<String>, store: &ChatStore) -> Vec<String> {
     } else if args.len() == 3 {
         let input = &args[2];
         match (args[0].as_str(), args[1].as_str()) {
+            ("access", "set") => {
+                complete_choices(input, &[
+                    "invite",
+                    "knock",
+                    "knock-restricted",
+                    "public",
+                    "restricted",
+                ])
+            },
             ("history", "set") => {
                 complete_choices(input, &["invited", "joined", "shared", "world_readable"])
             },

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -24,6 +24,7 @@ use matrix_sdk::{
             },
             tag::{TagInfo, Tags},
         },
+        room::{AllowRule, JoinRule, Restricted as JoinRestrictions},
     },
 };
 
@@ -255,6 +256,16 @@ pub async fn room_command(
 
             Ok(vec![(act, cmd.context.clone())])
         },
+        RoomAction::SetAccess(rule) => {
+            let Some(room) = store.application.worker.client.get_room(id) else {
+                return Err(IambError::NotJoined.into());
+            };
+            room.privacy_settings()
+                .update_join_rule(rule)
+                .await
+                .map_err(IambError::from)?;
+            Ok(vec![])
+        },
         RoomAction::SetDirect(is_direct) => {
             let room = store
                 .application
@@ -404,14 +415,8 @@ pub async fn room_command(
                         .await
                         .map_err(IambError::from)?;
                 },
-                RoomField::Aliases => {
-                    // This never happens, aliases is only used for showing
-                },
-                RoomField::Id => {
-                    // This never happens, id is only used for showing
-                },
-                RoomField::Version => {
-                    // This never happens, version is only used for showing or upgrading.
+                RoomField::Access | RoomField::Aliases | RoomField::Id | RoomField::Version => {
+                    // These variants exist for RoomAction::Show, so we never actually get here.
                 },
             }
 
@@ -506,14 +511,8 @@ pub async fn room_command(
                 RoomField::UserName => {
                     room.set_own_member_display_name(None).await.map_err(IambError::from)?;
                 },
-                RoomField::Aliases => {
-                    // This will not happen, you cannot unset all aliases
-                },
-                RoomField::Id => {
-                    // This never happens, id is only used for showing
-                },
-                RoomField::Version => {
-                    // This never happens, version is only used for showing or upgrading.
+                RoomField::Access | RoomField::Aliases | RoomField::Id | RoomField::Version => {
+                    // These variants exist for RoomAction::Show, so we never actually get here.
                 },
             }
 
@@ -565,6 +564,55 @@ pub async fn room_command(
                     };
 
                     format!("Room notification level: {level:?}")
+                },
+                RoomField::Access => {
+                    let show_restrictions = |rs: JoinRestrictions| {
+                        rs.allow
+                            .into_iter()
+                            .map(|a| {
+                                match a {
+                                    AllowRule::RoomMembership(m) => {
+                                        if let Some(alias) =
+                                            store.application.get_joined_room_alias(&m.room_id)
+                                        {
+                                            format!("members of {} ({alias})", m.room_id)
+                                        } else {
+                                            format!("members of {}", m.room_id)
+                                        }
+                                    },
+                                    other => format!("{other:?}"),
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+
+                    let desc = match room.join_rule() {
+                        None => "<unknown>".into(),
+                        Some(JoinRule::Invite) => "invite".into(),
+                        Some(JoinRule::Knock) => "knock".into(),
+                        Some(JoinRule::Private) => "private".into(),
+                        Some(JoinRule::Public) => "public".into(),
+                        Some(JoinRule::Restricted(restrictions)) => {
+                            let allowing = show_restrictions(restrictions);
+                            if allowing.is_empty() {
+                                "restricted".into()
+                            } else {
+                                format!("restricted, allowing {allowing}")
+                            }
+                        },
+                        Some(JoinRule::KnockRestricted(restrictions)) => {
+                            let allowing = show_restrictions(restrictions);
+                            if allowing.is_empty() {
+                                "knock-restricted".into()
+                            } else {
+                                format!("knock-restricted, allowing {allowing}")
+                            }
+                        },
+                        Some(other) => format!("{other:?}"),
+                    };
+
+                    format!("Room join rules are set to: {desc}")
                 },
                 RoomField::Aliases => {
                     let aliases = room


### PR DESCRIPTION
This follows up on #658 and adds new `:room access` subcommands so that rooms can be updated to allow knocking/disable knocking from within iamb.