### PR TITLE
Support room aliases for `:room access set restricted`

### DIFF
--- a/docs/iamb.1
+++ b/docs/iamb.1
@@ -174,8 +174,9 @@ The
 and
 .Dq restricted
 values allow additional
-.Sy ++members=!room:example.org
+.Sy ++members=[room]
 arguments to specify rooms (and spaces) whose members are allowed to join without an invite or knocking.
+If a room alias is given instead of an id, it is resolved immediately.
 .It Sy ":room access unset"
 Set the room to being invite-only so that those not already members cannot join.
 .It Sy ":room access show"

--- a/src/base.rs
+++ b/src/base.rs
@@ -12,7 +12,9 @@ use std::time::{Duration, Instant};
 
 use emojis::Emoji;
 
+use matrix_sdk::Client;
 use matrix_sdk::encryption::verification::VerificationRequest;
+use matrix_sdk::ruma::room::{AllowRule, Restricted};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -469,6 +471,52 @@ impl Display for MemberUpdateAction {
     }
 }
 
+/// An internal version of [`JoinRule`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IambJoinRule {
+    Public,
+    Restricted(Vec<OwnedRoomOrAliasId>),
+    Knock,
+    KnockRestricted(Vec<OwnedRoomOrAliasId>),
+    Invite,
+}
+
+impl IambJoinRule {
+    pub async fn into_join_rule(self, client: &Client) -> Result<JoinRule, IambError> {
+        async fn resolve_aliases(
+            rooms: Vec<OwnedRoomOrAliasId>,
+            client: &Client,
+        ) -> Result<Restricted, IambError> {
+            let mut allow = vec![];
+            for room in rooms {
+                let alias = match OwnedRoomId::try_from(room) {
+                    Ok(room_id) => {
+                        allow.push(AllowRule::room_membership(room_id));
+                        continue;
+                    },
+                    Err(alias) => alias,
+                };
+
+                let resp = client.resolve_room_alias(&alias).await?;
+
+                allow.push(AllowRule::room_membership(resp.room_id));
+            }
+
+            Ok(Restricted::new(allow))
+        }
+
+        Ok(match self {
+            Self::Public => JoinRule::Public,
+            Self::Invite => JoinRule::Invite,
+            Self::Knock => JoinRule::Knock,
+            Self::Restricted(rooms) => JoinRule::Restricted(resolve_aliases(rooms, client).await?),
+            Self::KnockRestricted(rooms) => {
+                JoinRule::KnockRestricted(resolve_aliases(rooms, client).await?)
+            },
+        })
+    }
+}
+
 /// An action that operates on a focused room.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RoomAction {
@@ -507,7 +555,7 @@ pub enum RoomAction {
     SetDirect(bool),
 
     /// Set the join rules for a room to control who can access it and how.
-    SetAccess(JoinRule),
+    SetAccess(IambJoinRule),
 
     /// Set a room property.
     Set(RoomField, String),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,13 +6,11 @@ use std::{convert::TryFrom, str::FromStr as _};
 
 use matrix_sdk::ruma::{
     OwnedMxcUri,
-    OwnedRoomId,
     OwnedRoomOrAliasId,
     OwnedUserId,
     RoomVersionId,
     events::tag::TagName,
     profile::{ProfileFieldName, ProfileFieldValue},
-    room::{AllowRule, JoinRule, Restricted as JoinRestrictions},
 };
 
 use modalkit::{
@@ -28,6 +26,7 @@ use crate::base::{
     HomeserverAction,
     IambAction,
     IambId,
+    IambJoinRule,
     KeysAction,
     MemberUpdateAction,
     MessageAction,
@@ -644,7 +643,7 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
     let act: IambAction = match (field.as_str(), action.as_str(), arg) {
         // :room access set
         ("access", "set", Some(rule)) => {
-            let allow = trailing
+            let rooms = trailing
                 .iter()
                 .map(|a| {
                     let (flag, v) = match OptionType::from_str(a)? {
@@ -655,25 +654,23 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
 
                     match flag.as_str() {
                         "members" => {
-                            let room_id = OwnedRoomId::from_str(&v).map_err(|e| {
+                            OwnedRoomOrAliasId::from_str(&v).map_err(|e| {
                                 CommandError::Error(format!(
                                     "{v:?} is not a valid room identifier: {e}"
                                 ))
-                            })?;
-                            Ok(AllowRule::room_membership(room_id))
+                            })
                         },
                         _ => Err(CommandError::Error(format!("unknown flag {flag:?}"))),
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let restrictions = JoinRestrictions::new(allow);
 
             let rule = match rule.as_str() {
-                "invite" => JoinRule::Invite,
-                "knock" => JoinRule::Knock,
-                "knock-restricted" => JoinRule::KnockRestricted(restrictions),
-                "public" => JoinRule::Public,
-                "restricted" => JoinRule::Restricted(restrictions),
+                "invite" => IambJoinRule::Invite,
+                "knock" => IambJoinRule::Knock,
+                "knock-restricted" => IambJoinRule::KnockRestricted(rooms),
+                "public" => IambJoinRule::Public,
+                "restricted" => IambJoinRule::Restricted(rooms),
                 _ => return Err(CommandError::InvalidArgument),
             };
             RoomAction::SetAccess(rule).into()
@@ -681,7 +678,7 @@ fn iamb_room(desc: CommandDescription, ctx: &mut ProgContext) -> ProgResult {
         ("access", "set", None) => return Result::Err(CommandError::InvalidArgument),
 
         // :room access unset
-        ("access", "unset", None) => RoomAction::SetAccess(JoinRule::Invite).into(),
+        ("access", "unset", None) => RoomAction::SetAccess(IambJoinRule::Invite).into(),
         ("access", "unset", Some(_)) => return Result::Err(CommandError::InvalidArgument),
 
         // :room access unset
@@ -1800,19 +1797,19 @@ mod tests {
         let ctx = EditContext::default();
 
         let res = cmds.input_cmd("room access set knock", ctx.clone()).unwrap();
-        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::Knock));
+        let act = IambAction::Room(RoomAction::SetAccess(IambJoinRule::Knock));
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
         let res = cmds
             .input_cmd("room access set knock-restricted ++members=!abcde:example.org", ctx.clone())
             .unwrap();
-        let allow = AllowRule::room_membership(owned_room_id!("!abcde:example.org"));
-        let restrictions = JoinRestrictions::new(vec![allow]);
-        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::KnockRestricted(restrictions)));
+        let restrictions = vec![owned_room_id!("!abcde:example.org").into()];
+        let act =
+            IambAction::Room(RoomAction::SetAccess(IambJoinRule::KnockRestricted(restrictions)));
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
 
         let res = cmds.input_cmd("room access unset", ctx.clone()).unwrap();
-        let act = IambAction::Room(RoomAction::SetAccess(JoinRule::Invite));
+        let act = IambAction::Room(RoomAction::SetAccess(IambJoinRule::Invite));
         assert_eq!(res, vec![(act.into(), ctx.clone())]);
     }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -295,6 +295,16 @@ fn complete_matrix_names(input: &str, store: &ChatStore) -> Vec<String> {
     store.rooms.complete(input).into_iter().map(|i| i.to_string()).collect()
 }
 
+/// Tab completion for known room aliases and ids.
+fn complete_room_alias_or_id(input: &str, store: &ChatStore) -> Vec<String> {
+    let list = store.names.complete(input);
+    if !list.is_empty() {
+        return list;
+    }
+
+    store.rooms.complete(input).into_iter().map(|i| i.to_string()).collect()
+}
+
 /// Tab completion for open verification requests
 fn complete_verification(input: &str, store: &ChatStore) -> Vec<String> {
     store.verifications.complete(input)
@@ -487,9 +497,7 @@ fn complete_iamb_room(args: Vec<String>, store: &ChatStore) -> Vec<String> {
             ("version", "upgrade", _) => complete_users(input, store),
             ("access", "set", "restricted") | ("access", "set", "knock-restricted") => {
                 if let Some(remaining) = input.strip_prefix("++members=") {
-                    store
-                        .rooms
-                        .complete(remaining)
+                    complete_room_alias_or_id(remaining, store)
                         .into_iter()
                         .map(|id| format!("++members={id}"))
                         .collect()

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -483,8 +483,20 @@ fn complete_iamb_room(args: Vec<String>, store: &ChatStore) -> Vec<String> {
         }
     } else {
         let input = args.last().unwrap();
-        match (args[0].as_str(), args[1].as_str()) {
-            ("version", "upgrade") => complete_users(input, store),
+        match (args[0].as_str(), args[1].as_str(), args[2].as_str()) {
+            ("version", "upgrade", _) => complete_users(input, store),
+            ("access", "set", "restricted") | ("access", "set", "knock-restricted") => {
+                if let Some(remaining) = input.strip_prefix("++members=") {
+                    store
+                        .rooms
+                        .complete(remaining)
+                        .into_iter()
+                        .map(|id| format!("++members={id}"))
+                        .collect()
+                } else {
+                    complete_choices(input, &["++members"])
+                }
+            },
 
             _ => vec![],
         }

--- a/src/windows/room/mod.rs
+++ b/src/windows/room/mod.rs
@@ -260,6 +260,7 @@ pub async fn room_command(
             let Some(room) = store.application.worker.client.get_room(id) else {
                 return Err(IambError::NotJoined.into());
             };
+            let rule = rule.into_join_rule(&store.application.worker.client).await?;
             room.privacy_settings()
                 .update_join_rule(rule)
                 .await


### PR DESCRIPTION
Followup to #673 that allows passing a room alias to `:room access set restricted` and `:room access set knock-restricted`.